### PR TITLE
Logs for Aspire-hosted and standalone `dapr run` apps

### DIFF
--- a/docs/superpowers/plans/2026-07-01-aspire-standalone-logs.md
+++ b/docs/superpowers/plans/2026-07-01-aspire-standalone-logs.md
@@ -1,0 +1,813 @@
+# Aspire + standalone `dapr run` logs — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Logs page show `daprd` and `app` logs for .NET Aspire-hosted apps and for standalone `dapr run` (no `-f` template), in addition to the already-working `dapr run -f` case.
+
+**Architecture:** Add a log-source resolution step in the discovery layer that runs when the sidecar's `/v1.0/metadata` reports no log paths. For Aspire apps it locates the DCP session dir (from the app-port listener's `--kubeconfig` flag) and maps the `{guid}_out` capture files to daprd/app by parsing the `resource-executable-*.log` companion files. For standalone runs it inspects each process's stdout (fd 1) via `lsof` and uses it only if it is a regular file. The SSE log handler normalizes DCP-captured lines (strips the seq/timestamp prefix and ANSI codes) before streaming.
+
+**Tech Stack:** Go 1.26 (backend), gopsutil (existing, for port→process), `lsof` (fd resolution), chi router, React/TypeScript (frontend). Tests use the `unit` build tag; run with `go test -tags unit -race ./...`.
+
+## Global Constraints
+
+- Go module: `github.com/diagridio/dev-dashboard`; Go version floor `1.26.4`.
+- Unit tests use the `//go:build unit` tag (first line of the test file). Run via `go test -tags unit -race ./pkg/...`.
+- Existing test helper `fakeResolver` (in `pkg/discovery/appproc_test.go`) implements `appProcResolver` — reuse it, do not redefine it.
+- New JSON fields on `Instance` MUST use `omitempty` so existing golden JSON fixtures are unaffected.
+- Log-source resolution runs only when a metadata-reported path is empty; never override a metadata path.
+- Feature requires the dashboard to run on the host (same filesystem + process namespace as the dapr/Aspire processes) — this matches existing discovery behavior; do not attempt container-remote access.
+
+---
+
+### Task 1: Add log-format fields + DCP session-dir parsing
+
+**Files:**
+- Modify: `pkg/discovery/types.go:14-40` (add two fields to `Instance`)
+- Create: `pkg/discovery/logsource.go`
+- Create: `pkg/discovery/logsource_test.go`
+
+**Interfaces:**
+- Produces: `Instance.AppLogFormat string`, `Instance.DaprdLogFormat string` (values `""`/`"plain"`/`"dcp"`); `dcpSessionDir(cmd string) (string, bool)`; constants `logFormatPlain = "plain"`, `logFormatDCP = "dcp"`.
+
+- [ ] **Step 1: Add the format fields to `Instance`**
+
+In `pkg/discovery/types.go`, inside the `Instance` struct, immediately after the `DaprdLogPath` field (line 31), add:
+
+```go
+	AppLogFormat    string         `json:"appLogFormat,omitempty"`   // "" / "plain" / "dcp"
+	DaprdLogFormat  string         `json:"daprdLogFormat,omitempty"` // "" / "plain" / "dcp"
+```
+
+- [ ] **Step 2: Write the failing test for `dcpSessionDir`**
+
+Create `pkg/discovery/logsource_test.go`:
+
+```go
+//go:build unit
+
+package discovery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDcpSessionDir(t *testing.T) {
+	t.Run("space-separated flag", func(t *testing.T) {
+		cmd := "/x/.nuget/packages/aspire.hosting.orchestration.osx-arm64/13.4.6/tools/dcp run-controllers --kubeconfig /var/folders/4c/T/aspire-dcpZOY2Ea/kubeconfig --monitor 82529"
+		dir, ok := dcpSessionDir(cmd)
+		require.True(t, ok)
+		require.Equal(t, "/var/folders/4c/T/aspire-dcpZOY2Ea", dir)
+	})
+
+	t.Run("equals form", func(t *testing.T) {
+		dir, ok := dcpSessionDir("dcp run-controllers --kubeconfig=/tmp/aspire-dcpABC/kubeconfig")
+		require.True(t, ok)
+		require.Equal(t, "/tmp/aspire-dcpABC", dir)
+	})
+
+	t.Run("no kubeconfig flag", func(t *testing.T) {
+		_, ok := dcpSessionDir("daprd --app-id x")
+		require.False(t, ok)
+	})
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `go test -tags unit ./pkg/discovery/ -run TestDcpSessionDir -v`
+Expected: FAIL — `undefined: dcpSessionDir`.
+
+- [ ] **Step 4: Implement `dcpSessionDir` and constants**
+
+Create `pkg/discovery/logsource.go`:
+
+```go
+package discovery
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const (
+	logFormatPlain = "plain"
+	logFormatDCP   = "dcp"
+)
+
+// dcpSessionDir extracts the Aspire DCP session directory from a dcp process
+// command line by reading its `--kubeconfig <dir>/kubeconfig` flag. The session
+// directory is the parent of the kubeconfig file. Returns ("", false) when the
+// flag is absent.
+func dcpSessionDir(cmd string) (string, bool) {
+	fields := strings.Fields(cmd)
+	for i, f := range fields {
+		switch {
+		case f == "--kubeconfig" && i+1 < len(fields):
+			return filepath.Dir(fields[i+1]), true
+		case strings.HasPrefix(f, "--kubeconfig="):
+			return filepath.Dir(strings.TrimPrefix(f, "--kubeconfig=")), true
+		}
+	}
+	return "", false
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `go test -tags unit ./pkg/discovery/ -run TestDcpSessionDir -v`
+Expected: PASS (all three subtests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/discovery/types.go pkg/discovery/logsource.go pkg/discovery/logsource_test.go
+git commit -m "feat(discovery): add log-format fields and DCP session-dir parsing"
+```
+
+---
+
+### Task 2: Map DCP capture files to daprd/app logs
+
+**Files:**
+- Modify: `pkg/discovery/logsource.go`
+- Modify: `pkg/discovery/logsource_test.go`
+
+**Interfaces:**
+- Consumes: `logFormatDCP` (Task 1).
+- Produces: `resolveDCPLogs(sessionDir, appID string) (daprdPath, appPath string)`.
+
+Background — inside a DCP session dir, each resource has:
+- `resource-executable-<guid>.log` — text lines; the "Starting process..." line ends with a JSON object like `{"Executable": "/pr-digest-dapr-cli-yuhagtzr", "Cmd": "/usr/local/bin/dapr", "Args": ["run","--app-id","pr-digest",...]}`.
+- `<guid>_out` — the captured stdout for that resource.
+
+The daprd log is the `_out` of the resource whose `Cmd` is `dapr`/`daprd` and whose `Args` contain `run` and `--app-id <appID>`. The app log is the `_out` of the sibling executable resource sharing the base name (the daprd resource name with the trailing `-dapr-cli-<suffix>` removed).
+
+- [ ] **Step 1: Write the failing test for `resolveDCPLogs`**
+
+Add to `pkg/discovery/logsource_test.go`:
+
+```go
+func TestResolveDCPLogs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(name, content string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+	}
+
+	// daprd sidecar resource (guid AAA) — app-id "pr-digest", resource name "pr-digest-dapr-cli-yuha".
+	writeFile("resource-executable-AAA.log",
+		`2026-06-30T21:51:26Z	info	ExecutableReconciler	Starting process...	{"Executable": "/pr-digest-dapr-cli-yuha", "Cmd": "/usr/local/bin/dapr", "Args": ["run","--app-id","pr-digest","--app-port","5090"]}`+"\n")
+	writeFile("AAA_out", "daprd log line\n")
+
+	// app resource (guid BBB) — same base "pr-digest", a dotnet process.
+	writeFile("resource-executable-BBB.log",
+		`2026-06-30T21:51:30Z	info	ExecutableReconciler	Starting process...	{"Executable": "/pr-digest-zfzg", "Cmd": "/opt/homebrew/bin/dotnet", "Args": ["run","--project","App.csproj"]}`+"\n")
+	writeFile("BBB_out", "app log line\n")
+
+	// unrelated container resource (must be ignored — not resource-executable-*).
+	writeFile("resource-container-CCC.log", "irrelevant\n")
+
+	daprdPath, appPath := resolveDCPLogs(dir, "pr-digest")
+	require.Equal(t, filepath.Join(dir, "AAA_out"), daprdPath)
+	require.Equal(t, filepath.Join(dir, "BBB_out"), appPath)
+}
+
+func TestResolveDCPLogs_AppIdDiffersFromResourceName(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(name, content string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+	}
+	// Resource name "myapi" but Dapr app-id "different-id".
+	writeFile("resource-executable-AAA.log",
+		`x	info	r	Starting process...	{"Executable": "/myapi-dapr-cli-xx", "Cmd": "/usr/local/bin/dapr", "Args": ["run","--app-id","different-id"]}`+"\n")
+	writeFile("AAA_out", "d\n")
+	writeFile("resource-executable-BBB.log",
+		`x	info	r	Starting process...	{"Executable": "/myapi-yy", "Cmd": "/usr/bin/node", "Args": ["server.js"]}`+"\n")
+	writeFile("BBB_out", "a\n")
+
+	daprdPath, appPath := resolveDCPLogs(dir, "different-id")
+	require.Equal(t, filepath.Join(dir, "AAA_out"), daprdPath)
+	require.Equal(t, filepath.Join(dir, "BBB_out"), appPath)
+}
+```
+
+Add `"os"` and `"path/filepath"` to the test file's imports.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test -tags unit ./pkg/discovery/ -run TestResolveDCPLogs -v`
+Expected: FAIL — `undefined: resolveDCPLogs`.
+
+- [ ] **Step 3: Implement `resolveDCPLogs` and helpers**
+
+Append to `pkg/discovery/logsource.go` (and extend the import block to include `encoding/json`, `os`):
+
+```go
+// dcpResourceInfo is the subset of the JSON object DCP writes on the
+// "Starting process..." line of a resource-executable-<guid>.log file.
+type dcpResourceInfo struct {
+	Executable string   `json:"Executable"`
+	Cmd        string   `json:"Cmd"`
+	Args       []string `json:"Args"`
+}
+
+// dcpResource pairs a resource's guid (from its log filename) with its parsed info.
+type dcpResource struct {
+	guid string
+	info dcpResourceInfo
+}
+
+// resolveDCPLogs finds the daprd and app stdout capture files (<guid>_out) that
+// Aspire's DCP writes inside sessionDir for the app with the given Dapr app-id.
+// Either return value is "" when no matching resource is found.
+func resolveDCPLogs(sessionDir, appID string) (daprdPath, appPath string) {
+	entries, err := os.ReadDir(sessionDir)
+	if err != nil {
+		return "", ""
+	}
+	var resources []dcpResource
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "resource-executable-") || !strings.HasSuffix(name, ".log") {
+			continue
+		}
+		guid := strings.TrimSuffix(strings.TrimPrefix(name, "resource-executable-"), ".log")
+		info, ok := parseDCPResourceLog(filepath.Join(sessionDir, name))
+		if !ok {
+			continue
+		}
+		resources = append(resources, dcpResource{guid: guid, info: info})
+	}
+
+	// daprd: the dapr/daprd resource whose args carry `run --app-id <appID>`.
+	var daprdRes *dcpResource
+	for i := range resources {
+		r := &resources[i]
+		base := filepath.Base(r.info.Cmd)
+		if (base == "dapr" || base == "daprd") && argsHaveAppID(r.info.Args, appID) {
+			daprdRes = r
+			daprdPath = filepath.Join(sessionDir, r.guid+"_out")
+			break
+		}
+	}
+	if daprdRes == nil {
+		return daprdPath, ""
+	}
+
+	// app: the sibling executable sharing the base name (daprd resource name minus
+	// the trailing "-dapr-cli-<suffix>"), that is not itself a dapr process.
+	appBase := dcpAppBaseName(daprdRes.info.Executable)
+	for i := range resources {
+		r := &resources[i]
+		if r.guid == daprdRes.guid {
+			continue
+		}
+		cmdBase := filepath.Base(r.info.Cmd)
+		if cmdBase == "dapr" || cmdBase == "daprd" {
+			continue
+		}
+		execName := strings.TrimPrefix(r.info.Executable, "/")
+		if appBase != "" && strings.HasPrefix(execName, appBase+"-") && !strings.Contains(execName, "-dapr-cli-") {
+			appPath = filepath.Join(sessionDir, r.guid+"_out")
+			break
+		}
+	}
+	return daprdPath, appPath
+}
+
+// parseDCPResourceLog reads a resource-executable-<guid>.log file and returns the
+// resource info from its "Starting process..." line (the last one wins, so a
+// restarted resource reflects its latest command).
+func parseDCPResourceLog(path string) (dcpResourceInfo, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return dcpResourceInfo{}, false
+	}
+	var found dcpResourceInfo
+	ok := false
+	for _, line := range strings.Split(string(data), "\n") {
+		idx := strings.Index(line, "{")
+		if idx < 0 {
+			continue
+		}
+		var info dcpResourceInfo
+		if err := json.Unmarshal([]byte(line[idx:]), &info); err != nil {
+			continue
+		}
+		if info.Cmd != "" {
+			found = info
+			ok = true
+		}
+	}
+	return found, ok
+}
+
+// argsHaveAppID reports whether args contains the pair `--app-id <appID>`.
+func argsHaveAppID(args []string, appID string) bool {
+	for i, a := range args {
+		if a == "--app-id" && i+1 < len(args) && args[i+1] == appID {
+			return true
+		}
+	}
+	return false
+}
+
+// dcpAppBaseName derives the app resource base name from a Dapr sidecar resource
+// name by removing the leading "/" and the trailing "-dapr-cli-<suffix>".
+// e.g. "/pr-digest-dapr-cli-yuha" -> "pr-digest".
+func dcpAppBaseName(sidecarExecutable string) string {
+	n := strings.TrimPrefix(sidecarExecutable, "/")
+	if i := strings.Index(n, "-dapr-cli-"); i >= 0 {
+		return n[:i]
+	}
+	return n
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test -tags unit ./pkg/discovery/ -run TestResolveDCPLogs -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/discovery/logsource.go pkg/discovery/logsource_test.go
+git commit -m "feat(discovery): map DCP capture files to daprd/app logs"
+```
+
+---
+
+### Task 3: Resolve standalone-run logs via `lsof`
+
+**Files:**
+- Modify: `pkg/discovery/logsource.go`
+- Modify: `pkg/discovery/logsource_test.go`
+
+**Interfaces:**
+- Produces: `parseLsofStdout(out []byte) string`; `lsofStdoutFile(pid int) string`.
+
+- [ ] **Step 1: Write the failing test for `parseLsofStdout`**
+
+Add to `pkg/discovery/logsource_test.go`:
+
+```go
+func TestParseLsofStdout(t *testing.T) {
+	t.Run("regular file", func(t *testing.T) {
+		out := []byte("p58324\nf1\ntREG\nn/private/tmp/lsoftest.out\n")
+		require.Equal(t, "/private/tmp/lsoftest.out", parseLsofStdout(out))
+	})
+	t.Run("pipe -> empty", func(t *testing.T) {
+		out := []byte("p82640\nf1\ntPIPE\nn->0x4652e99aa6990ec3\n")
+		require.Equal(t, "", parseLsofStdout(out))
+	})
+	t.Run("tty -> empty", func(t *testing.T) {
+		out := []byte("p61604\nf1\ntCHR\nn/dev/ttys014\n")
+		require.Equal(t, "", parseLsofStdout(out))
+	})
+	t.Run("empty input -> empty", func(t *testing.T) {
+		require.Equal(t, "", parseLsofStdout(nil))
+	})
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test -tags unit ./pkg/discovery/ -run TestParseLsofStdout -v`
+Expected: FAIL — `undefined: parseLsofStdout`.
+
+- [ ] **Step 3: Implement `parseLsofStdout` and `lsofStdoutFile`**
+
+Append to `pkg/discovery/logsource.go` (extend the import block to include `os/exec` and `strconv`):
+
+```go
+// parseLsofStdout extracts the file path from `lsof -F ftn` output when the
+// descriptor is a regular file (type "REG"). Returns "" for pipes, ttys ("CHR"),
+// or unparseable output. lsof -F emits one field per line prefixed by a type
+// character: 't' = descriptor type, 'n' = name.
+func parseLsofStdout(out []byte) string {
+	var typ string
+	for _, line := range strings.Split(string(out), "\n") {
+		if len(line) == 0 {
+			continue
+		}
+		switch line[0] {
+		case 't':
+			typ = line[1:]
+		case 'n':
+			if typ == "REG" {
+				return line[1:]
+			}
+		}
+	}
+	return ""
+}
+
+// lsofStdoutFile returns the filesystem path backing pid's stdout (fd 1) when it
+// is a regular file, else "". It shells out to lsof, which is available on macOS
+// and Linux (gopsutil's OpenFiles is not implemented on darwin).
+func lsofStdoutFile(pid int) string {
+	if pid <= 0 {
+		return ""
+	}
+	out, err := exec.Command("lsof", "-p", strconv.Itoa(pid), "-a", "-d", "1", "-F", "ftn").Output()
+	if err != nil {
+		return ""
+	}
+	return parseLsofStdout(out)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test -tags unit ./pkg/discovery/ -run TestParseLsofStdout -v`
+Expected: PASS (all four subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/discovery/logsource.go pkg/discovery/logsource_test.go
+git commit -m "feat(discovery): resolve standalone-run stdout log via lsof"
+```
+
+---
+
+### Task 4: Wire resolution into the discovery service
+
+**Files:**
+- Modify: `pkg/discovery/service.go:39-47` (struct + `New`), `:118-124` (enrich)
+- Modify: `pkg/discovery/logsource_test.go`
+
+**Interfaces:**
+- Consumes: `resolveDCPLogs`, `dcpSessionDir`, `lsofStdoutFile`, `logFormatDCP`, `logFormatPlain`, `appProcResolver.CommandForPort`.
+- Produces: `service.stdoutFile func(pid int) string` field; `(*service).resolveLogSources(*Instance)`.
+
+- [ ] **Step 1: Add the `stdoutFile` seam to the service struct and `New`**
+
+In `pkg/discovery/service.go`, change the struct (lines 39-43) to:
+
+```go
+type service struct {
+	scan       Scanner
+	client     *http.Client
+	appProc    appProcResolver
+	stdoutFile func(pid int) string
+}
+```
+
+And change `New` (lines 45-47) to:
+
+```go
+func New(scan Scanner, client *http.Client) Service {
+	return &service{scan: scan, client: client, appProc: gopsutilResolver{}, stdoutFile: lsofStdoutFile}
+}
+```
+
+- [ ] **Step 2: Call `resolveLogSources` from `enrich`**
+
+In `pkg/discovery/service.go`, in `enrich`, replace the existing block (lines 119-124):
+
+```go
+	if md.AppLogPath != "" {
+		in.AppLogPath = md.AppLogPath
+	}
+	if md.DaprdLogPath != "" {
+		in.DaprdLogPath = md.DaprdLogPath
+	}
+```
+
+with:
+
+```go
+	if md.AppLogPath != "" {
+		in.AppLogPath, in.AppLogFormat = md.AppLogPath, logFormatPlain
+	}
+	if md.DaprdLogPath != "" {
+		in.DaprdLogPath, in.DaprdLogFormat = md.DaprdLogPath, logFormatPlain
+	}
+	s.resolveLogSources(&in)
+```
+
+- [ ] **Step 3: Implement `resolveLogSources`**
+
+Add this method to `pkg/discovery/service.go` (e.g. immediately after `enrich`):
+
+```go
+// resolveLogSources fills in AppLogPath/DaprdLogPath (and their formats) when the
+// sidecar's metadata reported none. Aspire apps get their logs from the DCP
+// session dir; standalone `dapr run` gets them from the process's stdout when it
+// is a regular file (i.e. redirected to a file rather than a terminal).
+func (s *service) resolveLogSources(in *Instance) {
+	if in.DaprdLogPath != "" && in.AppLogPath != "" {
+		return
+	}
+
+	// Aspire: locate the DCP session dir from the app-port listener command.
+	if in.IsAspire && s.appProc != nil && in.AppPort != 0 {
+		if cmd, ok := s.appProc.CommandForPort(in.AppPort); ok {
+			if dir, ok := dcpSessionDir(cmd); ok {
+				daprdPath, appPath := resolveDCPLogs(dir, in.AppID)
+				if in.DaprdLogPath == "" && daprdPath != "" {
+					in.DaprdLogPath, in.DaprdLogFormat = daprdPath, logFormatDCP
+				}
+				if in.AppLogPath == "" && appPath != "" {
+					in.AppLogPath, in.AppLogFormat = appPath, logFormatDCP
+				}
+			}
+		}
+	}
+
+	// Standalone dapr run: stdout is tailable only if redirected to a regular file.
+	if s.stdoutFile == nil {
+		return
+	}
+	if in.DaprdLogPath == "" && in.DaprdPID != 0 {
+		if p := s.stdoutFile(in.DaprdPID); p != "" {
+			in.DaprdLogPath, in.DaprdLogFormat = p, logFormatPlain
+		}
+	}
+	if in.AppLogPath == "" && in.AppPID != 0 {
+		if p := s.stdoutFile(in.AppPID); p != "" {
+			in.AppLogPath, in.AppLogFormat = p, logFormatPlain
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Write the failing test for `resolveLogSources`**
+
+Add to `pkg/discovery/logsource_test.go`:
+
+```go
+func TestResolveLogSources_Aspire(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "resource-executable-AAA.log"),
+		[]byte(`x	info	r	Starting process...	{"Executable":"/pr-digest-dapr-cli-yuha","Cmd":"/usr/local/bin/dapr","Args":["run","--app-id","pr-digest"]}`+"\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AAA_out"), []byte("d\n"), 0o600))
+
+	dcpCmd := "/x/tools/dcp run-controllers --kubeconfig " + filepath.Join(dir, "kubeconfig")
+	s := &service{appProc: fakeResolver{cmd: dcpCmd, ok: true}}
+	in := Instance{AppID: "pr-digest", IsAspire: true, AppPort: 5090}
+	s.resolveLogSources(&in)
+
+	require.Equal(t, filepath.Join(dir, "AAA_out"), in.DaprdLogPath)
+	require.Equal(t, logFormatDCP, in.DaprdLogFormat)
+}
+
+func TestResolveLogSources_StandaloneRegularFile(t *testing.T) {
+	s := &service{stdoutFile: func(pid int) string {
+		if pid == 111 {
+			return "/tmp/app.out"
+		}
+		return ""
+	}}
+	in := Instance{AppID: "x", DaprdPID: 111}
+	s.resolveLogSources(&in)
+
+	require.Equal(t, "/tmp/app.out", in.DaprdLogPath)
+	require.Equal(t, logFormatPlain, in.DaprdLogFormat)
+}
+
+func TestResolveLogSources_StandaloneTTYLeavesEmpty(t *testing.T) {
+	s := &service{stdoutFile: func(int) string { return "" }}
+	in := Instance{AppID: "x", DaprdPID: 111}
+	s.resolveLogSources(&in)
+
+	require.Equal(t, "", in.DaprdLogPath)
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `go test -tags unit ./pkg/discovery/ -run TestResolveLogSources -v`
+Expected: PASS (all three tests). (Implementation from Steps 1-3 is already in place.)
+
+- [ ] **Step 6: Run the full discovery package to check for regressions**
+
+Run: `go test -tags unit -race ./pkg/discovery/`
+Expected: `ok` — existing golden/service tests still pass (new fields use `omitempty`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/discovery/service.go pkg/discovery/logsource_test.go
+git commit -m "feat(discovery): resolve Aspire/standalone log sources in enrich"
+```
+
+---
+
+### Task 5: Normalize DCP lines in the SSE log handler
+
+**Files:**
+- Modify: `pkg/server/logs.go`
+- Create: `pkg/server/logs_test.go`
+
+**Interfaces:**
+- Consumes: `Instance.DaprdLogFormat`, `Instance.AppLogFormat`.
+- Produces: `normalizeLine(line, format string) string`.
+
+- [ ] **Step 1: Write the failing test for `normalizeLine`**
+
+Create `pkg/server/logs_test.go`:
+
+```go
+//go:build unit
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeLine(t *testing.T) {
+	t.Run("dcp daprd line -> standard daprd format", func(t *testing.T) {
+		in := `3 2026-06-30T19:51:27.797Z time="2026..." level=info msg="hi" app_id=pr-digest`
+		want := `time="2026..." level=info msg="hi" app_id=pr-digest`
+		require.Equal(t, want, normalizeLine(in, "dcp"))
+	})
+	t.Run("dcp app line -> ansi stripped", func(t *testing.T) {
+		in := "1 2026-06-30T19:51:31.768Z \x1b[33mwarn\x1b[39m: Dapr.Workflow"
+		require.Equal(t, "warn: Dapr.Workflow", normalizeLine(in, "dcp"))
+	})
+	t.Run("plain strips ansi only, keeps content", func(t *testing.T) {
+		require.Equal(t, "level=info msg=x", normalizeLine("level=info msg=x", "plain"))
+		require.Equal(t, "hello", normalizeLine("\x1b[31mhello\x1b[0m", "plain"))
+	})
+	t.Run("empty format treated as plain", func(t *testing.T) {
+		require.Equal(t, "abc", normalizeLine("abc", ""))
+	})
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test -tags unit ./pkg/server/ -run TestNormalizeLine -v`
+Expected: FAIL — `undefined: normalizeLine`.
+
+- [ ] **Step 3: Implement `normalizeLine`**
+
+In `pkg/server/logs.go`, add `"regexp"` to the import block, and add these package-level vars and function (e.g. above `logsHandler`):
+
+```go
+var (
+	ansiRE      = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	dcpPrefixRE = regexp.MustCompile(`^\d+\s+\S+Z\s+`)
+)
+
+// normalizeLine cleans a captured log line for display. For DCP-captured lines
+// (format "dcp") it strips the leading "<seq> <RFC3339-UTC> " prefix that Aspire's
+// orchestrator prepends. For all formats it strips ANSI color escape codes.
+func normalizeLine(line, format string) string {
+	if format == "dcp" {
+		line = dcpPrefixRE.ReplaceAllString(line, "")
+	}
+	return ansiRE.ReplaceAllString(line, "")
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test -tags unit ./pkg/server/ -run TestNormalizeLine -v`
+Expected: PASS (all subtests).
+
+- [ ] **Step 5: Apply normalization in the stream loop**
+
+In `pkg/server/logs.go`, `logsHandler`: after `source`/`path` are chosen (after line 33, before the `if path == ""` check), capture the format for the chosen source:
+
+```go
+		format := in.DaprdLogFormat
+		if source == "app" {
+			format = in.AppLogFormat
+		}
+```
+
+Then change the SSE write (line 63) from:
+
+```go
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", line)
+```
+
+to:
+
+```go
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", normalizeLine(line, format))
+```
+
+- [ ] **Step 6: Build and run the server package tests**
+
+Run: `go build ./... && go test -tags unit -race ./pkg/server/`
+Expected: build succeeds; `ok`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/server/logs.go pkg/server/logs_test.go
+git commit -m "feat(server): normalize DCP-captured log lines in SSE stream"
+```
+
+---
+
+### Task 6: Correct the frontend "no log file" copy
+
+**Files:**
+- Modify: `web/src/pages/Logs.tsx:361-366`
+
+**Interfaces:**
+- Consumes: nothing new (backend now populates `appLogPath`/`daprdLogPath`; `hasPath` already keys off them).
+
+- [ ] **Step 1: Update the empty-state message**
+
+In `web/src/pages/Logs.tsx`, replace the block at lines 361-366:
+
+```tsx
+      {appId && !isLoading && app && !hasPath && (
+        <div className="card">
+          No log file — this app was started with <code className="mono">dapr run</code> without{' '}
+          <code className="mono">-f</code>
+        </div>
+      )}
+```
+
+with:
+
+```tsx
+      {appId && !isLoading && app && !hasPath && (
+        <div className="card">
+          No captured log file — this app streams its logs to the terminal. Redirect{' '}
+          <code className="mono">dapr run</code> output to a file, or use a{' '}
+          <code className="mono">-f</code> run template, to view logs here.
+        </div>
+      )}
+```
+
+- [ ] **Step 2: Build the frontend to verify it compiles**
+
+Run: `cd web && npm install && npm run build`
+Expected: build succeeds with no TypeScript errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/pages/Logs.tsx
+git commit -m "fix(web): accurate empty-state copy on the Logs page"
+```
+
+---
+
+### Task 7: End-to-end verification against a live app
+
+**Files:** none (manual verification; no code changes).
+
+This task has no automated test — it verifies the feature against real processes. Requires the dashboard running on the host and at least one dapr/Aspire app running.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `make test-go`
+Expected: all Go packages report `ok`.
+
+- [ ] **Step 2: Start the dashboard and verify an Aspire app**
+
+Start the dashboard (per the repo README) with an Aspire app running (e.g. the `PrDigest` sample: `aspire run` in that project). In the dashboard:
+- Open the Logs page, select the Aspire app.
+- Set source to `daprd only`: confirm Dapr runtime lines stream and are level-colored (no `<seq> <timestamp>` prefix, no raw ANSI codes).
+- Set source to `app only`: confirm the app's own log lines stream and are readable (ANSI stripped).
+
+Expected: both sources show live, clean logs.
+
+- [ ] **Step 3: Verify a redirected standalone `dapr run`**
+
+In a terminal: `dapr run --app-id verifytest --dapr-http-port 3597 -- sleep 300 > /tmp/verifytest.out 2>&1 &`
+In the dashboard Logs page, select `verifytest`, source `daprd only`.
+Expected: daprd startup lines appear (resolved via the FD/`lsof` path).
+Cleanup: `pkill -f "app-id verifytest"`.
+
+- [ ] **Step 4: Verify no regression for `dapr run -f`**
+
+If a `dapr run -f <template>` app is available, confirm its logs still stream as before.
+Expected: unchanged behavior.
+
+- [ ] **Step 5: Commit (docs/notes only, if any)**
+
+No code change expected. If verification surfaced issues, file them as follow-up tasks rather than expanding this plan.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Layered resolution (metadata → DCP → FD): Tasks 2, 3, 4. ✅
+- DCP session dir from `--kubeconfig`: Task 1. ✅
+- daprd/app mapping incl. app-id ≠ resource-name: Task 2 (both tests). ✅
+- Standalone via lsof, regular-file only: Task 3 + Task 4. ✅
+- `Instance` format fields (`omitempty`): Task 1. ✅
+- Backend normalization (dcp prefix + ANSI): Task 5. ✅
+- Frontend copy: Task 6. ✅
+- Testing (unit + manual verification): Tasks 1-5 unit, Task 7 manual. ✅
+- Constraints (host access, ephemeral session dir): honored — resolution runs per enrich (no caching), and reuses existing host-scanning resolvers.
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. ✅
+
+**Type consistency:** `resolveDCPLogs(sessionDir, appID) (daprdPath, appPath string)`, `dcpSessionDir(cmd) (string, bool)`, `parseLsofStdout([]byte) string`, `lsofStdoutFile(int) string`, `normalizeLine(string, string) string`, `service.stdoutFile func(int) string`, and format constants `logFormatPlain`/`logFormatDCP` are used identically across Tasks 1-5. ✅

--- a/docs/superpowers/specs/2026-07-01-aspire-standalone-logs-design.md
+++ b/docs/superpowers/specs/2026-07-01-aspire-standalone-logs-design.md
@@ -92,10 +92,14 @@ are empty**, trying resolvers in priority order and recording the format of each
      (the app resource) → its `<guid>_out`. Format = `dcp`. Robust to app-id ≠
      resource-name.
 3. **FD resolver** (standalone `dapr run`) — used when still empty and not Aspire:
-   - Inspect the `daprd` process (`DaprdPID`) stdout via gopsutil `OpenFiles()`. If it
-     resolves to a **regular file** (not `/dev/*`, not a pipe), use it. Format = `plain`.
-   - App log: find the app process (child of `CLIPID` that is not daprd, or `AppPID` from
-     metadata) and inspect its stdout the same way. Format = `plain`.
+   - Inspect the `daprd` process (`DaprdPID`) stdout (fd 1) via `lsof -p <pid> -a -d 1
+     -F ftn`. If it resolves to a **regular file** (lsof type `REG`, not `CHR`/tty, not
+     `PIPE`), use it. Format = `plain`.
+     - Note: gopsutil `OpenFiles()` returns "not implemented" on darwin, so `lsof` is
+       used directly. lsof is standard on macOS and Linux.
+   - App log: inspect the app process (`AppPID` from metadata, when > 0) stdout the same
+     way. Format = `plain`. Deriving the app PID by walking `CLIPID` children is out of
+     scope for v1; when `AppPID` is unknown the app source simply has no log.
    - If the fd is a tty/pipe with no backing file, leave the path empty (no log).
 
 **New code:**
@@ -103,13 +107,13 @@ are empty**, trying resolvers in priority order and recording the format of each
 - `pkg/discovery/types.go`: add `AppLogFormat` and `DaprdLogFormat` fields to `Instance`
   (`"plain"` | `"dcp"`, default `"plain"`).
 - `pkg/discovery/logsource.go` (new): `dcpSessionDir(listenerCmd string) (string, bool)`,
-  `resolveDCPLogs(sessionDir, appID string) (daprdPath, appPath, daprdFmt, appFmt string)`,
-  `resolveFDLogs(daprdPID, appPID, cliPID int) (daprdPath, appPath string)`. The FD
-  resolver takes an injectable `openFiles` function so it can be unit-tested without real
-  processes.
-- `pkg/discovery/service.go`: wire the resolvers into `enrich()` after the metadata fetch.
-  Reuse the app-port listener command already resolved for Aspire detection rather than
-  resolving the process twice.
+  `resolveDCPLogs(sessionDir, appID string) (daprdPath, appPath string)`,
+  `parseLsofStdout(out []byte) string`, `lsofStdoutFile(pid int) string`. The service
+  holds an injectable `stdoutFile func(pid int) string` seam (default `lsofStdoutFile`) so
+  the FD path can be unit-tested without real processes.
+- `pkg/discovery/service.go`: add a `stdoutFile` field (defaulted in `New`), and wire a
+  `resolveLogSources(*Instance)` step into `enrich()` after the metadata fetch. Reuse the
+  app-port listener command (via `appProc.CommandForPort`) rather than resolving twice.
 - `metadata.go` is unchanged.
 
 ### 2. Backend normalization (`pkg/server/logs.go`)
@@ -144,8 +148,10 @@ are empty**, trying resolvers in priority order and recording the format of each
   name.
 - `normalizeLine`: DCP daprd sample → standard `time=…` line; DCP app sample (with ANSI)
   → clean text; plain line with ANSI → ANSI stripped; plain line without ANSI → unchanged.
-- `resolveFDLogs`: with an injected `openFiles` seam, selects a regular file and rejects
-  tty/pipe/`/dev/*` entries.
+- `parseLsofStdout`: returns the path for a `tREG` record; returns `""` for `tPIPE` and
+  `tCHR` (tty) records.
+- `resolveLogSources` (FD path): with an injected `stdoutFile` seam, populates
+  `DaprdLogPath` from a regular-file stdout and leaves it empty when the seam returns `""`.
 
 **Manual verification:**
 

--- a/docs/superpowers/specs/2026-07-01-aspire-standalone-logs-design.md
+++ b/docs/superpowers/specs/2026-07-01-aspire-standalone-logs-design.md
@@ -1,0 +1,169 @@
+# Logs for Aspire-hosted and standalone `dapr run` apps
+
+**Date:** 2026-07-01
+**Status:** Approved (design)
+
+## Problem
+
+The Logs page shows nothing for applications launched via .NET Aspire (`aspire run`),
+and for a standalone single-app `dapr run` (i.e. `dapr run` without a `-f` multi-app
+run template). Only `dapr run -f <template>` currently produces visible logs.
+
+### Root cause
+
+The Logs feature can only tail **log file paths reported by the Dapr sidecar** through
+its `/v1.0/metadata` endpoint (`extended.appLogPath` / `extended.daprdLogPath`):
+
+- `pkg/discovery/metadata.go` copies those two fields into `Instance.AppLogPath` /
+  `Instance.DaprdLogPath`.
+- `pkg/server/logs.go` returns **404** when the selected path is empty.
+- `web/src/pages/Logs.tsx` shows *"No log file — this app was started with `dapr run`
+  without `-f`"* when both paths are empty.
+
+The sidecar only fills `appLogPath` / `daprdLogPath` when launched with a **run
+template** (`dapr run -f`). Verified empirically against a live Aspire app
+(`/v1.0/metadata` returned `appLogPath: None`, `daprdLogPath: None`).
+
+### Where the logs actually are (verified empirically)
+
+| Run mode | Where logs live | Tailable? |
+|---|---|---|
+| `dapr run -f <template>` | files under `~/.dapr/logs`, reported in metadata | Yes — already works |
+| **Aspire** (`aspire run`) | Aspire/DCP session dir: `<sessionDir>/<guid>_out` files | Yes — via DCP session dir |
+| **standalone `dapr run`** (no `-f`) | inherited stdout → tty (or a file only if redirected) | Only if redirected to a regular file |
+
+Details confirmed on a running `PrDigest` Aspire app:
+
+- Aspire's orchestrator (DCP) redirects each child resource's stdout/stderr to
+  `<sessionDir>/<guid>_out` and `<guid>_err`, with a companion
+  `resource-executable-<guid>.log` recording that resource's `Cmd`/`Args`/name.
+  - The `dapr run` CLI resource's `<guid>_out` contains the **daprd** runtime log.
+  - The `dotnet run` app resource's `<guid>_out` contains the **app** log.
+- The DCP **session dir** is discoverable from the process listening on the app port:
+  that listener is the `dcp` process, whose command line carries
+  `--kubeconfig <sessionDir>/kubeconfig`. The discovery layer already resolves this
+  process (`CommandForPort(appPort)` in `pkg/discovery/appproc.go`) during Aspire
+  detection.
+- A standalone single-app `dapr run` writes **no log files** (`~/.dapr/logs` is not
+  created). daprd's stdout/stderr (fd 1/2) inherit from the `dapr run` parent — a tty
+  in a normal terminal (not tailable), or a regular file if the user redirected output.
+- In the Aspire case, daprd's fd 1/2 are **pipes** to DCP (not the `_out` file), so
+  file-descriptor inspection cannot find Aspire logs — the DCP session dir is required.
+
+## Goals
+
+1. Show `daprd` and `app` logs for Aspire-hosted apps.
+2. Show logs for a standalone `dapr run` **when its output is a regular file**
+   (redirected or supervised).
+3. Keep `dapr run -f` working unchanged.
+4. Render DCP-captured lines cleanly (no seq/timestamp prefix noise, no raw ANSI codes).
+
+## Non-goals
+
+- Actively capturing stdout of an already-running terminal `dapr run` whose output is a
+  tty (fundamentally no file to read). Such apps continue to show a clear message.
+- Reworking the dashboard to launch/supervise dapr processes.
+- Parsing `AppHost.cs` source (rejected: fragile to arbitrary C#; runtime data suffices).
+- Querying the DCP API server via kubeconfig (rejected: needs a Kubernetes-style TLS
+  client; heaviest to build/maintain).
+
+## Design
+
+### 1. Layered log-source resolution (`pkg/discovery`)
+
+Add a resolution step in `service.enrich()` that runs **only when the metadata log paths
+are empty**, trying resolvers in priority order and recording the format of each source.
+
+**Resolver order:**
+
+1. **Metadata** (existing) — `extended.appLogPath` / `daprdLogPath`. Format = `plain`.
+   Covers `dapr run -f`.
+2. **DCP resolver** (Aspire) — used when the app-port listener is the DCP proxy
+   (already detected in `appproc.go`):
+   - Parse `--kubeconfig <dir>/kubeconfig` from that listener's command line → DCP
+     **session dir**.
+   - Enumerate `resource-executable-*.log` in the session dir. Parse each file's JSON to
+     obtain the resource name (`Executable`), `Cmd`, and `Args`. The `<guid>` in the
+     filename maps directly to the `<guid>_out` stdout file.
+   - **daprd log** = the resource whose `Cmd` basename is `dapr`/`daprd` and whose `Args`
+     contain `run` and `--app-id <appId>` → its `<guid>_out`. Format = `dcp`.
+   - **app log** = strip the trailing `-dapr-cli-<suffix>` from that daprd resource's name
+     to get the base name, then find the sibling executable resource sharing that base
+     (the app resource) → its `<guid>_out`. Format = `dcp`. Robust to app-id ≠
+     resource-name.
+3. **FD resolver** (standalone `dapr run`) — used when still empty and not Aspire:
+   - Inspect the `daprd` process (`DaprdPID`) stdout via gopsutil `OpenFiles()`. If it
+     resolves to a **regular file** (not `/dev/*`, not a pipe), use it. Format = `plain`.
+   - App log: find the app process (child of `CLIPID` that is not daprd, or `AppPID` from
+     metadata) and inspect its stdout the same way. Format = `plain`.
+   - If the fd is a tty/pipe with no backing file, leave the path empty (no log).
+
+**New code:**
+
+- `pkg/discovery/types.go`: add `AppLogFormat` and `DaprdLogFormat` fields to `Instance`
+  (`"plain"` | `"dcp"`, default `"plain"`).
+- `pkg/discovery/logsource.go` (new): `dcpSessionDir(listenerCmd string) (string, bool)`,
+  `resolveDCPLogs(sessionDir, appID string) (daprdPath, appPath, daprdFmt, appFmt string)`,
+  `resolveFDLogs(daprdPID, appPID, cliPID int) (daprdPath, appPath string)`. The FD
+  resolver takes an injectable `openFiles` function so it can be unit-tested without real
+  processes.
+- `pkg/discovery/service.go`: wire the resolvers into `enrich()` after the metadata fetch.
+  Reuse the app-port listener command already resolved for Aspire detection rather than
+  resolving the process twice.
+- `metadata.go` is unchanged.
+
+### 2. Backend normalization (`pkg/server/logs.go`)
+
+- Add `normalizeLine(line, format string) string`, applied in the SSE streaming loop in
+  `logs.go`, which already knows the chosen source and can read its format from the
+  `Instance` (`DaprdLogFormat` for `source=daprd`, `AppLogFormat` for `source=app`):
+  - `dcp`: strip the leading `^\d+\s+\S+Z\s+` (sequence number + RFC3339-UTC timestamp)
+    prefix, then strip ANSI escape sequences (`\x1b\[[0-9;]*m`). daprd lines collapse back
+    to the standard `time=… level=… msg=…` format the frontend already parses; app lines
+    become clean text. The DCP timestamp is discarded (matches existing sources).
+  - `plain`: strip ANSI escapes only (harmless), no prefix stripping.
+- `pkg/logs/tail.go` stays generic and returns raw lines; the transform lives in the
+  handler.
+
+### 3. Frontend (`web/src`)
+
+- No functional change: `hasPath` and the SSE stream in `useLogStream.ts` / `Logs.tsx`
+  work as soon as the backend populates `appLogPath` / `daprdLogPath`.
+- Update the "No log file" message copy so it is accurate for the genuine tty case, e.g.
+  *"No captured log file — this app streams logs to its terminal."*
+
+## Testing
+
+**Unit tests:**
+
+- `dcpSessionDir`: parses the session dir from a sample `dcp … --kubeconfig
+  <dir>/kubeconfig …` command line; returns `false` for non-DCP commands.
+- `resolveDCPLogs`: given a temp dir containing sample `resource-executable-*.log` files
+  (with representative JSON) and matching `<guid>_out` files, returns the correct daprd
+  and app paths. Includes a case where the Dapr app-id differs from the Aspire resource
+  name.
+- `normalizeLine`: DCP daprd sample → standard `time=…` line; DCP app sample (with ANSI)
+  → clean text; plain line with ANSI → ANSI stripped; plain line without ANSI → unchanged.
+- `resolveFDLogs`: with an injected `openFiles` seam, selects a regular file and rejects
+  tty/pipe/`/dev/*` entries.
+
+**Manual verification:**
+
+- Against the live `PrDigest` Aspire app: select the app on the Logs page, confirm both
+  the `daprd` and `app` sources stream and render cleanly.
+- `dapr run --app-id x … > app.log 2>&1`: confirm logs appear via the FD resolver.
+- A `dapr run -f` template app: confirm it still works (no regression).
+
+## Constraints & risks
+
+- **Host access required.** DCP file reads and FD inspection require the dashboard to run
+  on the host with access to the same filesystem and process namespace as the
+  dapr/Aspire processes. This is already true — discovery relies on host process/port
+  scanning (`standalone.List`, gopsutil) — but the feature will not work if the dashboard
+  runs inside a container without the relevant host mounts.
+- **DCP session dir is per-run and ephemeral.** It must be re-resolved on each discovery
+  pass (resolution runs per `List`/`Get`, so no stale caching).
+- **Combined redirect.** If a standalone `dapr run` redirects both daprd and app to the
+  same file, both sources point at the same combined log — acceptable.
+- **DCP file permissions.** `_out` files are user-owned (0600); the dashboard runs as the
+  same user locally, so reads succeed.

--- a/pkg/discovery/logsource.go
+++ b/pkg/discovery/logsource.go
@@ -95,10 +95,19 @@ func resolveDCPLogs(sessionDir, appID string) (daprdPath, appPath string) {
 			continue
 		}
 		execName := strings.TrimPrefix(r.info.Executable, "/")
-		if appBase != "" && strings.HasPrefix(execName, appBase+"-") && !strings.Contains(execName, "-dapr-cli-") {
-			appPath = filepath.Join(sessionDir, r.guid+"_out")
-			break
+		// The "-dapr-cli-" infix is a DCP naming convention observed empirically (not a stable public API).
+		if appBase == "" || !strings.HasPrefix(execName, appBase+"-") || strings.Contains(execName, "-dapr-cli-") {
+			continue
 		}
+		// Require an exact base match: the suffix after "<appBase>-" must be a single
+		// opaque token with no dash (e.g. "order-zfzg"), so "order-worker-abcd"
+		// (remainder "worker-abcd" contains a dash) does not mis-match app "order".
+		remainder := execName[len(appBase)+1:]
+		if strings.Contains(remainder, "-") {
+			continue
+		}
+		appPath = filepath.Join(sessionDir, r.guid+"_out")
+		break
 	}
 	return daprdPath, appPath
 }

--- a/pkg/discovery/logsource.go
+++ b/pkg/discovery/logsource.go
@@ -3,7 +3,9 @@ package discovery
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -147,4 +149,40 @@ func dcpAppBaseName(sidecarExecutable string) string {
 		return n[:i]
 	}
 	return n
+}
+
+// parseLsofStdout extracts the file path from `lsof -F ftn` output when the
+// descriptor is a regular file (type "REG"). Returns "" for pipes, ttys ("CHR"),
+// or unparseable output. lsof -F emits one field per line prefixed by a type
+// character: 't' = descriptor type, 'n' = name.
+func parseLsofStdout(out []byte) string {
+	var typ string
+	for _, line := range strings.Split(string(out), "\n") {
+		if len(line) == 0 {
+			continue
+		}
+		switch line[0] {
+		case 't':
+			typ = line[1:]
+		case 'n':
+			if typ == "REG" {
+				return line[1:]
+			}
+		}
+	}
+	return ""
+}
+
+// lsofStdoutFile returns the filesystem path backing pid's stdout (fd 1) when it
+// is a regular file, else "". It shells out to lsof, which is available on macOS
+// and Linux (gopsutil's OpenFiles is not implemented on darwin).
+func lsofStdoutFile(pid int) string {
+	if pid <= 0 {
+		return ""
+	}
+	out, err := exec.Command("lsof", "-p", strconv.Itoa(pid), "-a", "-d", "1", "-F", "ftn").Output()
+	if err != nil {
+		return ""
+	}
+	return parseLsofStdout(out)
 }

--- a/pkg/discovery/logsource.go
+++ b/pkg/discovery/logsource.go
@@ -1,0 +1,28 @@
+package discovery
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const (
+	logFormatPlain = "plain"
+	logFormatDCP   = "dcp"
+)
+
+// dcpSessionDir extracts the Aspire DCP session directory from a dcp process
+// command line by reading its `--kubeconfig <dir>/kubeconfig` flag. The session
+// directory is the parent of the kubeconfig file. Returns ("", false) when the
+// flag is absent.
+func dcpSessionDir(cmd string) (string, bool) {
+	fields := strings.Fields(cmd)
+	for i, f := range fields {
+		switch {
+		case f == "--kubeconfig" && i+1 < len(fields):
+			return filepath.Dir(fields[i+1]), true
+		case strings.HasPrefix(f, "--kubeconfig="):
+			return filepath.Dir(strings.TrimPrefix(f, "--kubeconfig=")), true
+		}
+	}
+	return "", false
+}

--- a/pkg/discovery/logsource.go
+++ b/pkg/discovery/logsource.go
@@ -1,6 +1,8 @@
 package discovery
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -25,4 +27,124 @@ func dcpSessionDir(cmd string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// dcpResourceInfo is the subset of the JSON object DCP writes on the
+// "Starting process..." line of a resource-executable-<guid>.log file.
+type dcpResourceInfo struct {
+	Executable string   `json:"Executable"`
+	Cmd        string   `json:"Cmd"`
+	Args       []string `json:"Args"`
+}
+
+// dcpResource pairs a resource's guid (from its log filename) with its parsed info.
+type dcpResource struct {
+	guid string
+	info dcpResourceInfo
+}
+
+// resolveDCPLogs finds the daprd and app stdout capture files (<guid>_out) that
+// Aspire's DCP writes inside sessionDir for the app with the given Dapr app-id.
+// Either return value is "" when no matching resource is found.
+func resolveDCPLogs(sessionDir, appID string) (daprdPath, appPath string) {
+	entries, err := os.ReadDir(sessionDir)
+	if err != nil {
+		return "", ""
+	}
+	var resources []dcpResource
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "resource-executable-") || !strings.HasSuffix(name, ".log") {
+			continue
+		}
+		guid := strings.TrimSuffix(strings.TrimPrefix(name, "resource-executable-"), ".log")
+		info, ok := parseDCPResourceLog(filepath.Join(sessionDir, name))
+		if !ok {
+			continue
+		}
+		resources = append(resources, dcpResource{guid: guid, info: info})
+	}
+
+	// daprd: the dapr/daprd resource whose args carry `run --app-id <appID>`.
+	var daprdRes *dcpResource
+	for i := range resources {
+		r := &resources[i]
+		base := filepath.Base(r.info.Cmd)
+		if (base == "dapr" || base == "daprd") && argsHaveAppID(r.info.Args, appID) {
+			daprdRes = r
+			daprdPath = filepath.Join(sessionDir, r.guid+"_out")
+			break
+		}
+	}
+	if daprdRes == nil {
+		return daprdPath, ""
+	}
+
+	// app: the sibling executable sharing the base name (daprd resource name minus
+	// the trailing "-dapr-cli-<suffix>"), that is not itself a dapr process.
+	appBase := dcpAppBaseName(daprdRes.info.Executable)
+	for i := range resources {
+		r := &resources[i]
+		if r.guid == daprdRes.guid {
+			continue
+		}
+		cmdBase := filepath.Base(r.info.Cmd)
+		if cmdBase == "dapr" || cmdBase == "daprd" {
+			continue
+		}
+		execName := strings.TrimPrefix(r.info.Executable, "/")
+		if appBase != "" && strings.HasPrefix(execName, appBase+"-") && !strings.Contains(execName, "-dapr-cli-") {
+			appPath = filepath.Join(sessionDir, r.guid+"_out")
+			break
+		}
+	}
+	return daprdPath, appPath
+}
+
+// parseDCPResourceLog reads a resource-executable-<guid>.log file and returns the
+// resource info from its "Starting process..." line (the last one wins, so a
+// restarted resource reflects its latest command).
+func parseDCPResourceLog(path string) (dcpResourceInfo, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return dcpResourceInfo{}, false
+	}
+	var found dcpResourceInfo
+	ok := false
+	for _, line := range strings.Split(string(data), "\n") {
+		idx := strings.Index(line, "{")
+		if idx < 0 {
+			continue
+		}
+		var info dcpResourceInfo
+		if err := json.Unmarshal([]byte(line[idx:]), &info); err != nil {
+			continue
+		}
+		if info.Cmd != "" {
+			found = info
+			ok = true
+		}
+	}
+	return found, ok
+}
+
+// argsHaveAppID reports whether args contains the pair `--app-id <appID>`.
+func argsHaveAppID(args []string, appID string) bool {
+	for i, a := range args {
+		if a == "--app-id" && i+1 < len(args) && args[i+1] == appID {
+			return true
+		}
+	}
+	return false
+}
+
+// dcpAppBaseName derives the app resource base name from a Dapr sidecar resource
+// name by removing the leading "/" and the trailing "-dapr-cli-<suffix>".
+// e.g. "/pr-digest-dapr-cli-yuha" -> "pr-digest".
+func dcpAppBaseName(sidecarExecutable string) string {
+	n := strings.TrimPrefix(sidecarExecutable, "/")
+	if i := strings.Index(n, "-dapr-cli-"); i >= 0 {
+		return n[:i]
+	}
+	return n
 }

--- a/pkg/discovery/logsource_test.go
+++ b/pkg/discovery/logsource_test.go
@@ -1,0 +1,29 @@
+//go:build unit
+
+package discovery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDcpSessionDir(t *testing.T) {
+	t.Run("space-separated flag", func(t *testing.T) {
+		cmd := "/x/.nuget/packages/aspire.hosting.orchestration.osx-arm64/13.4.6/tools/dcp run-controllers --kubeconfig /var/folders/4c/T/aspire-dcpZOY2Ea/kubeconfig --monitor 82529"
+		dir, ok := dcpSessionDir(cmd)
+		require.True(t, ok)
+		require.Equal(t, "/var/folders/4c/T/aspire-dcpZOY2Ea", dir)
+	})
+
+	t.Run("equals form", func(t *testing.T) {
+		dir, ok := dcpSessionDir("dcp run-controllers --kubeconfig=/tmp/aspire-dcpABC/kubeconfig")
+		require.True(t, ok)
+		require.Equal(t, "/tmp/aspire-dcpABC", dir)
+	})
+
+	t.Run("no kubeconfig flag", func(t *testing.T) {
+		_, ok := dcpSessionDir("daprd --app-id x")
+		require.False(t, ok)
+	})
+}

--- a/pkg/discovery/logsource_test.go
+++ b/pkg/discovery/logsource_test.go
@@ -72,6 +72,34 @@ func TestResolveDCPLogs_AppIdDiffersFromResourceName(t *testing.T) {
 	require.Equal(t, filepath.Join(dir, "BBB_out"), appPath)
 }
 
+func TestResolveDCPLogs_MultiAppPrefixNotMisMatched(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(name, content string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+	}
+
+	// daprd sidecar for "order" (guid AAA) — resource name "order-dapr-cli-xx".
+	writeFile("resource-executable-AAA.log",
+		`x	info	r	Starting process...	{"Executable": "/order-dapr-cli-xx", "Cmd": "/usr/local/bin/dapr", "Args": ["run","--app-id","order"]}`+"\n")
+	writeFile("AAA_out", "order daprd log\n")
+
+	// app resource for "order" (guid BBB) — resource name "order-aaaa" (no extra dash in remainder).
+	writeFile("resource-executable-BBB.log",
+		`x	info	r	Starting process...	{"Executable": "/order-aaaa", "Cmd": "/usr/bin/myapp", "Args": []}`+"\n")
+	writeFile("BBB_out", "order app log\n")
+
+	// app resource for "order-worker" (guid CCC) — resource name "order-worker-bbbb".
+	// Its remainder after "order-" is "worker-bbbb" which contains a dash, so it must NOT match "order".
+	writeFile("resource-executable-CCC.log",
+		`x	info	r	Starting process...	{"Executable": "/order-worker-bbbb", "Cmd": "/usr/bin/worker", "Args": []}`+"\n")
+	writeFile("CCC_out", "order-worker app log\n")
+
+	daprdPath, appPath := resolveDCPLogs(dir, "order")
+	require.Equal(t, filepath.Join(dir, "AAA_out"), daprdPath)
+	// Must resolve to order's own resource (BBB), not order-worker's (CCC).
+	require.Equal(t, filepath.Join(dir, "BBB_out"), appPath)
+}
+
 func TestParseLsofStdout(t *testing.T) {
 	t.Run("regular file", func(t *testing.T) {
 		out := []byte("p58324\nf1\ntREG\nn/private/tmp/lsoftest.out\n")

--- a/pkg/discovery/logsource_test.go
+++ b/pkg/discovery/logsource_test.go
@@ -89,3 +89,40 @@ func TestParseLsofStdout(t *testing.T) {
 		require.Equal(t, "", parseLsofStdout(nil))
 	})
 }
+
+func TestResolveLogSources_Aspire(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "resource-executable-AAA.log"),
+		[]byte(`x	info	r	Starting process...	{"Executable":"/pr-digest-dapr-cli-yuha","Cmd":"/usr/local/bin/dapr","Args":["run","--app-id","pr-digest"]}`+"\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AAA_out"), []byte("d\n"), 0o600))
+
+	dcpCmd := "/x/tools/dcp run-controllers --kubeconfig " + filepath.Join(dir, "kubeconfig")
+	s := &service{appProc: fakeResolver{cmd: dcpCmd, ok: true}}
+	in := Instance{AppID: "pr-digest", IsAspire: true, AppPort: 5090}
+	s.resolveLogSources(&in)
+
+	require.Equal(t, filepath.Join(dir, "AAA_out"), in.DaprdLogPath)
+	require.Equal(t, logFormatDCP, in.DaprdLogFormat)
+}
+
+func TestResolveLogSources_StandaloneRegularFile(t *testing.T) {
+	s := &service{stdoutFile: func(pid int) string {
+		if pid == 111 {
+			return "/tmp/app.out"
+		}
+		return ""
+	}}
+	in := Instance{AppID: "x", DaprdPID: 111}
+	s.resolveLogSources(&in)
+
+	require.Equal(t, "/tmp/app.out", in.DaprdLogPath)
+	require.Equal(t, logFormatPlain, in.DaprdLogFormat)
+}
+
+func TestResolveLogSources_StandaloneTTYLeavesEmpty(t *testing.T) {
+	s := &service{stdoutFile: func(int) string { return "" }}
+	in := Instance{AppID: "x", DaprdPID: 111}
+	s.resolveLogSources(&in)
+
+	require.Equal(t, "", in.DaprdLogPath)
+}

--- a/pkg/discovery/logsource_test.go
+++ b/pkg/discovery/logsource_test.go
@@ -71,3 +71,21 @@ func TestResolveDCPLogs_AppIdDiffersFromResourceName(t *testing.T) {
 	require.Equal(t, filepath.Join(dir, "AAA_out"), daprdPath)
 	require.Equal(t, filepath.Join(dir, "BBB_out"), appPath)
 }
+
+func TestParseLsofStdout(t *testing.T) {
+	t.Run("regular file", func(t *testing.T) {
+		out := []byte("p58324\nf1\ntREG\nn/private/tmp/lsoftest.out\n")
+		require.Equal(t, "/private/tmp/lsoftest.out", parseLsofStdout(out))
+	})
+	t.Run("pipe -> empty", func(t *testing.T) {
+		out := []byte("p82640\nf1\ntPIPE\nn->0x4652e99aa6990ec3\n")
+		require.Equal(t, "", parseLsofStdout(out))
+	})
+	t.Run("tty -> empty", func(t *testing.T) {
+		out := []byte("p61604\nf1\ntCHR\nn/dev/ttys014\n")
+		require.Equal(t, "", parseLsofStdout(out))
+	})
+	t.Run("empty input -> empty", func(t *testing.T) {
+		require.Equal(t, "", parseLsofStdout(nil))
+	})
+}

--- a/pkg/discovery/logsource_test.go
+++ b/pkg/discovery/logsource_test.go
@@ -3,6 +3,8 @@
 package discovery
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,4 +28,46 @@ func TestDcpSessionDir(t *testing.T) {
 		_, ok := dcpSessionDir("daprd --app-id x")
 		require.False(t, ok)
 	})
+}
+
+func TestResolveDCPLogs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(name, content string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+	}
+
+	// daprd sidecar resource (guid AAA) — app-id "pr-digest", resource name "pr-digest-dapr-cli-yuha".
+	writeFile("resource-executable-AAA.log",
+		`2026-06-30T21:51:26Z	info	ExecutableReconciler	Starting process...	{"Executable": "/pr-digest-dapr-cli-yuha", "Cmd": "/usr/local/bin/dapr", "Args": ["run","--app-id","pr-digest","--app-port","5090"]}`+"\n")
+	writeFile("AAA_out", "daprd log line\n")
+
+	// app resource (guid BBB) — same base "pr-digest", a dotnet process.
+	writeFile("resource-executable-BBB.log",
+		`2026-06-30T21:51:30Z	info	ExecutableReconciler	Starting process...	{"Executable": "/pr-digest-zfzg", "Cmd": "/opt/homebrew/bin/dotnet", "Args": ["run","--project","App.csproj"]}`+"\n")
+	writeFile("BBB_out", "app log line\n")
+
+	// unrelated container resource (must be ignored — not resource-executable-*).
+	writeFile("resource-container-CCC.log", "irrelevant\n")
+
+	daprdPath, appPath := resolveDCPLogs(dir, "pr-digest")
+	require.Equal(t, filepath.Join(dir, "AAA_out"), daprdPath)
+	require.Equal(t, filepath.Join(dir, "BBB_out"), appPath)
+}
+
+func TestResolveDCPLogs_AppIdDiffersFromResourceName(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(name, content string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+	}
+	// Resource name "myapi" but Dapr app-id "different-id".
+	writeFile("resource-executable-AAA.log",
+		`x	info	r	Starting process...	{"Executable": "/myapi-dapr-cli-xx", "Cmd": "/usr/local/bin/dapr", "Args": ["run","--app-id","different-id"]}`+"\n")
+	writeFile("AAA_out", "d\n")
+	writeFile("resource-executable-BBB.log",
+		`x	info	r	Starting process...	{"Executable": "/myapi-yy", "Cmd": "/usr/bin/node", "Args": ["server.js"]}`+"\n")
+	writeFile("BBB_out", "a\n")
+
+	daprdPath, appPath := resolveDCPLogs(dir, "different-id")
+	require.Equal(t, filepath.Join(dir, "AAA_out"), daprdPath)
+	require.Equal(t, filepath.Join(dir, "BBB_out"), appPath)
 }

--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -155,7 +155,8 @@ func (s *service) resolveLogSources(in *Instance) {
 	}
 
 	// Standalone dapr run: stdout is tailable only if redirected to a regular file.
-	if s.stdoutFile == nil {
+	// Skip entirely for Aspire apps — fds are pipes so lsof always returns "".
+	if s.stdoutFile == nil || in.IsAspire {
 		return
 	}
 	if in.DaprdLogPath == "" && in.DaprdPID != 0 {

--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -37,13 +37,14 @@ type Service interface {
 }
 
 type service struct {
-	scan    Scanner
-	client  *http.Client
-	appProc appProcResolver
+	scan       Scanner
+	client     *http.Client
+	appProc    appProcResolver
+	stdoutFile func(pid int) string
 }
 
 func New(scan Scanner, client *http.Client) Service {
-	return &service{scan: scan, client: client, appProc: gopsutilResolver{}}
+	return &service{scan: scan, client: client, appProc: gopsutilResolver{}, stdoutFile: lsofStdoutFile}
 }
 
 const enrichWorkers = 8
@@ -117,15 +118,56 @@ func (s *service) enrich(ctx context.Context, r ScanResult) Instance {
 	}
 	in.Runtime, in.IsAspire = appRuntime(in.Command, in.AppPort, s.appProc)
 	if md.AppLogPath != "" {
-		in.AppLogPath = md.AppLogPath
+		in.AppLogPath, in.AppLogFormat = md.AppLogPath, logFormatPlain
 	}
 	if md.DaprdLogPath != "" {
-		in.DaprdLogPath = md.DaprdLogPath
+		in.DaprdLogPath, in.DaprdLogFormat = md.DaprdLogPath, logFormatPlain
 	}
+	s.resolveLogSources(&in)
 	if md.RunTemplate != "" {
 		in.RunTemplate = md.RunTemplate
 	}
 	return in
+}
+
+// resolveLogSources fills in AppLogPath/DaprdLogPath (and their formats) when the
+// sidecar's metadata reported none. Aspire apps get their logs from the DCP
+// session dir; standalone `dapr run` gets them from the process's stdout when it
+// is a regular file (i.e. redirected to a file rather than a terminal).
+func (s *service) resolveLogSources(in *Instance) {
+	if in.DaprdLogPath != "" && in.AppLogPath != "" {
+		return
+	}
+
+	// Aspire: locate the DCP session dir from the app-port listener command.
+	if in.IsAspire && s.appProc != nil && in.AppPort != 0 {
+		if cmd, ok := s.appProc.CommandForPort(in.AppPort); ok {
+			if dir, ok := dcpSessionDir(cmd); ok {
+				daprdPath, appPath := resolveDCPLogs(dir, in.AppID)
+				if in.DaprdLogPath == "" && daprdPath != "" {
+					in.DaprdLogPath, in.DaprdLogFormat = daprdPath, logFormatDCP
+				}
+				if in.AppLogPath == "" && appPath != "" {
+					in.AppLogPath, in.AppLogFormat = appPath, logFormatDCP
+				}
+			}
+		}
+	}
+
+	// Standalone dapr run: stdout is tailable only if redirected to a regular file.
+	if s.stdoutFile == nil {
+		return
+	}
+	if in.DaprdLogPath == "" && in.DaprdPID != 0 {
+		if p := s.stdoutFile(in.DaprdPID); p != "" {
+			in.DaprdLogPath, in.DaprdLogFormat = p, logFormatPlain
+		}
+	}
+	if in.AppLogPath == "" && in.AppPID != 0 {
+		if p := s.stdoutFile(in.AppPID); p != "" {
+			in.AppLogPath, in.AppLogFormat = p, logFormatPlain
+		}
+	}
 }
 
 func humanAge(t time.Time) string {

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -29,6 +29,8 @@ type Instance struct {
 	ConfigPath      string         `json:"configPath"`
 	AppLogPath      string         `json:"appLogPath"`
 	DaprdLogPath    string         `json:"daprdLogPath"`
+	AppLogFormat    string         `json:"appLogFormat,omitempty"`   // "" / "plain" / "dcp"
+	DaprdLogFormat  string         `json:"daprdLogFormat,omitempty"` // "" / "plain" / "dcp"
 	Command         string         `json:"command"`
 	RuntimeVersion  string         `json:"runtimeVersion"` // from metadata; "" if unavailable
 	MetadataOK      bool           `json:"metadataOk"`     // false if /v1.0/metadata failed

--- a/pkg/server/logs.go
+++ b/pkg/server/logs.go
@@ -5,12 +5,28 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/diagridio/dev-dashboard/pkg/discovery"
 	"github.com/diagridio/dev-dashboard/pkg/logs"
 	"github.com/go-chi/chi/v5"
 )
+
+var (
+	ansiRE      = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	dcpPrefixRE = regexp.MustCompile(`^\d+\s+\S+Z\s+`)
+)
+
+// normalizeLine cleans a captured log line for display. For DCP-captured lines
+// (format "dcp") it strips the leading "<seq> <RFC3339-UTC> " prefix that Aspire's
+// orchestrator prepends. For all formats it strips ANSI color escape codes.
+func normalizeLine(line, format string) string {
+	if format == "dcp" {
+		line = dcpPrefixRE.ReplaceAllString(line, "")
+	}
+	return ansiRE.ReplaceAllString(line, "")
+}
 
 func logsHandler(svc discovery.Service) http.HandlerFunc {
 	log := slog.Default().With("component", "server")
@@ -30,6 +46,10 @@ func logsHandler(svc discovery.Service) http.HandlerFunc {
 		if req.URL.Query().Get("source") == "app" {
 			source = "app"
 			path = in.AppLogPath
+		}
+		format := in.DaprdLogFormat
+		if source == "app" {
+			format = in.AppLogFormat
 		}
 		if path == "" {
 			log.Warn("log stream source unavailable", "app", appID, "source", source, "path", path)
@@ -60,7 +80,7 @@ func logsHandler(svc discovery.Service) http.HandlerFunc {
 				if !open {
 					return
 				}
-				_, _ = fmt.Fprintf(w, "data: %s\n\n", line)
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", normalizeLine(line, format))
 				flusher.Flush()
 			case <-req.Context().Done():
 				return

--- a/pkg/server/logs_test.go
+++ b/pkg/server/logs_test.go
@@ -92,3 +92,22 @@ func TestLogsHandler_LogsSourceUnavailable(t *testing.T) {
 		t.Fatalf("expected 'log stream source unavailable' WARN, got %q", buf.String())
 	}
 }
+
+func TestNormalizeLine(t *testing.T) {
+	t.Run("dcp daprd line -> standard daprd format", func(t *testing.T) {
+		in := `3 2026-06-30T19:51:27.797Z time="2026..." level=info msg="hi" app_id=pr-digest`
+		want := `time="2026..." level=info msg="hi" app_id=pr-digest`
+		require.Equal(t, want, normalizeLine(in, "dcp"))
+	})
+	t.Run("dcp app line -> ansi stripped", func(t *testing.T) {
+		in := "1 2026-06-30T19:51:31.768Z \x1b[33mwarn\x1b[39m: Dapr.Workflow"
+		require.Equal(t, "warn: Dapr.Workflow", normalizeLine(in, "dcp"))
+	})
+	t.Run("plain strips ansi only, keeps content", func(t *testing.T) {
+		require.Equal(t, "level=info msg=x", normalizeLine("level=info msg=x", "plain"))
+		require.Equal(t, "hello", normalizeLine("\x1b[31mhello\x1b[0m", "plain"))
+	})
+	t.Run("empty format treated as plain", func(t *testing.T) {
+		require.Equal(t, "abc", normalizeLine("abc", ""))
+	})
+}

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -360,8 +360,9 @@ export function Logs() {
 
       {appId && !isLoading && app && !hasPath && (
         <div className="card">
-          No log file — this app was started with <code className="mono">dapr run</code> without{' '}
-          <code className="mono">-f</code>
+          No captured log file — this app streams its logs to the terminal. Redirect{' '}
+          <code className="mono">dapr run</code> output to a file, or use a{' '}
+          <code className="mono">-f</code> run template, to view logs here.
         </div>
       )}
 


### PR DESCRIPTION
## Problem

The Logs page showed nothing for apps launched via **.NET Aspire** (`aspire run`) or via a plain **standalone `dapr run`** (no `-f` run template). Only `dapr run -f <template>` produced visible logs, because the page can only tail log-file paths that the Dapr sidecar reports through `/v1.0/metadata` — and the sidecar only populates those for run templates.

## What the logs actually are (verified on a live app)

| Run mode | Where logs live | Status |
|---|---|---|
| `dapr run -f <template>` | files under `~/.dapr/logs`, reported in metadata | already worked |
| **Aspire** (`aspire run`) | Aspire/DCP session dir `<guid>_out` capture files | **now supported** |
| **standalone `dapr run`** (no `-f`) | inherited stdout → tty, or a regular file if redirected | **now supported when redirected to a file** |

## Approach

Layered log-source resolution in the discovery layer, run only when metadata reports no path (so `dapr run -f` is never overridden):

1. **Metadata** (existing) — covers `dapr run -f`.
2. **DCP resolver (Aspire)** — parse `--kubeconfig` from the app-port's DCP listener to find the session dir, then map each resource's `<guid>_out` to daprd (matched by `--app-id`) and app (matched by the DCP `<base>-dapr-cli` naming convention, with an exact-base check so multi-app runs don't cross-map).
3. **FD resolver (standalone)** — resolve the process's stdout (fd 1) via `lsof`; use it only if it's a regular file (tty/pipe → no log).

The SSE handler normalizes DCP-captured lines (strips the `<seq> <timestamp>` prefix and ANSI codes) so daprd lines collapse to the standard format the frontend already parses and app lines render cleanly. The frontend empty-state copy was corrected.

## Testing

- Unit tests for `dcpSessionDir`, `resolveDCPLogs` (incl. app-id ≠ resource-name and multi-app prefix cases), `parseLsofStdout` (REG/PIPE/CHR), `resolveLogSources` (Aspire + standalone via a seam), and `normalizeLine`. Full `go test -tags unit -race ./...` passes.
- **Live end-to-end**: verified against a running Aspire app (both daprd + app sources resolve to DCP `_out`, `format=dcp`, streaming) and a redirected standalone `dapr run` (resolved via `lsof`, `format=plain`, streaming).

## Notes / constraints

- Requires the dashboard to run on the host (same filesystem + process namespace as the dapr/Aspire processes) — already true of existing discovery.
- A standalone `dapr run` whose output goes to a terminal (not a file) still has no on-disk log; the page shows an accurate message.
- Includes the design spec and implementation plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)