### PR TITLE
chore(web): upgrade React 18 → 19

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,16 +7,16 @@
       "name": "dev-dashboard-web",
       "dependencies": {
         "@tanstack/react-query": "^5.59.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
+        "react": "^19",
+        "react-dom": "^19",
         "react-router-dom": "^6.26.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.1",
         "@testing-library/user-event": "^14.5.2",
-        "@types/react": "^18.3.5",
-        "@types/react-dom": "^18.3.0",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^6.0.3",
         "jsdom": "^25.0.0",
         "msw": "^2.4.0",
@@ -514,9 +514,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -534,9 +531,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -554,9 +548,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -574,9 +565,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -594,9 +582,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -614,9 +599,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -880,32 +862,24 @@
         "undici-types": "~8.3.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/set-cookie-parser": {
@@ -1765,7 +1739,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jsdom": {
       "version": "25.0.1",
@@ -1951,9 +1927,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1975,9 +1948,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1999,9 +1969,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2023,9 +1990,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2079,18 +2043,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/lz-string": {
@@ -2402,28 +2354,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-is": {
@@ -2559,13 +2507,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/set-cookie-parser": {
       "version": "3.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -10,16 +10,16 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.59.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19",
+    "react-dom": "^19",
     "react-router-dom": "^6.26.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.5.2",
-    "@types/react": "^18.3.5",
-    "@types/react-dom": "^18.3.0",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.3",
     "jsdom": "^25.0.0",
     "msw": "^2.4.0",

--- a/web/src/components/LiveIndicator.test.tsx
+++ b/web/src/components/LiveIndicator.test.tsx
@@ -5,11 +5,11 @@ import { LiveIndicator } from './LiveIndicator'
 
 function wrap(intervalMs: number, paused: boolean) {
   return render(
-    <RefreshContext.Provider
+    <RefreshContext
       value={{ intervalMs, paused, setInterval: () => {}, setPaused: () => {} }}
     >
       <LiveIndicator />
-    </RefreshContext.Provider>,
+    </RefreshContext>,
   )
 }
 

--- a/web/src/lib/refresh.tsx
+++ b/web/src/lib/refresh.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, type ReactNode } from 'react'
+import { createContext, use, useState, type ReactNode } from 'react'
 
 const REFRESH_MS_KEY = 'devdash.refreshMs'
 const REFRESH_PAUSED_KEY = 'devdash.refreshPaused'
@@ -41,14 +41,14 @@ export function RefreshProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <RefreshContext.Provider value={{ intervalMs, paused, setInterval, setPaused }}>
+    <RefreshContext value={{ intervalMs, paused, setInterval, setPaused }}>
       {children}
-    </RefreshContext.Provider>
+    </RefreshContext>
   )
 }
 
 export function useRefreshInterval(): RefreshCtx {
-  const ctx = useContext(RefreshContext)
+  const ctx = use(RefreshContext)
   if (!ctx) throw new Error('useRefreshInterval must be used within a RefreshProvider')
   return ctx
 }


### PR DESCRIPTION
## Summary

Upgrades the `web/` SPA from React 18.3 to React 19 and adopts two clean React 19 idioms.

Implements the plan in `docs/superpowers/plans/2026-06-30-react-19-upgrade.md`.

## Changes

- **`chore(web): upgrade react and react-dom to v19`** — bump `react`, `react-dom`, `@types/react`, `@types/react-dom` to `^19` (resolves to react@19.2.7 / @types/react@19.2.17) and regenerate the lockfile. Peer deps (`@tanstack/react-query@^5`, `react-router-dom@^6`, `@testing-library/react@^16`, `@vitejs/plugin-react@^6`) left at their current majors. No new dependencies, no `any` suppressions, zero source changes needed.
- **`refactor(web): adopt React 19 context-as-provider and use() in refresh`** — in `web/src/lib/refresh.tsx`, switch to context-as-provider (`<RefreshContext value=...>`) and the `use(RefreshContext)` hook; update the `LiveIndicator.test.tsx` `wrap` helper to match. No public API change.

## Verification

- `npm run build` (tsc -b + vite build): clean, zero TypeScript errors.
- `npm test`: 311/311 passing across 46 files — identical to the React 18 baseline.
- Whole-branch review (independent): zero findings, ready to merge. Confirmed peers dedupe cleanly to react@19.2.7, lockfile churn benign (dropped `loose-envify`/`@types/prop-types`), `use(RefreshContext)` null-guard semantics preserved, and a full React-19 breaking-surface sweep of `web/src` (no `forwardRef`/`defaultProps`/`propTypes`/string-refs/`ReactDOM.render`; all `useRef` calls have initial args; `createRoot`+`StrictMode` already in place).

> Note: the plan's manual dev-server smoke test (toggle/pause the live-refresh indicator under StrictMode) is the only check not covered by types/unit tests — worth a quick run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)