### PR TITLE
Fix web CI: sync Logs empty-state test + hint with new log sources

### DIFF
--- a/web/src/pages/Logs.test.tsx
+++ b/web/src/pages/Logs.test.tsx
@@ -269,7 +269,7 @@ describe('Logs', () => {
     renderAt()
 
     await waitFor(() =>
-      expect(screen.getByText(/No log file/)).toBeInTheDocument(),
+      expect(screen.getByText(/No captured log file/)).toBeInTheDocument(),
     )
 
     expect(FakeES.instances).toHaveLength(0)

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -381,8 +381,9 @@ export function Logs() {
       )}
 
       <p className="hint">
-        Logs are read from the run-template log files (<span className="mono">~/.dapr/logs/…</span>
-        ). Level chips &amp; search filter live; search matches are highlighted.
+        Logs are read from run-template files (<span className="mono">~/.dapr/logs/…</span>), .NET Aspire
+        captured output, or a redirected <span className="mono">dapr run</span> stdout file. Level chips &amp;
+        search filter live; search matches are highlighted.
       </p>
     </div>
   )


### PR DESCRIPTION
## Problem

Web CI (`vitest`) failed after the Aspire/standalone-logs feature merged (#15). The Logs empty-state test still asserted the old copy `/No log file/`, but the message was changed to *"No captured log file — this app streams its logs to the terminal…"*. The assertion timed out.

It slipped through because that task verified with `npm run build` (passes) but not `npm test`.

## Changes

- **`web/src/pages/Logs.test.tsx`** — update the empty-state assertion to `/No captured log file/`, matching the intentional new copy (test intent unchanged: empty state renders when no log path).
- **`web/src/pages/Logs.tsx`** — correct the footer hint, which still claimed logs come only from run-template files. It now also names .NET Aspire captured output and a redirected `dapr run` stdout file, consistent with the feature and the empty-state copy.

## Verification

- `npm test` (vitest): **46 files, 319 tests passing**.
- `npm run build`: clean (no TypeScript errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)