### PR TITLE
docs: sync README/AGENTS/STYLEGUIDE with recent features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,15 @@ runtime** — the frontend is compiled to `web/dist` and baked into the binary a
 
 ```
 main.go            thin entry point
-cmd/               cobra root + subcommands (serve, update, workflow); no domain logic
+cmd/               cobra root + subcommands (serve, update, workflow); no domain logic.
+                   Also hosts the connection registry / store-election layer (registry.go,
+                   reconciler.go, derive.go, connpool.go): the connections.yaml-backed store
+                   list, lazy per-store connection pool, and secretKeyRef resolution.
 pkg/               domain packages — each is isolated, none import cmd/
   discovery/       standalone.List() + /v1.0/metadata sidecar enrichment
   workflow/        list / history / terminate / purge
   statestore/      redis / postgres / sqlite client
+  metadata/        embedded component-metadata catalog (drives the add/edit connection forms)
   resources/       component + configuration YAML loader
   logs/            file tail → SSE
   server/          chi router + go:embed SPA mount (one file per domain)
@@ -128,8 +132,11 @@ via ldflags (`dev-dashboard --version`).
 - **Follow the UI style guide for frontend work.** New pages/components compose the existing
   class vocabulary and design tokens in `web/src/styles/theme.css` — don't hardcode colors or
   reinvent primitives. See [`web/STYLEGUIDE.md`](web/STYLEGUIDE.md).
-- **Read-only product surface:** the dashboard never starts/stops apps; the only mutating
-  operation is workflow terminate/purge. Don't add side-effecting behavior without explicit ask.
+- **Read-only product surface:** the dashboard never starts/stops apps and never edits app or
+  component state. The mutating operations are limited to workflow terminate/purge and managing
+  the user's own saved state-store connections (the `connections.yaml` registry under
+  `~/.dapr/dev-dashboard/`, written `0600`). Don't add other side-effecting behavior without an
+  explicit ask.
 - Commit/push only when asked; the project uses Conventional Commit prefixes (`feat:`, `refactor:`,
   `docs:`) — match the existing `git log` style.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Design goals:
 - **Zero-config for the common case** — point it at your machine and it discovers running apps.
 - **Single self-contained binary** — no runtime dependencies (the React frontend is embedded
   via `go:embed`; there is no Node.js at runtime).
-- **Read-only, except for workflow purge** — it never starts or stops your apps in v1.
+- **Read-only over your apps** — it never starts or stops them. The only mutating actions are
+  workflow terminate/purge and managing your own saved state-store connections (persisted to a
+  local config file, see [Use cases](#use-cases)); it never edits app or component state.
 - **Degrade gracefully** — keep working when a sidecar or state store is unavailable.
 - **Minimal, high-density UI** with light and dark themes, optimized for desktop widths.
 
@@ -36,6 +38,10 @@ Developers use the dashboard to observe and debug Dapr apps while building local
   subscriptions across all apps, each linkable back to the owning application.
 - **Read components & configurations** — read-only YAML viewers, enriched with which apps
   loaded each component.
+- **Manage state-store connections** — on the Components page, add / edit / remove the state
+  stores the dashboard reads workflows from. Auto-detected stores appear automatically; manual
+  connections are saved to `~/.dapr/dev-dashboard/connections.yaml` (mode `0600`). When more
+  than one store is known, a selector on the Workflows page lets you switch which one you browse.
 - **Tail logs** — per-app daprd + app logs streamed live (SSE) with level coloring, keyword
   highlight, and a follow toggle.
 
@@ -156,7 +162,7 @@ If the dashboard does not behave as expected, run it with `--verbose` to print d
 dev-dashboard --verbose
 ```
 
-Logs are grouped by `component=` (values: `server`, `discovery`, `statestore`, `workflow`) and use levels INFO (normal milestones), WARN (degraded but still working, e.g. a state store that failed to initialise), and ERROR (an operation failed, e.g. the server could not bind its port). Without `--verbose`, no diagnostic logs are emitted.
+Logs are grouped by `component=` (values: `server`, `discovery`, `workflow`, `registry`, `reconciler`) and use levels INFO (normal milestones), WARN (degraded but still working, e.g. a state store that failed to initialise), and ERROR (an operation failed, e.g. the server could not bind its port). Without `--verbose`, no diagnostic logs are emitted.
 
 ## Building from source
 
@@ -232,8 +238,10 @@ you just run both on the same machine.
 `~/.dapr/components` and from the live `--resources-path` of running apps, then uses the one
 marked `actorStateStore: "true"` (falling back to the first detected). Check:
 
-- If detection is ambiguous (several stores), point it explicitly:
-  `./bin/dev-dashboard --statestore ~/.dapr/components/statestore.yaml`.
+- If detection is ambiguous (several stores), either pick one with the store selector on the
+  Workflows page, or point it explicitly:
+  `./bin/dev-dashboard --statestore ~/.dapr/components/statestore.yaml`. You can also add a
+  store by hand via the connection manager on the Components page.
 - Workflow keys are namespaced; the dashboard defaults to `default`. For another namespace, pass
   `--namespace <ns>`.
 - Only **Redis / PostgreSQL / SQLite** state stores are supported.
@@ -371,6 +379,7 @@ sidecars and state store.
 │  pkg/discovery  standalone.List() + /v1.0/metadata    │
 │  pkg/workflow   list / history / purge                │
 │  pkg/statestore client (redis / postgres / sqlite)    │
+│  pkg/metadata   component metadata catalog            │
 │  pkg/resources  component + configuration YAML loader │
 │  pkg/logs       file tail → SSE                       │
 │  web/           React + Vite SPA → dist/ (embedded)   │
@@ -406,6 +415,12 @@ sidecars and state store.
   SQLite); a client is built from the auto-detected component YAML. Purge uses the official
   Dapr workflow API when reachable, with direct state-store key deletion as an explicit force
   fallback.
+- **Connections registry** — the state stores the dashboard can read from are tracked in a
+  registry: auto-detected component refs plus any connections added in the UI, persisted to
+  `~/.dapr/dev-dashboard/connections.yaml` (mode `0600`). The `pkg/metadata` catalog drives the
+  add/edit forms, the workflow backend connects to the selected store lazily (on demand), and
+  `secretKeyRef` metadata is resolved through local secret stores
+  (`secretstores.local.file` / `secretstores.local.env`).
 - **Resources** (components + configurations) are loaded from `~/.dapr` and live
   `--resources-path` directories read from daprd args.
 - **Logs** are tailed from `~/.dapr/logs/*` and the `appLogPath`/`daprdLogPath` reported in

--- a/web/STYLEGUIDE.md
+++ b/web/STYLEGUIDE.md
@@ -213,8 +213,12 @@ Reusable React components — prefer these over re-implementing.
 |---|---|---|
 | `StatusPill` | `components/StatusPill.tsx` | Workflow status → correct `.pill .s-*` class + uppercased label. **Use this; don't hand-map statuses.** |
 | `LiveIndicator` | `components/LiveIndicator.tsx` | The pulsing "live" dot for `.phead`. |
-| `RefreshControl` | `components/RefreshControl.tsx` | Auto-refresh control inside a `.refreshbar`. |
-| `ConfirmRemoveDialog` | `components/ConfirmRemoveDialog.tsx` | Modal confirm for destructive actions. |
+| `RefreshControl` | `components/RefreshControl.tsx` | Global auto-refresh control, mounted in `TopNav` (top-right). Renders as `.refresh-compact` — a `.beatbtn` pulse/pause toggle (`.beat` dot) plus a `.select.compact` interval dropdown. |
+| `Modal` | `components/Modal.tsx` | Focus-trapped modal shell: `.modal-backdrop` overlay + `.card.modal-card` dialog + `.modal-title`. Wrap dialog content in this; close on backdrop/Escape. |
+| `ConfirmRemoveDialog` | `components/ConfirmRemoveDialog.tsx` | Modal confirm for destructive actions (built on `Modal`). |
+| `MetadataFieldInput` | `components/MetadataFieldInput.tsx` | Renders one form control (`.inp` text or select) from a component-metadata field descriptor. Use for metadata-driven forms; don't hand-build inputs. |
+| `StateStoreConnectionDialog` | `components/StateStoreConnectionDialog.tsx` | Add/edit a state-store connection — a `Modal` with `.field` rows driven by `MetadataFieldInput`. |
+| `StateStoreConnectionsPanel` | `components/StateStoreConnectionsPanel.tsx` | The list/add/edit/delete connections panel mounted on the Components page. |
 | `ThemeToggle` | `components/ThemeToggle.tsx` | Light/dark switch (lives in `TopNav`). |
 | `useToast()` | `lib/toast.tsx` | Transient confirmation (e.g. "Instance ID copied"). |
 | `copyText()` | `lib/clipboard.ts` | Clipboard write; pair with a toast. |
@@ -237,6 +241,10 @@ Reusable React components — prefer these over re-implementing.
 - `.twocol` / `.io` — two equal columns (collapse to 1 on narrow screens).
 - `.md` — master-detail split (300px list + flexible pane); list items are `.ci`
   (`.ci.sel` = selected).
+- **Modal shell** — `.modal-backdrop` (fixed full-screen overlay, centers its child) wraps
+  `.card.modal-card` (the dialog surface; composes `.card`), with `.modal-title` for the
+  heading and `.modal-actions` for the right-aligned footer button row. Prefer the `Modal`
+  component over assembling these by hand.
 
 **Tables**
 - `table.t` — standard table; add `.click` to make rows clickable (cursor + hover).
@@ -264,10 +272,19 @@ Reusable React components — prefer these over re-implementing.
 - `.segs` — segmented toggle group (`button[aria-pressed]`).
 - `.lvchip` — log-level toggle chips; `.followbtn` — log follow toggle.
 
+**Form fields** (used in modal dialogs — see `StateStoreConnectionDialog`)
+- `.inp` — full-width text input / `<select>` (the metadata-form control style). `.select` is
+  the compact filter variant; `.inp` is the form-field variant.
+- `.field` — a label-over-control row (`grid`, `gap`); `.field > label` is the muted caption.
+  `.req` marks a required-field asterisk; `.field-err` is the inline error line under a control;
+  `.field-row` lays out a control plus adjacent element horizontally.
+
 **Feedback**
 - `.toast` (`.show`) — driven by `useToast`.
 - `.hint` — centered faint helper line under content.
-- `.refreshbar` — the refresh/clock strip on auto-refreshing pages.
+- `.refresh-compact` — the compact global refresh control in the top nav (`.beatbtn` + `.beat`
+  pulse toggle, `.select.compact` interval dropdown); rendered by `RefreshControl`.
+- `.refreshbar` — the wider refresh/clock strip still used on the Workflow detail page.
 
 **Code blocks**
 - `<pre className="json">` + `highlightJson(...)` for JSON.


### PR DESCRIPTION
Documentation-only sync. The connection-manager, connection-registry, store-selector, `pkg/metadata` catalog, and compact top-nav refresh work that landed over the last few days left the docs stale. Every claim below was verified against the current code, not just the specs.

## Must-fixes (the docs stated things that were false)
- **"Read-only except workflow purge" is no longer true.** The state-store connection manager ships `POST/PUT/DELETE /api/statestores` writing to `~/.dapr/dev-dashboard/connections.yaml` (`0600`). Reworded the read-only goal in `README.md` and the product-surface rule in `AGENTS.md` to name this second mutating surface.
- **slog `component=` values were wrong** in `README.md`: `statestore` is gone; `registry` and `reconciler` are new. Now lists `server, discovery, workflow, registry, reconciler`.

## Gaps filled
- **README:** added `pkg/metadata` to the architecture diagram (kept 57-col alignment), a **Connections registry** data-source bullet (registry file, lazy per-store connect, `secretKeyRef` resolution), a **Manage state-store connections** use case, and a store-selector note in the "Workflows page empty" troubleshooting.
- **AGENTS:** repo layout now lists `pkg/metadata` and the `cmd/` connection-registry/store-election layer (`registry.go`, `reconciler.go`, `derive.go`, `connpool.go`).
- **STYLEGUIDE:** added `Modal`, `MetadataFieldInput`, `StateStoreConnectionDialog`, `StateStoreConnectionsPanel` to the component catalog; documented the modal-shell and form-field CSS classes; and noted `RefreshControl` moved to the top nav (`.refresh-compact`), while `.refreshbar` is still used on the workflow detail page.

## Deliberately excluded
- The Component/Resiliency Builders (Wizard/Stepper/`/components/new`) — that spec exists but is **not** implemented in `web/src`, so it isn't documented yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)