### PR TITLE
feat(web): select and auto-expand event pairs in the workflow timeline

### DIFF
--- a/docs/superpowers/plans/2026-07-01-event-pair-selection.md
+++ b/docs/superpowers/plans/2026-07-01-event-pair-selection.md
@@ -1,0 +1,543 @@
+# Event Pair Selection & Auto-Expand Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a persistent, toggleable "selected pair" state to the workflow event timeline: clicking a paired row (or navigating to it via its pair-ID chip) highlights both rows of the pair with a border and expands the acted-on row; clicking the selected row again clears it.
+
+**Architecture:** Selection is a single piece of state in `WorkflowDetail` (`{ pairId, index } | null`). `EventRow` becomes *controlled* for paired rows: its `<details>` `open` is driven by whether it is the active (acted-on) row, its header click drives selection instead of native toggle, and a `pair-selected` class draws a border via the existing `::after` overlay. Unpaired rows keep native uncontrolled behavior. Navigation reuses the existing `hashchange` handler, extended to set selection.
+
+**Tech Stack:** React 19 + TypeScript, Vitest + `@testing-library/react` + `@testing-library/user-event` + MSW (`server.use`), plain CSS (`theme.css`). All frontend, in `web/`.
+
+## Global Constraints
+
+- Run frontend tests from `web/`: `npx vitest run`; typecheck: `npx tsc --noEmit`.
+- Single selection: at most one pair selected at a time; selecting another replaces it.
+- Only paired rows participate in selection. Unpaired rows keep native `<details>` expand/collapse and never set/clear selection.
+- Only the acted-on row expands; its partner is highlighted (border) but stays collapsed until navigated/clicked.
+- Deselect (toggle off) happens only when re-clicking the *active* row of the selected pair. Clicking the highlighted-but-inactive partner moves the active row to it (selects+expands it), it does not toggle off.
+- Inner controls must not toggle selection: the pair chip `<a>`, the `#` copy-link button (`.evanchor`), and the child-instance link (`.evchildlink`) call `e.stopPropagation()`.
+- `EventRow`'s new props (`pairSelected`, `isActive`, `onToggleSelect`) MUST be optional so the existing `EventRow` unit tests in `WorkflowDetail.test.tsx` and `WorkflowDetail.pairing.test.tsx` (which omit them) keep compiling and passing.
+- Selection state must survive the asc/desc order toggle and data refetch: it is keyed by canonical index (`pairIndex`/`canonicalIndex` are memoized on history and order-independent).
+- Border overlay reuses the inset `::after` geometry established for hover: `left:-8px; right:-8px; top:4px; bottom:-6px; border-radius:10px; z-index:-1; pointer-events:none`.
+
+---
+
+### Task 1: `EventRow` selection/expansion rendering + CSS
+
+Make `EventRow` render paired rows as controlled (selectable + expand-on-active) and draw the selected border, without changing unpaired-row behavior.
+
+**Files:**
+- Modify: `web/src/pages/WorkflowDetail.tsx` (`EventRow`, lines 76-256)
+- Modify: `web/src/styles/theme.css` (add `.ev.pair-selected::after` after the `.ev.pair-hover::after` rule, ~line 411; add a selectable-static cursor rule)
+- Test: `web/src/pages/WorkflowDetail.pairing.test.tsx` (add a describe block)
+
+**Interfaces:**
+- Consumes (from Task 2): `pairSelected?: boolean`, `isActive?: boolean`, `onToggleSelect?: () => void` passed by `WorkflowDetail`.
+- Produces: `EventRow` renders `<details open>` when `isActive`, applies `pair-selected` class when `pairSelected`, calls `onToggleSelect()` on header click for paired rows, and stops propagation on inner controls.
+
+- [ ] **Step 1: Write the failing EventRow tests**
+
+Append to `web/src/pages/WorkflowDetail.pairing.test.tsx`. First extend `renderRow` to accept optional extra props, then add the describe block:
+
+```tsx
+import { fireEvent } from '@testing-library/react'
+
+function renderRowEx(
+  event: WorkflowHistoryEvent,
+  pair: Parameters<typeof EventRow>[0]['pair'],
+  extra?: Partial<Parameters<typeof EventRow>[0]>,
+) {
+  const noop = () => {}
+  return render(
+    <MemoryRouter>
+      <EventRow
+        event={event}
+        createdAt={'2026-06-28T10:00:00.000Z'}
+        isNewest={false}
+        toast={{ show: noop } as never}
+        anchorId="event-1"
+        appId="app"
+        pair={pair}
+        pairHovered={false}
+        onPairHover={noop}
+        {...extra}
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe('EventRow selection', () => {
+  const scheduled: WorkflowHistoryEvent = {
+    type: 'TaskScheduled', sequenceId: 1, timestamp: '2026-06-28T10:00:00.100Z', name: 'Charge', input: '{"x":1}',
+  }
+  const startPair = { pairId: 1, role: 'start' as const, partnerIndex: 4, durationMs: null }
+
+  it('renders the details open when isActive', () => {
+    const { container } = renderRowEx(scheduled, startPair, { isActive: true })
+    expect((container.querySelector('details.evd') as HTMLDetailsElement).open).toBe(true)
+  })
+
+  it('renders the details closed when not active', () => {
+    const { container } = renderRowEx(scheduled, startPair, { isActive: false })
+    expect((container.querySelector('details.evd') as HTMLDetailsElement).open).toBe(false)
+  })
+
+  it('adds the pair-selected class to the row when pairSelected', () => {
+    const { container } = renderRowEx(scheduled, startPair, { pairSelected: true })
+    expect(container.querySelector('.ev')!.className).toContain('pair-selected')
+  })
+
+  it('calls onToggleSelect and suppresses native toggle when the summary is clicked', () => {
+    let calls = 0
+    const { container } = renderRowEx(scheduled, startPair, { isActive: false, onToggleSelect: () => { calls++ } })
+    const summary = container.querySelector('details.evd > summary')!
+    fireEvent.click(summary)
+    expect(calls).toBe(1)
+    // Controlled: still closed because state (isActive) did not change in this shallow render.
+    expect((container.querySelector('details.evd') as HTMLDetailsElement).open).toBe(false)
+  })
+
+  it('does NOT call onToggleSelect when the pair chip is clicked (stopPropagation)', () => {
+    let calls = 0
+    const { container } = renderRowEx(scheduled, startPair, { onToggleSelect: () => { calls++ } })
+    const chip = container.querySelector('a.pairchip') as HTMLAnchorElement
+    fireEvent.click(chip)
+    expect(calls).toBe(0)
+  })
+
+  it('does NOT call onToggleSelect when the copy-link (#) button is clicked (stopPropagation)', () => {
+    let calls = 0
+    const { container } = renderRowEx(scheduled, startPair, { onToggleSelect: () => { calls++ } })
+    fireEvent.click(container.querySelector('.evanchor') as HTMLElement)
+    expect(calls).toBe(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd /Users/marcduiker/dev/diagrid/dev-dashboard/.claude/worktrees/spec+workflow-event-pairing-links/web && npx vitest run src/pages/WorkflowDetail.pairing.test.tsx`
+Expected: FAIL — `EventRow` has no `pairSelected`/`isActive`/`onToggleSelect` props (TS error) and the details is not controlled / clicks not intercepted.
+
+- [ ] **Step 3: Extend the `EventRow` prop list**
+
+In `web/src/pages/WorkflowDetail.tsx`, update the destructure (lines 76-98) to add the three optional props:
+
+```tsx
+export function EventRow({
+  event,
+  createdAt,
+  isNewest,
+  toast,
+  anchorId,
+  appId,
+  store,
+  pair,
+  pairHovered,
+  onPairHover,
+  pairSelected,
+  isActive,
+  onToggleSelect,
+}: {
+  event: WorkflowHistoryEvent
+  createdAt: string | undefined
+  isNewest: boolean
+  toast: ToastHandle
+  anchorId: string
+  appId: string
+  store?: string
+  pair?: PairInfo | null
+  pairHovered?: boolean
+  onPairHover?: (pairId: number | null) => void
+  pairSelected?: boolean
+  isActive?: boolean
+  onToggleSelect?: () => void
+}) {
+```
+
+- [ ] **Step 4: Stop propagation on the pair chip links**
+
+In the `pairChip` IIFE (lines 125-138), add `onClick={(e) => e.stopPropagation()}` to BOTH `<a className="pairchip">` variants (the `role === 'start'` and the end variant), so a chip click navigates without triggering the row's selection toggle. The pending `<span>` variant is left as-is (clicking it may fall through to select the row — acceptable, it has no navigation of its own).
+
+Start variant:
+```tsx
+      return (
+        <a className="pairchip" href={href} aria-label="Jump to result" title="Jump to result" onClick={(e) => e.stopPropagation()} onMouseEnter={enter} onMouseLeave={leave}>
+          #{pair.pairId} ↓
+        </a>
+      )
+```
+End variant:
+```tsx
+    return (
+      <a className="pairchip" href={href} aria-label="Jump to scheduled" title="Jump to scheduled" onClick={(e) => e.stopPropagation()} onMouseEnter={enter} onMouseLeave={leave}>
+        #{pair.pairId} ↑{dur ? ` ${dur}` : ''}
+      </a>
+    )
+```
+
+- [ ] **Step 5: Add a `selectable` flag and the header-click handler**
+
+Immediately after `const hasDetails = !!(event.input || event.output)` (line 149), add:
+
+```tsx
+  const selectable = !!pair
+  const onHeaderClick = (e: React.MouseEvent) => {
+    e.preventDefault() // suppress native <details> toggle; selection drives expansion
+    onToggleSelect?.()
+  }
+```
+
+Add the `React` type import if not already present — the file's first import is `import { useState, useEffect, useMemo } from 'react'`; change it to also import the type:
+```tsx
+import { useState, useEffect, useMemo, type MouseEvent as ReactMouseEvent } from 'react'
+```
+and use `ReactMouseEvent` instead of `React.MouseEvent` in the handler signature:
+```tsx
+  const onHeaderClick = (e: ReactMouseEvent) => {
+```
+
+- [ ] **Step 6: Make the row container, details, and header controlled**
+
+Update the row container className (line 158) to add the selected class:
+```tsx
+    <div id={anchorId} className={`ev${isNewest ? ' reveal' : ''}${pairHovered ? ' pair-hover' : ''}${pairSelected ? ' pair-selected' : ''}`}>
+```
+
+Replace the opening of the expandable branch (line 168) so paired rows are controlled and intercept the summary click:
+```tsx
+          <details className="evd" {...(selectable ? { open: !!isActive } : {})}>
+            <summary onClick={selectable ? onHeaderClick : undefined}>
+```
+
+Add `stopPropagation` to the `#` copy-link button inside the summary (lines 174-184) — keep its existing `preventDefault`/copy behavior:
+```tsx
+              <button
+                className="evanchor"
+                aria-label="Copy link to this event"
+                title="Copy link to this event"
+                onClick={(e) => {
+                  e.preventDefault() // don't toggle the <details>
+                  e.stopPropagation() // don't trigger row selection
+                  copyAnchorLink()
+                }}
+              >
+                #
+              </button>
+```
+
+For the static (body-less) branch, make the head selectable. Replace the wrapper + head opening (lines 224-225):
+```tsx
+          <div className={`evd evstatic${selectable ? ' selectable' : ''}`}>
+            <div className="evstatic-head" onClick={selectable ? () => onToggleSelect?.() : undefined}>
+```
+
+Add `stopPropagation` to the child-instance link (lines 232-239):
+```tsx
+                {event.type === 'SubOrchestrationCreated' && event.instanceId && (
+                  <Link
+                    className="evchildlink"
+                    to={`/workflows/${appId}/${event.instanceId}${store ? `?store=${encodeURIComponent(store)}` : ''}`}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {event.instanceId}
+                  </Link>
+                )}
+```
+
+Add `stopPropagation` to the static branch's `#` copy-link button (lines 242-249):
+```tsx
+              <button
+                className="evanchor"
+                aria-label="Copy link to this event"
+                title="Copy link to this event"
+                onClick={(e) => {
+                  e.stopPropagation() // don't trigger row selection
+                  copyAnchorLink()
+                }}
+              >
+                #
+              </button>
+```
+
+- [ ] **Step 7: Add the selected-border CSS**
+
+In `web/src/styles/theme.css`, immediately AFTER the `.ev.pair-hover::after { ... }` rule (ends ~line 411), add:
+
+```css
+.ev.pair-selected::after {
+  content: "";
+  position: absolute;
+  left: -8px;
+  right: -8px;
+  top: 4px;
+  bottom: -6px;
+  background: color-mix(in srgb, var(--accent2) 14%, transparent);
+  border: 1.5px solid var(--accent2);
+  border-radius: 10px;
+  z-index: -1;
+  pointer-events: none;
+}
+.evd.evstatic.selectable { cursor: pointer; }
+```
+
+(Placed after `.ev.pair-hover::after` so, when a row is both hovered and selected, the selected declarations win on the shared `::after`.)
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `cd /Users/marcduiker/dev/diagrid/dev-dashboard/.claude/worktrees/spec+workflow-event-pairing-links/web && npx vitest run src/pages/WorkflowDetail.pairing.test.tsx && npx tsc --noEmit`
+Expected: PASS (new selection tests + existing chip tests) and no type errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/src/pages/WorkflowDetail.tsx web/src/styles/theme.css web/src/pages/WorkflowDetail.pairing.test.tsx
+git commit -m "feat(web): EventRow selectable pairs with controlled expand + selected border
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `WorkflowDetail` selection state + wiring + navigation
+
+Own the selection state, wire it into every row, and make chip navigation select+expand the target.
+
+**Files:**
+- Modify: `web/src/pages/WorkflowDetail.tsx` (`WorkflowDetail`: state, `jumpToHash` effect, render loop; ~lines 262-688)
+- Test: `web/src/pages/WorkflowDetail.test.tsx` (add a describe block)
+
+**Interfaces:**
+- Consumes: `EventRow`'s `pairSelected`/`isActive`/`onToggleSelect` props (Task 1); `pairIndex`/`canonicalIndex` maps (existing memo); `eventAnchorId` (existing).
+- Produces: end-to-end selection behavior in the rendered timeline.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append to `web/src/pages/WorkflowDetail.test.tsx` a new describe block (it reuses the file's existing `renderDetail`, `server`, `http`, `HttpResponse`, `userEvent`, `screen`, `waitFor`, `act` imports). The pairing fixture's canonical ascending order is `[ExecutionStarted(ci0), TaskScheduled(ci1), TaskCompleted(ci2), ExecutionCompleted(ci3)]`:
+
+```tsx
+describe('WorkflowDetail — pair selection', () => {
+  beforeEach(() => {
+    server.use(http.get('/api/apps', () => HttpResponse.json([{ appId: 'order', health: 'healthy' }])))
+  })
+
+  function seedPair() {
+    server.use(
+      http.get('/api/workflows/order/abc', () =>
+        HttpResponse.json({
+          appId: 'order', instanceId: 'abc', name: 'OrderWorkflow', status: 'Completed',
+          createdAt: '2026-06-28T10:00:00.000Z', lastUpdatedAt: '2026-06-28T10:00:01.000Z',
+          replayCount: 0, output: '"ok"',
+          history: [
+            { sequenceId: 0, type: 'ExecutionStarted', name: 'OrderWorkflow', input: '{}', timestamp: '2026-06-28T10:00:00.000Z' },
+            { sequenceId: 1, type: 'TaskScheduled', name: 'Charge', input: '{"amt":5}', timestamp: '2026-06-28T10:00:00.100Z' },
+            { sequenceId: 2, type: 'TaskCompleted', scheduledId: 1, output: '"charged"', timestamp: '2026-06-28T10:00:00.440Z' },
+            { sequenceId: 3, type: 'ExecutionCompleted', output: '"ok"', timestamp: '2026-06-28T10:00:01.000Z' },
+          ],
+        }),
+      ),
+    )
+  }
+
+  function rowByType(container: HTMLElement, type: string): HTMLElement {
+    const row = Array.from(container.querySelectorAll('.timeline .ev')).find(
+      (el) => el.querySelector('.evtype')?.textContent === type,
+    )
+    if (!row) throw new Error(`row ${type} not found`)
+    return row as HTMLElement
+  }
+
+  it('clicking a paired row selects the pair (both highlighted) and expands the clicked row', async () => {
+    seedPair()
+    const { container } = renderDetail()
+    await screen.findByRole('heading', { name: 'OrderWorkflow' })
+
+    const scheduled = rowByType(container, 'TaskScheduled')
+    await userEvent.click(scheduled.querySelector('summary') as HTMLElement)
+
+    expect(rowByType(container, 'TaskScheduled').className).toContain('pair-selected')
+    expect(rowByType(container, 'TaskCompleted').className).toContain('pair-selected')
+    expect((rowByType(container, 'TaskScheduled').querySelector('details') as HTMLDetailsElement).open).toBe(true)
+    // partner highlighted but not expanded
+    expect((rowByType(container, 'TaskCompleted').querySelector('details') as HTMLDetailsElement).open).toBe(false)
+  })
+
+  it('clicking the selected row again clears the selection and collapses it', async () => {
+    seedPair()
+    const { container } = renderDetail()
+    await screen.findByRole('heading', { name: 'OrderWorkflow' })
+    const summary = () => rowByType(container, 'TaskScheduled').querySelector('summary') as HTMLElement
+
+    await userEvent.click(summary())
+    expect(rowByType(container, 'TaskScheduled').className).toContain('pair-selected')
+    await userEvent.click(summary())
+    expect(rowByType(container, 'TaskScheduled').className).not.toContain('pair-selected')
+    expect(rowByType(container, 'TaskCompleted').className).not.toContain('pair-selected')
+    expect((rowByType(container, 'TaskScheduled').querySelector('details') as HTMLDetailsElement).open).toBe(false)
+  })
+
+  it('clicking an unpaired row does not select anything', async () => {
+    seedPair()
+    const { container } = renderDetail()
+    await screen.findByRole('heading', { name: 'OrderWorkflow' })
+    await userEvent.click(rowByType(container, 'ExecutionStarted').querySelector('summary') as HTMLElement)
+    expect(container.querySelector('.ev.pair-selected')).toBeNull()
+  })
+
+  it('navigating via hash to a paired event selects the pair and expands the target', async () => {
+    seedPair()
+    const { container } = renderDetail()
+    await screen.findByRole('heading', { name: 'OrderWorkflow' })
+
+    // TaskCompleted is canonical index 2 -> anchor event-2.
+    await act(async () => {
+      window.location.hash = '#event-2'
+      window.dispatchEvent(new HashChangeEvent('hashchange'))
+    })
+
+    expect(rowByType(container, 'TaskCompleted').className).toContain('pair-selected')
+    expect(rowByType(container, 'TaskScheduled').className).toContain('pair-selected')
+    expect((rowByType(container, 'TaskCompleted').querySelector('details') as HTMLDetailsElement).open).toBe(true)
+
+    // reset hash so it doesn't leak into other tests
+    await act(async () => { window.location.hash = '' })
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd /Users/marcduiker/dev/diagrid/dev-dashboard/.claude/worktrees/spec+workflow-event-pairing-links/web && npx vitest run src/pages/WorkflowDetail.test.tsx`
+Expected: FAIL — clicking rows does not add `pair-selected`, and hash navigation does not select.
+
+- [ ] **Step 3: Add selection state**
+
+In `WorkflowDetail`, next to the other `useState` calls (after line 284, `const [hoveredPair, ...]`), add:
+
+```tsx
+  const [selection, setSelection] = useState<{ pairId: number; index: number } | null>(null)
+```
+
+- [ ] **Step 4: Move the `jumpToHash` effect below the memo and make it set selection**
+
+The `jumpToHash` effect currently sits at lines 292-309, BEFORE the `const { canonicalIndex, pairIndex } = useMemo(...)` block (lines 322-328). It must reference `pairIndex`, and adding `pairIndex` to its dependency array would read it before declaration (temporal dead zone). So MOVE the effect to immediately AFTER the memo block, and extend it:
+
+First, delete the existing effect at lines 292-309.
+
+Then, immediately after the `useMemo` block (after line 328), insert:
+
+```tsx
+  // Scroll to and pulse the row referenced by the URL hash (e.g. #event-2), both
+  // on mount and on in-page anchor clicks. If the target is part of a pair, also
+  // select it (highlight both rows) and mark it active so its body expands.
+  useEffect(() => {
+    function jumpToHash() {
+      const id = window.location.hash.slice(1)
+      if (!id) return
+      const el = document.getElementById(id)
+      if (!el) return
+      try {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      } catch {
+        // jsdom / unsupported environments: scrolling is non-essential
+      }
+      el.classList.add('target-pulse')
+      window.setTimeout(() => el.classList.remove('target-pulse'), 1500)
+      const m = id.match(/^event-(\d+)$/)
+      if (m) {
+        const idx = Number(m[1])
+        const p = pairIndex.get(idx)
+        if (p) setSelection({ pairId: p.pairId, index: idx })
+      }
+    }
+    jumpToHash()
+    window.addEventListener('hashchange', jumpToHash)
+    return () => window.removeEventListener('hashchange', jumpToHash)
+  }, [execution, pairIndex])
+```
+
+- [ ] **Step 5: Add the toggle handler**
+
+After the `copyWorkflowLink` definition (around line 335), add:
+
+```tsx
+  const togglePairSelection = (pairId: number, index: number) =>
+    setSelection((cur) => (cur && cur.pairId === pairId && cur.index === index ? null : { pairId, index }))
+```
+
+- [ ] **Step 6: Wire selection into the render loop and use stable keys**
+
+Replace the render loop (lines 668-686) so each row receives its selection props, and change the React `key` from the display index to the canonical index (stable per event, so paired rows stay consistently controlled across the asc/desc flip):
+
+```tsx
+          {displayHistory.map((event, idx) => {
+            const ci = canonicalIndex.get(event) ?? idx
+            const pair = pairIndex.get(ci) ?? null
+            return (
+              <EventRow
+                key={ci}
+                event={event}
+                createdAt={execution.createdAt}
+                isNewest={event === newestEvent}
+                toast={toast}
+                anchorId={eventAnchorId(ci)}
+                appId={appId ?? ''}
+                store={store}
+                pair={pair}
+                pairHovered={pair !== null && pair.pairId === hoveredPair}
+                onPairHover={setHoveredPair}
+                pairSelected={pair !== null && selection !== null && pair.pairId === selection.pairId}
+                isActive={selection !== null && selection.index === ci}
+                onToggleSelect={pair !== null ? () => togglePairSelection(pair.pairId, ci) : undefined}
+              />
+            )
+          })}
+```
+
+- [ ] **Step 7: Run the integration tests to verify they pass**
+
+Run: `cd /Users/marcduiker/dev/diagrid/dev-dashboard/.claude/worktrees/spec+workflow-event-pairing-links/web && npx vitest run src/pages/WorkflowDetail.test.tsx`
+Expected: PASS (new pair-selection block + all existing WorkflowDetail tests).
+
+- [ ] **Step 8: Run the full suite + typecheck**
+
+Run: `cd /Users/marcduiker/dev/diagrid/dev-dashboard/.claude/worktrees/spec+workflow-event-pairing-links/web && npx vitest run && npx tsc --noEmit`
+Expected: all tests PASS, no type errors. (If the repo has a build script, also run `npm run build` to confirm the bundle compiles.)
+
+- [ ] **Step 9: Manual verification (written checklist in report; do not launch the app)**
+
+Confirm the intended behavior for the report:
+- Clicking a paired row header highlights both rows (border) and expands the clicked one; the partner is highlighted but collapsed.
+- Clicking the same row again clears the highlight and collapses.
+- Clicking a different pair moves the highlight.
+- Clicking a pair chip jumps to, highlights, and expands the target.
+- Clicking the child-instance link, the `#` button, or a chip does not toggle selection.
+- Unpaired rows still expand/collapse natively and never highlight.
+- Selection persists across the Oldest/Newest-first toggle.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add web/src/pages/WorkflowDetail.tsx web/src/pages/WorkflowDetail.test.tsx
+git commit -m "feat(web): select and auto-expand event pairs in the workflow timeline
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Navigate → target expands + both highlighted → Task 2 Step 4 (`jumpToHash` sets selection) + Task 1 controlled `open`. ✓
+- Persistent highlighted border on the selected event regardless of where the header is clicked → Task 1 `pair-selected` class + `::after` border; header-level click handler. ✓
+- Corresponding event same highlight → `pairSelected` computed from shared `pairId` (Task 2 Step 6). ✓
+- Click selected event again → highlight disappears → `togglePairSelection` toggle (Task 2 Step 5); deselect only on active row is inherent (toggles on matching `{pairId, index}`). ✓
+- Selection drives expansion; unpaired rows unchanged; inner controls don't toggle; single selection; order-flip safe → Global Constraints, Task 1 Steps 4/6, Task 2 Step 6 (stable key). ✓
+- Testing (EventRow-level + WorkflowDetail integration) → Tasks 1 & 2. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step is complete.
+
+**Type consistency:** `selection: { pairId: number; index: number } | null` is used identically in state, `togglePairSelection`, `jumpToHash`, and the render loop. `pairSelected`/`isActive`/`onToggleSelect` prop names/types match between Task 1's `EventRow` signature and Task 2's call site. `EventRow`'s new props are all optional (existing tests unaffected).
+
+**Ambiguity check:** Deselect applies only to the active row (toggle keyed on `{pairId, index}`); clicking the inactive partner sets a new `{pairId, index}` (moves active) rather than clearing — matches the spec's edge case.

--- a/docs/superpowers/specs/2026-07-01-event-pair-selection-design.md
+++ b/docs/superpowers/specs/2026-07-01-event-pair-selection-design.md
@@ -1,0 +1,152 @@
+# Event Pair Selection & Auto-Expand — Design
+
+**Date:** 2026-07-01
+**Status:** Approved (pending spec review)
+**Builds on:** the workflow event pairing links feature (shared pair-ID chips + hover cross-highlight).
+
+## Problem
+
+The timeline already lets a user hover a pair-ID chip to transiently highlight a
+scheduled/completion pair and click the chip to jump between the two rows. But
+after jumping, the user has to manually expand the target row to see its body,
+the highlight is only transient (gone as soon as the pointer leaves), and there
+is no persistent indication of *which* two rows form the pair they're looking
+at. This makes it hard to keep a related pair in view while reading their
+input/output.
+
+## Goal
+
+Introduce a persistent, toggleable **selected pair** state:
+
+1. Navigating to a paired event (via its pair-ID chip) auto-expands the target
+   row's body so the user immediately sees where they landed.
+2. The selected event shows a persistent highlighted **border** regardless of
+   where in its header the user clicked.
+3. The corresponding paired event (its scheduled/completion counterpart) shows
+   the same highlight, so the relationship is obvious.
+4. Clicking the selected event again clears the highlight (toggle off).
+
+## Interaction model
+
+**Selection drives expansion** for paired rows. At most one pair is selected at
+a time.
+
+- **Click a paired row header** (the always-visible summary/head, anywhere on
+  it): if that row is already the active row of the currently selected pair,
+  toggle *off* — clear the selection and collapse it. Otherwise select this
+  pair (highlight both its rows) and expand this row.
+- **Chip navigation** (clicking a pair-ID chip performs the existing hash jump):
+  in addition to the existing scroll + pulse, the target event becomes selected
+  (both rows highlighted) and its row expands.
+- **Only the acted-on row expands.** Its partner is highlighted but stays
+  collapsed until the user navigates to (or clicks) it.
+- **Unpaired rows are unchanged** — native `<details>` expand/collapse, and they
+  never participate in selection.
+- **Inner controls do not toggle selection.** Clicks on the pair chip, the `#`
+  copy-link button, and a child-instance link perform their own action and stop
+  propagation so they never trigger the row-level selection toggle.
+
+### Clickable toggle region
+
+The toggle target is the row's always-visible header (`<summary>` for rows with
+a body, the static head for rows without one) — not the expanded body content,
+so selecting JSON text inside an open row never collapses it.
+
+## Components & state
+
+### `WorkflowDetail`
+Owns two new state values:
+- `selectedPairId: number | null` — the pair whose two rows carry the persistent
+  highlight border. `null` when nothing is selected.
+- `activeIndex: number | null` — the single canonical index that is
+  force-expanded because it is the acted-on / navigated-to row.
+
+Derived per row (using the existing `pairIndex` / `canonicalIndex` maps):
+- `isSelected = pair != null && pair.pairId === selectedPairId` (true for BOTH
+  rows of the selected pair).
+- `isActive = canonicalIndex === activeIndex` (the one expanded row).
+
+Handlers:
+- `togglePairSelection(pairId, index)`: if `selectedPairId === pairId &&
+  activeIndex === index` → set both to `null`; else → `selectedPairId = pairId`,
+  `activeIndex = index`.
+- The existing `jumpToHash` effect additionally resolves the target event's
+  canonical index; if that event is part of a pair, it sets `selectedPairId` to
+  the pair and `activeIndex` to that index. (Scroll + `target-pulse` behavior is
+  retained unchanged.)
+
+### `EventRow`
+New props: `pairSelected: boolean` (draws the border), `isActive: boolean`
+(controls expansion), and `onToggleSelect: () => void`.
+
+- **Paired rows** render a *controlled* `<details open={isActive}>`. The summary's
+  `onClick` calls `e.preventDefault()` (suppressing native toggle) and invokes
+  `onToggleSelect()`. The static (body-less) paired row variant gets an
+  equivalent header `onClick`.
+- **Unpaired rows** keep the current uncontrolled `<details>` / static markup
+  untouched.
+- The pair chip, the `#` copy-link button, and the child-instance link each call
+  `e.stopPropagation()` in their handlers so a click on them does not bubble to
+  the header's selection toggle. (The `#` button already calls
+  `preventDefault`; add `stopPropagation`.)
+- A `pair-selected` class is applied to the row container when `pairSelected`.
+
+## Styling (`theme.css`)
+
+Reuse the single `::after` overlay introduced for hover (a positioned inset
+overlay on `.ev`). Add a selected variant:
+
+- `.ev.pair-selected::after` — a solid accent **border**
+  (`border: 1.5px solid var(--accent2)`) plus a slightly stronger tint than
+  hover, using the same inset geometry (`left/right: -8px; top: 4px;
+  bottom: -6px; border-radius: 10px`).
+- Precedence: when a row is both hovered and selected, the selected style wins
+  (place `.ev.pair-selected::after` after `.ev.pair-hover::after` in the
+  stylesheet, or scope so selected overrides). The hover tint remains for
+  non-selected pairs.
+
+No new elements or libraries; the border is drawn by the existing overlay
+pseudo-element with different properties.
+
+## Edge cases
+
+- **Deselect on re-click** applies only to the active row of the selected pair.
+  Clicking the *partner* (highlighted but not active) selects/expands the partner
+  (moving `activeIndex`), rather than toggling off — the partner was never the
+  active row.
+- **Selecting a different pair** replaces the current selection (single-selection
+  invariant) — no explicit clear needed.
+- **Order-flip toggle (asc/desc)** does not change canonical indices, so
+  `selectedPairId`/`activeIndex` remain valid and the highlight/expansion persist
+  across a flip.
+- **Data refetch** (react-query poll) re-renders with the same canonical indices
+  for existing events; selection persists. If the selected events somehow leave
+  the history, the derived `isSelected`/`isActive` simply match nothing (no
+  crash); no explicit reset required.
+- **Running / orphan chips** (a start with no completion yet) are still clickable
+  to select+expand the single row; there is no partner to co-highlight.
+
+## Testing
+
+Extend `web/src/pages/WorkflowDetail.pairing.test.tsx` (Vitest +
+`@testing-library/react`) at the `WorkflowDetail` level so real click/selection
+wiring is exercised:
+
+1. Clicking a paired row header selects the pair — both rows get
+   `pair-selected`, and the clicked row's body is expanded (`<details open>`).
+2. Clicking the same row again clears selection and collapses it.
+3. Clicking a row of a *different* pair moves the selection (previous pair no
+   longer `pair-selected`).
+4. Navigating via a pair chip (hash change to the partner's anchor) selects the
+   partner's pair and expands the partner row.
+5. Clicking an unpaired row does not apply `pair-selected` and does not affect an
+   existing selection.
+6. Clicking an inner control (the `#` copy-link button) does not toggle
+   selection.
+
+## Out of scope
+
+- Expanding both rows of a pair simultaneously (only the acted-on row expands).
+- Multi-pair selection.
+- Persisting selection across full page reloads or in the URL.
+- Any change to unpaired-row behavior or to the pairing/decode logic.

--- a/web/src/pages/WorkflowDetail.pairing.test.tsx
+++ b/web/src/pages/WorkflowDetail.pairing.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { EventRow } from './WorkflowDetail'
@@ -48,6 +48,14 @@ function renderRowEx(
 }
 
 describe('EventRow selection', () => {
+  beforeEach(() => {
+    Object.defineProperty(document, 'execCommand', {
+      value: vi.fn().mockReturnValue(true),
+      writable: true,
+      configurable: true,
+    })
+  })
+
   const scheduled: WorkflowHistoryEvent = {
     type: 'TaskScheduled', sequenceId: 1, timestamp: '2026-06-28T10:00:00.100Z', name: 'Charge', input: '{"x":1}',
   }

--- a/web/src/pages/WorkflowDetail.pairing.test.tsx
+++ b/web/src/pages/WorkflowDetail.pairing.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { EventRow } from './WorkflowDetail'
 import type { WorkflowHistoryEvent } from '../types/workflow'
@@ -22,6 +22,77 @@ function renderRow(event: WorkflowHistoryEvent, pair: Parameters<typeof EventRow
     </MemoryRouter>,
   )
 }
+
+function renderRowEx(
+  event: WorkflowHistoryEvent,
+  pair: Parameters<typeof EventRow>[0]['pair'],
+  extra?: Partial<Parameters<typeof EventRow>[0]>,
+) {
+  const noop = () => {}
+  return render(
+    <MemoryRouter>
+      <EventRow
+        event={event}
+        createdAt={'2026-06-28T10:00:00.000Z'}
+        isNewest={false}
+        toast={{ show: noop } as never}
+        anchorId="event-1"
+        appId="app"
+        pair={pair}
+        pairHovered={false}
+        onPairHover={noop}
+        {...extra}
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe('EventRow selection', () => {
+  const scheduled: WorkflowHistoryEvent = {
+    type: 'TaskScheduled', sequenceId: 1, timestamp: '2026-06-28T10:00:00.100Z', name: 'Charge', input: '{"x":1}',
+  }
+  const startPair = { pairId: 1, role: 'start' as const, partnerIndex: 4, durationMs: null }
+
+  it('renders the details open when isActive', () => {
+    const { container } = renderRowEx(scheduled, startPair, { isActive: true })
+    expect((container.querySelector('details.evd') as HTMLDetailsElement).open).toBe(true)
+  })
+
+  it('renders the details closed when not active', () => {
+    const { container } = renderRowEx(scheduled, startPair, { isActive: false })
+    expect((container.querySelector('details.evd') as HTMLDetailsElement).open).toBe(false)
+  })
+
+  it('adds the pair-selected class to the row when pairSelected', () => {
+    const { container } = renderRowEx(scheduled, startPair, { pairSelected: true })
+    expect(container.querySelector('.ev')!.className).toContain('pair-selected')
+  })
+
+  it('calls onToggleSelect and suppresses native toggle when the summary is clicked', () => {
+    let calls = 0
+    const { container } = renderRowEx(scheduled, startPair, { isActive: false, onToggleSelect: () => { calls++ } })
+    const summary = container.querySelector('details.evd > summary')!
+    fireEvent.click(summary)
+    expect(calls).toBe(1)
+    // Controlled: still closed because state (isActive) did not change in this shallow render.
+    expect((container.querySelector('details.evd') as HTMLDetailsElement).open).toBe(false)
+  })
+
+  it('does NOT call onToggleSelect when the pair chip is clicked (stopPropagation)', () => {
+    let calls = 0
+    const { container } = renderRowEx(scheduled, startPair, { onToggleSelect: () => { calls++ } })
+    const chip = container.querySelector('a.pairchip') as HTMLAnchorElement
+    fireEvent.click(chip)
+    expect(calls).toBe(0)
+  })
+
+  it('does NOT call onToggleSelect when the copy-link (#) button is clicked (stopPropagation)', () => {
+    let calls = 0
+    const { container } = renderRowEx(scheduled, startPair, { onToggleSelect: () => { calls++ } })
+    fireEvent.click(container.querySelector('.evanchor') as HTMLElement)
+    expect(calls).toBe(0)
+  })
+})
 
 describe('EventRow pair chip', () => {
   it('renders a start chip linking to the completion row', () => {

--- a/web/src/pages/WorkflowDetail.test.tsx
+++ b/web/src/pages/WorkflowDetail.test.tsx
@@ -926,3 +926,91 @@ describe('EventRow', () => {
     )
   })
 })
+
+describe('WorkflowDetail — pair selection', () => {
+  beforeEach(() => {
+    server.use(http.get('/api/apps', () => HttpResponse.json([{ appId: 'order', health: 'healthy' }])))
+  })
+
+  function seedPair() {
+    server.use(
+      http.get('/api/workflows/order/abc', () =>
+        HttpResponse.json({
+          appId: 'order', instanceId: 'abc', name: 'OrderWorkflow', status: 'Completed',
+          createdAt: '2026-06-28T10:00:00.000Z', lastUpdatedAt: '2026-06-28T10:00:01.000Z',
+          replayCount: 0, output: '"ok"',
+          history: [
+            { sequenceId: 0, type: 'ExecutionStarted', name: 'OrderWorkflow', input: '{}', timestamp: '2026-06-28T10:00:00.000Z' },
+            { sequenceId: 1, type: 'TaskScheduled', name: 'Charge', input: '{"amt":5}', timestamp: '2026-06-28T10:00:00.100Z' },
+            { sequenceId: 2, type: 'TaskCompleted', scheduledId: 1, output: '"charged"', timestamp: '2026-06-28T10:00:00.440Z' },
+            { sequenceId: 3, type: 'ExecutionCompleted', output: '"ok"', timestamp: '2026-06-28T10:00:01.000Z' },
+          ],
+        }),
+      ),
+    )
+  }
+
+  function rowByType(container: HTMLElement, type: string): HTMLElement {
+    const row = Array.from(container.querySelectorAll('.timeline .ev')).find(
+      (el) => el.querySelector('.evtype')?.textContent === type,
+    )
+    if (!row) throw new Error(`row ${type} not found`)
+    return row as HTMLElement
+  }
+
+  it('clicking a paired row selects the pair (both highlighted) and expands the clicked row', async () => {
+    seedPair()
+    const { container } = renderDetail()
+    await screen.findByRole('heading', { name: 'OrderWorkflow' })
+
+    const scheduled = rowByType(container, 'TaskScheduled')
+    await userEvent.click(scheduled.querySelector('summary') as HTMLElement)
+
+    expect(rowByType(container, 'TaskScheduled').className).toContain('pair-selected')
+    expect(rowByType(container, 'TaskCompleted').className).toContain('pair-selected')
+    expect((rowByType(container, 'TaskScheduled').querySelector('details') as HTMLDetailsElement).open).toBe(true)
+    // partner highlighted but not expanded
+    expect((rowByType(container, 'TaskCompleted').querySelector('details') as HTMLDetailsElement).open).toBe(false)
+  })
+
+  it('clicking the selected row again clears the selection and collapses it', async () => {
+    seedPair()
+    const { container } = renderDetail()
+    await screen.findByRole('heading', { name: 'OrderWorkflow' })
+    const summary = () => rowByType(container, 'TaskScheduled').querySelector('summary') as HTMLElement
+
+    await userEvent.click(summary())
+    expect(rowByType(container, 'TaskScheduled').className).toContain('pair-selected')
+    await userEvent.click(summary())
+    expect(rowByType(container, 'TaskScheduled').className).not.toContain('pair-selected')
+    expect(rowByType(container, 'TaskCompleted').className).not.toContain('pair-selected')
+    expect((rowByType(container, 'TaskScheduled').querySelector('details') as HTMLDetailsElement).open).toBe(false)
+  })
+
+  it('clicking an unpaired row does not select anything', async () => {
+    seedPair()
+    const { container } = renderDetail()
+    await screen.findByRole('heading', { name: 'OrderWorkflow' })
+    await userEvent.click(rowByType(container, 'ExecutionStarted').querySelector('summary') as HTMLElement)
+    expect(container.querySelector('.ev.pair-selected')).toBeNull()
+  })
+
+  it('navigating via hash to a paired event selects the pair and expands the target', async () => {
+    seedPair()
+    const { container } = renderDetail()
+    await screen.findByRole('heading', { name: 'OrderWorkflow' })
+
+    // TaskCompleted is canonical index 2 -> anchor event-2.
+    await act(async () => {
+      window.location.hash = '#event-2'
+      window.dispatchEvent(new HashChangeEvent('hashchange'))
+    })
+
+    expect(rowByType(container, 'TaskCompleted').className).toContain('pair-selected')
+    expect(rowByType(container, 'TaskScheduled').className).toContain('pair-selected')
+    expect((rowByType(container, 'TaskCompleted').querySelector('details') as HTMLDetailsElement).open).toBe(true)
+
+    // reset hash so it doesn't leak into other tests
+    await act(async () => { window.location.hash = '' })
+  })
+})

--- a/web/src/pages/WorkflowDetail.test.tsx
+++ b/web/src/pages/WorkflowDetail.test.tsx
@@ -1031,4 +1031,62 @@ describe('WorkflowDetail — pair selection', () => {
     // reset hash so it doesn't leak into other tests
     await act(async () => { window.location.hash = '' })
   })
+
+  it('does not re-select on refetch after a manual deselect (running workflow)', async () => {
+    server.use(
+      http.get('/api/workflows/order/abc', () =>
+        HttpResponse.json({
+          appId: 'order', instanceId: 'abc', name: 'OrderWorkflow', status: 'Running',
+          createdAt: '2026-06-28T10:00:00.000Z', replayCount: 0,
+          history: [
+            { sequenceId: 0, type: 'ExecutionStarted', name: 'OrderWorkflow', input: '{}', timestamp: '2026-06-28T10:00:00.000Z' },
+            { sequenceId: 1, type: 'TaskScheduled', name: 'Charge', input: '{"amt":5}', timestamp: '2026-06-28T10:00:00.100Z' },
+            { sequenceId: 2, type: 'TaskCompleted', scheduledId: 1, output: '"charged"', timestamp: '2026-06-28T10:00:00.440Z' },
+          ],
+        }),
+      ),
+    )
+    const client = makeQueryClient()
+    const { container } = renderDetail(client)
+    await screen.findByRole('heading', { name: 'OrderWorkflow' })
+
+    // Navigate via hash to TaskCompleted (canonical index 2) -> selects the pair.
+    await act(async () => {
+      window.location.hash = '#event-2'
+      window.dispatchEvent(new HashChangeEvent('hashchange'))
+    })
+    expect(rowByType(container, 'TaskCompleted').className).toContain('pair-selected')
+
+    // Manually deselect by clicking the active row.
+    await userEvent.click(rowByType(container, 'TaskCompleted').querySelector('summary') as HTMLElement)
+    expect(container.querySelector('.ev.pair-selected')).toBeNull()
+
+    // A poll arrives with grown history; the hash still points at #event-2.
+    server.use(
+      http.get('/api/workflows/order/abc', () =>
+        HttpResponse.json({
+          appId: 'order', instanceId: 'abc', name: 'OrderWorkflow', status: 'Running',
+          createdAt: '2026-06-28T10:00:00.000Z', replayCount: 0,
+          history: [
+            { sequenceId: 0, type: 'ExecutionStarted', name: 'OrderWorkflow', input: '{}', timestamp: '2026-06-28T10:00:00.000Z' },
+            { sequenceId: 1, type: 'TaskScheduled', name: 'Charge', input: '{"amt":5}', timestamp: '2026-06-28T10:00:00.100Z' },
+            { sequenceId: 2, type: 'TaskCompleted', scheduledId: 1, output: '"charged"', timestamp: '2026-06-28T10:00:00.440Z' },
+            { sequenceId: 3, type: 'TimerCreated', timestamp: '2026-06-28T10:00:00.900Z' },
+          ],
+        }),
+      ),
+    )
+    await act(async () => { await client.invalidateQueries({ queryKey: ['workflow', 'order', 'abc'] }) })
+    // Wait for the refetch to complete and the new event to appear in the DOM.
+    await waitFor(() => {
+      const rows = Array.from(container.querySelectorAll('.timeline .ev'))
+      const timerRow = rows.find(el => el.querySelector('.evtype')?.textContent === 'TimerCreated')
+      expect(timerRow).toBeTruthy()
+    })
+
+    // Selection must remain cleared — the poll must not re-assert the dismissed selection.
+    expect(container.querySelector('.ev.pair-selected')).toBeNull()
+
+    await act(async () => { window.location.hash = '' })
+  })
 })

--- a/web/src/pages/WorkflowDetail.test.tsx
+++ b/web/src/pages/WorkflowDetail.test.tsx
@@ -995,6 +995,24 @@ describe('WorkflowDetail — pair selection', () => {
     expect(container.querySelector('.ev.pair-selected')).toBeNull()
   })
 
+  it('clicking the inactive partner moves selection to it (does not clear)', async () => {
+    seedPair()
+    const { container } = renderDetail()
+    await screen.findByRole('heading', { name: 'OrderWorkflow' })
+
+    // Select TaskScheduled (canonical index 1)
+    await userEvent.click(rowByType(container, 'TaskScheduled').querySelector('summary') as HTMLElement)
+    expect(rowByType(container, 'TaskScheduled').className).toContain('pair-selected')
+
+    // Click TaskCompleted (same pair, different index) — should MOVE selection, not clear
+    await userEvent.click(rowByType(container, 'TaskCompleted').querySelector('summary') as HTMLElement)
+    expect(rowByType(container, 'TaskCompleted').className).toContain('pair-selected')
+    expect(rowByType(container, 'TaskScheduled').className).toContain('pair-selected')
+    // Active row moved: TaskCompleted now open, TaskScheduled collapsed
+    expect((rowByType(container, 'TaskCompleted').querySelector('details') as HTMLDetailsElement).open).toBe(true)
+    expect((rowByType(container, 'TaskScheduled').querySelector('details') as HTMLDetailsElement).open).toBe(false)
+  })
+
   it('navigating via hash to a paired event selects the pair and expands the target', async () => {
     seedPair()
     const { container } = renderDetail()

--- a/web/src/pages/WorkflowDetail.tsx
+++ b/web/src/pages/WorkflowDetail.tsx
@@ -350,7 +350,7 @@ export function WorkflowDetail() {
     jumpToHash()
     window.addEventListener('hashchange', jumpToHash)
     return () => window.removeEventListener('hashchange', jumpToHash)
-  }, [execution, pairIndex])
+  }, [pairIndex])
 
   const copyWorkflowLink = () => {
     const { origin, pathname } = window.location

--- a/web/src/pages/WorkflowDetail.tsx
+++ b/web/src/pages/WorkflowDetail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, type MouseEvent as ReactMouseEvent } from 'react'
 import { useParams, Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useWorkflow } from '../hooks/useWorkflows'
 import { useApps } from '../hooks/useApps'
@@ -84,6 +84,9 @@ export function EventRow({
   pair,
   pairHovered,
   onPairHover,
+  pairSelected,
+  isActive,
+  onToggleSelect,
 }: {
   event: WorkflowHistoryEvent
   createdAt: string | undefined
@@ -95,6 +98,9 @@ export function EventRow({
   pair?: PairInfo | null
   pairHovered?: boolean
   onPairHover?: (pairId: number | null) => void
+  pairSelected?: boolean
+  isActive?: boolean
+  onToggleSelect?: () => void
 }) {
   const offset = formatOffset(createdAt, event.timestamp)
   const dateTime = formatDateTime(event.timestamp) ?? ''
@@ -125,14 +131,14 @@ export function EventRow({
     const href = `#${eventAnchorId(pair.partnerIndex)}`
     if (pair.role === 'start') {
       return (
-        <a className="pairchip" href={href} aria-label="Jump to result" title="Jump to result" onMouseEnter={enter} onMouseLeave={leave}>
+        <a className="pairchip" href={href} aria-label="Jump to result" title="Jump to result" onClick={(e) => e.stopPropagation()} onMouseEnter={enter} onMouseLeave={leave}>
           #{pair.pairId} ↓
         </a>
       )
     }
     const dur = pair.durationMs !== null ? formatDuration(pair.durationMs) : ''
     return (
-      <a className="pairchip" href={href} aria-label="Jump to scheduled" title="Jump to scheduled" onMouseEnter={enter} onMouseLeave={leave}>
+      <a className="pairchip" href={href} aria-label="Jump to scheduled" title="Jump to scheduled" onClick={(e) => e.stopPropagation()} onMouseEnter={enter} onMouseLeave={leave}>
         #{pair.pairId} ↑{dur ? ` ${dur}` : ''}
       </a>
     )
@@ -148,6 +154,12 @@ export function EventRow({
 
   const hasDetails = !!(event.input || event.output)
 
+  const selectable = !!pair
+  const onHeaderClick = (e: ReactMouseEvent) => {
+    e.preventDefault() // suppress native <details> toggle; selection drives expansion
+    onToggleSelect?.()
+  }
+
   const copyAnchorLink = () => {
     const { origin, pathname } = window.location
     copyText(`${origin}${pathname}#${anchorId}`)
@@ -155,7 +167,7 @@ export function EventRow({
   }
 
   return (
-    <div id={anchorId} className={`ev${isNewest ? ' reveal' : ''}${pairHovered ? ' pair-hover' : ''}`}>
+    <div id={anchorId} className={`ev${isNewest ? ' reveal' : ''}${pairHovered ? ' pair-hover' : ''}${pairSelected ? ' pair-selected' : ''}`}>
       <div className="t">
         <span className="off">{offset}</span>
         <span className="dt">{dateTime}</span>
@@ -165,8 +177,8 @@ export function EventRow({
       </div>
       <div className="c">
         {hasDetails ? (
-          <details className="evd">
-            <summary>
+          <details className="evd" {...(selectable ? { open: !!isActive } : {})}>
+            <summary onClick={selectable ? onHeaderClick : undefined}>
               <span className="caret">▸</span>
               <span className="evtype">{event.type}</span>
               {event.name && <span className="evname">{event.name}</span>}
@@ -177,6 +189,7 @@ export function EventRow({
                 title="Copy link to this event"
                 onClick={(e) => {
                   e.preventDefault() // don't toggle the <details>
+                  e.stopPropagation() // don't trigger row selection
                   copyAnchorLink()
                 }}
               >
@@ -221,8 +234,8 @@ export function EventRow({
             </div>
           </details>
         ) : (
-          <div className="evd evstatic">
-            <div className="evstatic-head">
+          <div className={`evd evstatic${selectable ? ' selectable' : ''}`}>
+            <div className="evstatic-head" onClick={selectable ? () => onToggleSelect?.() : undefined}>
               <span className="caretspace" aria-hidden="true">▸</span>
               <span className="evtype">{event.type}</span>
               <div className="evnamecell">
@@ -233,6 +246,7 @@ export function EventRow({
                   <Link
                     className="evchildlink"
                     to={`/workflows/${appId}/${event.instanceId}${store ? `?store=${encodeURIComponent(store)}` : ''}`}
+                    onClick={(e) => e.stopPropagation()}
                   >
                     {event.instanceId}
                   </Link>
@@ -243,7 +257,10 @@ export function EventRow({
                 className="evanchor"
                 aria-label="Copy link to this event"
                 title="Copy link to this event"
-                onClick={copyAnchorLink}
+                onClick={(e) => {
+                  e.stopPropagation() // don't trigger row selection
+                  copyAnchorLink()
+                }}
               >
                 #
               </button>

--- a/web/src/pages/WorkflowDetail.tsx
+++ b/web/src/pages/WorkflowDetail.tsx
@@ -299,31 +299,11 @@ export function WorkflowDetail() {
 
   const [order, setOrder] = useState<HistoryOrder>(() => getHistoryOrder())
   const [hoveredPair, setHoveredPair] = useState<number | null>(null)
+  const [selection, setSelection] = useState<{ pairId: number; index: number } | null>(null)
 
   useEffect(() => {
     setHistoryOrder(order)
   }, [order])
-
-  // Scroll to and pulse the row referenced by the URL hash (e.g. #event-2),
-  // both on mount and whenever the hash changes via an in-page anchor click.
-  useEffect(() => {
-    function jumpToHash() {
-      const id = window.location.hash.slice(1)
-      if (!id) return
-      const el = document.getElementById(id)
-      if (!el) return
-      try {
-        el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-      } catch {
-        // jsdom / unsupported environments: scrolling is non-essential
-      }
-      el.classList.add('target-pulse')
-      window.setTimeout(() => el.classList.remove('target-pulse'), 1500)
-    }
-    jumpToHash()
-    window.addEventListener('hashchange', jumpToHash)
-    return () => window.removeEventListener('hashchange', jumpToHash)
-  }, [execution])
 
   const { toast, toastNode } = useToast()
 
@@ -344,12 +324,43 @@ export function WorkflowDetail() {
     return { canonicalIndex: ci, pairIndex: buildPairIndex(ascending) }
   }, [_history])
 
+  // Scroll to and pulse the row referenced by the URL hash (e.g. #event-2), both
+  // on mount and on in-page anchor clicks. If the target is part of a pair, also
+  // select it (highlight both rows) and mark it active so its body expands.
+  useEffect(() => {
+    function jumpToHash() {
+      const id = window.location.hash.slice(1)
+      if (!id) return
+      const el = document.getElementById(id)
+      if (!el) return
+      try {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      } catch {
+        // jsdom / unsupported environments: scrolling is non-essential
+      }
+      el.classList.add('target-pulse')
+      window.setTimeout(() => el.classList.remove('target-pulse'), 1500)
+      const m = id.match(/^event-(\d+)$/)
+      if (m) {
+        const idx = Number(m[1])
+        const p = pairIndex.get(idx)
+        if (p) setSelection({ pairId: p.pairId, index: idx })
+      }
+    }
+    jumpToHash()
+    window.addEventListener('hashchange', jumpToHash)
+    return () => window.removeEventListener('hashchange', jumpToHash)
+  }, [execution, pairIndex])
+
   const copyWorkflowLink = () => {
     const { origin, pathname } = window.location
     const qs = store ? `?store=${encodeURIComponent(store)}` : ''
     copyText(`${origin}${pathname}${qs}`)
     toast.show('Link copied')
   }
+
+  const togglePairSelection = (pairId: number, index: number) =>
+    setSelection((cur) => (cur && cur.pairId === pairId && cur.index === index ? null : { pairId, index }))
 
   if (isLoading) {
     return (
@@ -687,7 +698,7 @@ export function WorkflowDetail() {
             const pair = pairIndex.get(ci) ?? null
             return (
               <EventRow
-                key={idx}
+                key={ci}
                 event={event}
                 createdAt={execution.createdAt}
                 isNewest={event === newestEvent}
@@ -698,6 +709,9 @@ export function WorkflowDetail() {
                 pair={pair}
                 pairHovered={pair !== null && pair.pairId === hoveredPair}
                 onPairHover={setHoveredPair}
+                pairSelected={pair !== null && selection !== null && pair.pairId === selection.pairId}
+                isActive={selection !== null && selection.index === ci}
+                onToggleSelect={pair !== null ? () => togglePairSelection(pair.pairId, ci) : undefined}
               />
             )
           })}

--- a/web/src/pages/WorkflowDetail.tsx
+++ b/web/src/pages/WorkflowDetail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, type MouseEvent as ReactMouseEvent } from 'react'
+import { useState, useEffect, useMemo, useRef, type MouseEvent as ReactMouseEvent } from 'react'
 import { useParams, Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useWorkflow } from '../hooks/useWorkflows'
 import { useApps } from '../hooks/useApps'
@@ -300,6 +300,7 @@ export function WorkflowDetail() {
   const [order, setOrder] = useState<HistoryOrder>(() => getHistoryOrder())
   const [hoveredPair, setHoveredPair] = useState<number | null>(null)
   const [selection, setSelection] = useState<{ pairId: number; index: number } | null>(null)
+  const lastAutoSelectedHash = useRef<string>('')
 
   useEffect(() => {
     setHistoryOrder(order)
@@ -340,11 +341,18 @@ export function WorkflowDetail() {
       }
       el.classList.add('target-pulse')
       window.setTimeout(() => el.classList.remove('target-pulse'), 1500)
-      const m = id.match(/^event-(\d+)$/)
-      if (m) {
-        const idx = Number(m[1])
-        const p = pairIndex.get(idx)
-        if (p) setSelection({ pairId: p.pairId, index: idx })
+      // Only auto-select on genuine navigation to a new hash — not on effect
+      // re-runs from polling (pairIndex changes as a running workflow's history
+      // grows), which would otherwise re-assert a selection the user dismissed.
+      // The anchor id encodes the canonical index, which is how pairIndex is keyed.
+      if (id !== lastAutoSelectedHash.current) {
+        lastAutoSelectedHash.current = id
+        const m = id.match(/^event-(\d+)$/)
+        if (m) {
+          const idx = Number(m[1])
+          const p = pairIndex.get(idx)
+          if (p) setSelection({ pairId: p.pairId, index: idx })
+        }
       }
     }
     jumpToHash()

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -409,6 +409,20 @@ span.pairchip.pending { border-style: dashed; color: var(--faint); cursor: defau
   z-index: -1;
   pointer-events: none;
 }
+.ev.pair-selected::after {
+  content: "";
+  position: absolute;
+  left: -8px;
+  right: -8px;
+  top: 4px;
+  bottom: -6px;
+  background: color-mix(in srgb, var(--accent2) 14%, transparent);
+  border: 1.5px solid var(--accent2);
+  border-radius: 10px;
+  z-index: -1;
+  pointer-events: none;
+}
+.evd.evstatic.selectable { cursor: pointer; }
 .evanchor { grid-column: 5; font-family: var(--mono); font-size: 12px; line-height: 1; color: var(--muted); background: transparent; border: 1px solid transparent; border-radius: 6px; padding: 2px 6px; cursor: pointer; opacity: 0; transition: opacity .12s ease, color .12s ease, border-color .12s ease; }
 .ev:hover .evanchor, .evanchor:focus-visible { opacity: 1; }
 .evanchor:hover { color: var(--text); border-color: var(--line); }


### PR DESCRIPTION
## Summary

Adds a persistent, toggleable **selected pair** state to the workflow event timeline, building on the pair-ID chips + hover highlight.

- Clicking a paired row header (or navigating to it via its pair-ID chip) highlights **both** rows of the pair with a border and expands the acted-on row's body.
- Clicking the active row again clears the selection (toggle off).
- One pair selected at a time; clicking a different pair moves the selection; clicking the highlighted-but-inactive partner moves the active row to it.
- Unpaired rows keep native expand/collapse and never participate in selection.

## Implementation

- **State:** a single `selection: { pairId, index } | null` in `WorkflowDetail`.
- **`EventRow`:** paired rows render a *controlled* `<details open={isActive}>`; the header click is intercepted (`preventDefault`) to drive selection instead of native toggle; inner controls (pair chip, `#` copy button, child link) `stopPropagation` so they don't toggle selection; a `pair-selected` class draws a border via the existing `::after` overlay.
- **Navigation:** the `jumpToHash` effect (moved below the `pairIndex` memo to satisfy the Rules of Hooks) selects + expands the hash target, guarded by a ref so a poll refetch on a running workflow never re-asserts a manually dismissed selection.
- Render `key` switched to the canonical index so paired rows stay consistently controlled across the asc/desc order flip.

## Testing
- `npx vitest run` → 346 passing (new EventRow-level selection tests + WorkflowDetail integration tests: select+expand, re-click clears, partner-move, hash-nav selects, unpaired no-op, and a running-workflow refetch regression test); `npx tsc --noEmit` clean.

## Docs
Design spec and implementation plan under `docs/superpowers/`.

## Known minor follow-up (non-blocking)
- Body-less selectable rows (e.g. an orphan `SubOrchestrationCreated`) are mouse-only to select — no keyboard `role`/`tabindex` (not a regression; body-ful rows use the natively-focusable `<summary>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)