### PR TITLE
feat(web): Component & Resiliency builders + resiliency enhancements

### DIFF
--- a/docs/superpowers/plans/2026-07-01-builders-01-foundation.md
+++ b/docs/superpowers/plans/2026-07-01-builders-01-foundation.md
@@ -1,0 +1,1114 @@
+# Builders — Plan 1: Shared Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the reusable, unit-tested foundation (YAML emitter, validators, download helper, data types, controlled form controls, and a presentational wizard shell) that the Component Builder (Plan 2) and Resiliency Builder (Plan 3) are built on.
+
+**Architecture:** Pure modules and presentational components on dev-dashboard's existing stack — vanilla CSS theme tokens, controlled components, TanStack Query. No routing/nav changes in this plan (those ship with each builder that needs them, in Plans 2–3, to avoid wiring routes to not-yet-existent builder pages). Logic is ported faithfully from cloudgrid but reimplemented without MUI/react-hook-form/Yup.
+
+**Tech Stack:** React 19, TypeScript, Vite, Vitest + Testing Library, `js-yaml` (new dependency).
+
+**Source spec:** `docs/superpowers/specs/2026-06-28-component-resiliency-builders-design.md`
+
+## Global Constraints
+
+- **Stack:** React 19 + TS + Vite; React Router v6; TanStack Query v5; controlled components. Vanilla CSS with semantic tokens in `web/src/styles/theme.css`. Light/dark via `data-theme`.
+- **No new UI/validation libraries:** NO MUI, react-hook-form, Yup, Ace, i18n, notistack.
+- **Exactly one new dependency approved:** `js-yaml` (emission only, `dump()`). Add `@types/js-yaml` as a dev dependency for types.
+- **Wizard buttons monochrome, NOT green:** never use the green brand `.btn.primary` (`background: var(--accent2)`) in wizard/builder UI. Do NOT change the global `.btn.primary` (used elsewhere). Primary action (Continue/Finish) = filled neutral `background: var(--text); color: var(--bg)`; secondary (Back/Cancel) = existing `.btn.ghost`. Copy/Download also neutral/ghost.
+- **Tests:** Vitest + Testing Library, colocated `*.test.ts(x)`. Run `npx tsc -b` before every commit (Vitest does not type-check).
+- **All `npm`/`npx` commands run from the `web/` subdirectory.**
+- **Reuse, don't rebuild:** `lib/api.ts` (`fetchJSON`/`apiUrl`), `lib/clipboard.ts` (`copyText`), `lib/toast.tsx` (`useToast`), `lib/yaml-highlight.tsx` (`highlightYaml`), `components/Modal.tsx`, `components/MetadataFieldInput.tsx`.
+
+---
+
+## File Structure
+
+- Create `web/src/lib/yaml-emit.ts` — `dumpYaml()` + `recursivelyRemoveEmptyValues()`.
+- Create `web/src/lib/validation.ts` — `validateGoDuration`, `validateResourceName`, `validateStatusCodes`, `requiredError`, `integerError`.
+- Create `web/src/lib/download.ts` — `downloadText(filename, text)`.
+- Create `web/src/types/component.ts` — `ComponentSpec`, `defaultComponentSpec()`.
+- Create `web/src/types/resiliency.ts` — `DaprResiliency` + policy/target types, `defaultResiliencyConfig()`.
+- Modify `web/src/types/metadata.ts` — add `AuthenticationProfile`, `authenticationProfiles?`, `isCert?`, `binding?`.
+- Create `web/src/components/form/Field.tsx`, `TextInput.tsx`, `NumberInput.tsx`, `SelectInput.tsx`, `Toggle.tsx`, `index.ts`.
+- Create `web/src/components/wizard/Stepper.tsx`, `StepNav.tsx`, `Wizard.tsx`, `index.ts`.
+- Modify `web/src/styles/theme.css` — append wizard-scoped styles incl. `.btn.mono` and `.wizard`/`.stepper` layout.
+
+Each task ends with a green focused test, a green `tsc -b`, and a commit.
+
+---
+
+## Task 1: YAML emitter + empty-value stripper
+
+**Files:**
+- Create: `web/src/lib/yaml-emit.ts`
+- Create: `web/src/lib/yaml-emit.test.ts`
+- Modify: `web/package.json` (add `js-yaml`, `@types/js-yaml`)
+
+**Interfaces:**
+- Produces: `dumpYaml(obj: unknown): string` and `recursivelyRemoveEmptyValues<T>(input: T): T`.
+
+- [ ] **Step 1: Install js-yaml**
+
+Run (from `web/`):
+```bash
+npm install js-yaml && npm install -D @types/js-yaml
+```
+Expected: `js-yaml` in dependencies, `@types/js-yaml` in devDependencies.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `web/src/lib/yaml-emit.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { dumpYaml, recursivelyRemoveEmptyValues } from './yaml-emit'
+
+describe('dumpYaml', () => {
+  it('serializes a plain object to YAML', () => {
+    expect(dumpYaml({ a: 1, b: 'x' })).toBe('a: 1\nb: x\n')
+  })
+})
+
+describe('recursivelyRemoveEmptyValues', () => {
+  it('removes null, undefined, empty string, whitespace string', () => {
+    expect(recursivelyRemoveEmptyValues({ a: null, b: undefined, c: '', d: '  ', e: 'keep' })).toEqual({ e: 'keep' })
+  })
+  it('preserves 0 and false', () => {
+    expect(recursivelyRemoveEmptyValues({ n: 0, b: false })).toEqual({ n: 0, b: false })
+  })
+  it('removes empty objects and empty arrays', () => {
+    expect(recursivelyRemoveEmptyValues({ o: {}, a: [], keep: { x: 1 } })).toEqual({ keep: { x: 1 } })
+  })
+  it('prunes branches that become empty after recursion', () => {
+    expect(recursivelyRemoveEmptyValues({ policies: { retries: { r1: { duration: '' } } } })).toEqual({})
+  })
+  it('keeps non-empty nested values and does not mutate the input', () => {
+    const input = { spec: { timeout: '30s', extra: '' } }
+    const out = recursivelyRemoveEmptyValues(input)
+    expect(out).toEqual({ spec: { timeout: '30s' } })
+    expect(input.spec.extra).toBe('') // original untouched
+  })
+})
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npm test -- yaml-emit`
+Expected: FAIL — cannot resolve `./yaml-emit`.
+
+- [ ] **Step 4: Implement**
+
+Create `web/src/lib/yaml-emit.ts`:
+```ts
+import { dump } from 'js-yaml'
+
+/** Serialize an object to YAML using js-yaml defaults (matches cloudgrid: no options). */
+export function dumpYaml(obj: unknown): string {
+  return dump(obj)
+}
+
+// lodash-isEmpty equivalent for the only cases used here: plain objects and arrays.
+function isEmptyContainer(v: unknown): boolean {
+  if (Array.isArray(v)) return v.length === 0
+  if (v && typeof v === 'object') return Object.keys(v as Record<string, unknown>).length === 0
+  return false
+}
+
+/**
+ * Deep-clone `input`, then delete keys whose value is null/undefined, an
+ * empty/whitespace string, or an empty object/array — recursing into nested
+ * objects and pruning branches that become empty. Numbers (incl. 0) and
+ * booleans (incl. false) are preserved. Ported from cloudgrid
+ * resiliency-builder/utils.ts `recursivelyRemoveEmptyValues`.
+ */
+export function recursivelyRemoveEmptyValues<T>(input: T): T {
+  const obj = structuredClone(input)
+  if (typeof obj === 'object' && obj !== null) {
+    const rec = obj as Record<string, unknown>
+    for (const key of Object.keys(rec)) {
+      const v = rec[key]
+      if (
+        v === null ||
+        v === undefined ||
+        (typeof v === 'string' && v.trim() === '') ||
+        (typeof v === 'object' && isEmptyContainer(v))
+      ) {
+        delete rec[key]
+      } else if (typeof v === 'object') {
+        rec[key] = recursivelyRemoveEmptyValues(v)
+        if (isEmptyContainer(rec[key])) delete rec[key]
+      }
+    }
+  }
+  return obj
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npm test -- yaml-emit`
+Expected: PASS (6 tests).
+
+- [ ] **Step 6: Type-check**
+
+Run: `npx tsc -b` → exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/package.json web/package-lock.json web/src/lib/yaml-emit.ts web/src/lib/yaml-emit.test.ts
+git commit -m "feat(web): add yaml-emit (dump + recursivelyRemoveEmptyValues)"
+```
+
+---
+
+## Task 2: Validators
+
+**Files:**
+- Create: `web/src/lib/validation.ts`
+- Create: `web/src/lib/validation.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `validateGoDuration(value: string): { valid: boolean; error?: string }`
+  - `validateResourceName(value: string): string | null` (returns error message, or `null` if valid)
+  - `validateStatusCodes(value: string): string | null`
+  - `requiredError(value: string): string | null`
+  - `integerError(value: string): string | null`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/lib/validation.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import {
+  validateGoDuration,
+  validateResourceName,
+  validateStatusCodes,
+  requiredError,
+  integerError,
+} from './validation'
+
+describe('validateGoDuration', () => {
+  it('accepts ordered unit combinations', () => {
+    for (const d of ['30s', '1h', '1h30m', '500ms', '1m30s', '10s', '15m']) {
+      expect(validateGoDuration(d).valid, d).toBe(true)
+    }
+  })
+  it('accepts empty string (required-ness gated separately)', () => {
+    expect(validateGoDuration('').valid).toBe(true)
+  })
+  it('rejects out-of-order and repeated units', () => {
+    expect(validateGoDuration('1s1h').valid).toBe(false)
+    expect(validateGoDuration('1m1m').valid).toBe(false)
+  })
+  it('rejects arbitrary text', () => {
+    const r = validateGoDuration('nope')
+    expect(r.valid).toBe(false)
+    expect(r.error).toBeTruthy()
+  })
+})
+
+describe('validateResourceName', () => {
+  it('accepts lowercase dns-ish names', () => {
+    expect(validateResourceName('order-store')).toBeNull()
+  })
+  it('rejects empty, spaces, bad chars, and non-letter starts', () => {
+    expect(validateResourceName('')).toMatch(/required/i)
+    expect(validateResourceName('a b')).toMatch(/space/i)
+    expect(validateResourceName('a_b')).toMatch(/alphanumeric/i)
+    expect(validateResourceName('1abc')).toMatch(/start/i)
+  })
+})
+
+describe('validateStatusCodes', () => {
+  it('accepts CSV of codes and ranges', () => {
+    expect(validateStatusCodes('200,404,500-503')).toBeNull()
+    expect(validateStatusCodes('')).toBeNull() // optional
+  })
+  it('rejects malformed input', () => {
+    expect(validateStatusCodes('200,abc')).toBeTruthy()
+    expect(validateStatusCodes('200-')).toBeTruthy()
+  })
+})
+
+describe('requiredError / integerError', () => {
+  it('requiredError flags empty', () => {
+    expect(requiredError('')).toMatch(/required/i)
+    expect(requiredError('x')).toBeNull()
+  })
+  it('integerError flags non-integers, allows empty', () => {
+    expect(integerError('')).toBeNull()
+    expect(integerError('3')).toBeNull()
+    expect(integerError('-1')).toBeNull()
+    expect(integerError('1.5')).toMatch(/integer/i)
+    expect(integerError('x')).toMatch(/integer/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- validation`
+Expected: FAIL — cannot resolve `./validation`.
+
+- [ ] **Step 3: Implement**
+
+Create `web/src/lib/validation.ts`:
+```ts
+// Go duration: optional units in strict descending order, no repetition.
+// Ported from cloudgrid utils/validateGoDuration.ts. Empty string is valid
+// (required-ness is enforced separately by requiredError).
+const DURATION_RE = /^(\d+h)?(\d+m)?(\d+s)?(\d+ms)?(\d+[uµ]s)?(\d+ns)?$/
+const UNIT_ORDER = ['h', 'm', 's', 'ms', 'us', 'µs', 'ns']
+
+export function validateGoDuration(value: string): { valid: boolean; error?: string } {
+  const err = 'Enter a Go duration like 30s, 5m, 1h30m (units in order h→m→s→ms→us→ns, no repeats)'
+  const matches = value.match(DURATION_RE)
+  if (!matches) return { valid: false, error: err }
+  let lastIndex = -1
+  for (let i = 1; i < matches.length; i++) {
+    const m = matches[i]
+    if (!m) continue
+    let unit: string
+    if (m.endsWith('ms')) unit = 'ms'
+    else if (m.endsWith('us')) unit = 'us'
+    else if (m.endsWith('µs')) unit = 'µs'
+    else if (m.endsWith('ns')) unit = 'ns'
+    else unit = UNIT_ORDER.find((u) => m.endsWith(u)) as string
+    const idx = UNIT_ORDER.indexOf(unit)
+    if (idx <= lastIndex) return { valid: false, error: err }
+    lastIndex = idx
+  }
+  return { valid: true }
+}
+
+// Ported from cloudgrid ConductorResourceMetadataSchema name rules.
+export function validateResourceName(value: string): string | null {
+  if (!value) return 'Name is required'
+  if (value.includes(' ')) return 'Name cannot contain spaces'
+  if (/[^a-zA-Z0-9-]/.test(value)) return 'Only alphanumeric characters and hyphens are allowed'
+  if (/^[^a-zA-Z]/.test(value)) return 'Name must start with a letter'
+  return null
+}
+
+// CSV of HTTP/gRPC status codes or ranges, e.g. "200,404,500-503". Optional.
+export function validateStatusCodes(value: string): string | null {
+  if (value.trim() === '') return null
+  const parts = value.split(',').map((p) => p.trim())
+  const seg = /^\d{1,3}(-\d{1,3})?$/
+  if (!parts.every((p) => seg.test(p))) return 'Use comma-separated codes or ranges, e.g. 200,404,500-503'
+  return null
+}
+
+export function requiredError(value: string): string | null {
+  return value.trim() === '' ? 'This field is required' : null
+}
+
+export function integerError(value: string): string | null {
+  if (value.trim() === '') return null
+  return /^-?\d+$/.test(value.trim()) ? null : 'Must be an integer'
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- validation`
+Expected: PASS.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc -b` → exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/lib/validation.ts web/src/lib/validation.test.ts
+git commit -m "feat(web): add builder validators (go-duration, name, status-codes)"
+```
+
+---
+
+## Task 3: Download helper
+
+**Files:**
+- Create: `web/src/lib/download.ts`
+- Create: `web/src/lib/download.test.ts`
+
+**Interfaces:**
+- Produces: `downloadText(filename: string, text: string): void`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/lib/download.test.ts`:
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { downloadText } from './download'
+
+describe('downloadText', () => {
+  beforeEach(() => {
+    // jsdom lacks these; stub them.
+    ;(URL as unknown as { createObjectURL: unknown }).createObjectURL = vi.fn(() => 'blob:mock')
+    ;(URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = vi.fn()
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('creates an anchor with the given filename and clicks it', () => {
+    const click = vi.fn()
+    const orig = document.createElement.bind(document)
+    const spy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = orig(tag) as HTMLElement
+      if (tag === 'a') (el as HTMLAnchorElement).click = click
+      return el
+    })
+    downloadText('order.yaml', 'a: 1\n')
+    const anchor = spy.mock.results.map((r) => r.value as HTMLElement).find((e) => e.tagName === 'A') as HTMLAnchorElement
+    expect(anchor.download).toBe('order.yaml')
+    expect(anchor.href).toContain('blob:mock')
+    expect(click).toHaveBeenCalledOnce()
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock')
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- download`
+Expected: FAIL — cannot resolve `./download`.
+
+- [ ] **Step 3: Implement**
+
+Create `web/src/lib/download.ts`:
+```ts
+/** Trigger a client-side download of `text` as a file named `filename`. */
+export function downloadText(filename: string, text: string): void {
+  const blob = new Blob([text], { type: 'text/yaml;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- download`
+Expected: PASS.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc -b` → exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/lib/download.ts web/src/lib/download.test.ts
+git commit -m "feat(web): add downloadText helper"
+```
+
+---
+
+## Task 4: Data types + default factories
+
+**Files:**
+- Create: `web/src/types/component.ts`
+- Create: `web/src/types/resiliency.ts`
+- Modify: `web/src/types/metadata.ts`
+- Create: `web/src/types/builders.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `types/component.ts`: `ComponentSpec`, `ComponentMetadataItem`, `defaultComponentSpec(): ComponentSpec`.
+  - `types/resiliency.ts`: `DaprResiliency`, `Policies`, `Targets`, `RetryPolicy`, `CircuitBreakerPolicy`, `AppTarget`, `ActorTarget`, `ComponentTarget`, `defaultResiliencyConfig(): DaprResiliency`.
+  - `types/metadata.ts`: adds `AuthenticationProfile`, and `authenticationProfiles?`, on `ComponentMetadataSchema`; adds `isCert?`, `binding?` on `MetadataField`.
+- Consumes: existing `MetadataField`, `ComponentMetadataSchema` from `types/metadata.ts`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/types/builders.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { defaultComponentSpec } from './component'
+import { defaultResiliencyConfig } from './resiliency'
+
+describe('defaultComponentSpec', () => {
+  it('returns a v1alpha1 Component skeleton', () => {
+    const c = defaultComponentSpec()
+    expect(c.apiVersion).toBe('dapr.io/v1alpha1')
+    expect(c.kind).toBe('Component')
+    expect(c.metadata).toEqual({ name: '', namespace: 'default' })
+    expect(c.scopes).toEqual([])
+    expect(c.spec).toEqual({ type: '', version: '', metadata: [] })
+  })
+  it('returns a fresh object each call (no shared refs)', () => {
+    const a = defaultComponentSpec()
+    const b = defaultComponentSpec()
+    expect(a.spec.metadata).not.toBe(b.spec.metadata)
+  })
+})
+
+describe('defaultResiliencyConfig', () => {
+  it('returns a v1alpha1 Resiliency skeleton with empty policy/target maps', () => {
+    const r = defaultResiliencyConfig()
+    expect(r.apiVersion).toBe('dapr.io/v1alpha1')
+    expect(r.kind).toBe('Resiliency')
+    expect(r.metadata).toEqual({ name: '', namespace: '' })
+    expect(r.spec.policies).toEqual({ timeouts: {}, retries: {}, circuitBreakers: {} })
+    expect(r.spec.targets).toEqual({ apps: {}, actors: {}, components: {} })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- builders`
+Expected: FAIL — cannot resolve `./component` / `./resiliency`.
+
+- [ ] **Step 3: Extend `types/metadata.ts`**
+
+Add to `web/src/types/metadata.ts` (append the new interface and two optional fields; keep existing content):
+```ts
+export interface AuthenticationProfile {
+  title: string
+  description?: string
+  metadata: MetadataField[]
+}
+```
+And extend the existing interfaces:
+- On `MetadataField`, add: `isCert?: boolean` and `binding?: { input?: boolean; output?: boolean }`.
+- On `ComponentMetadataSchema`, add: `authenticationProfiles?: AuthenticationProfile[]`.
+
+Resulting `MetadataField` and `ComponentMetadataSchema`:
+```ts
+export interface MetadataField {
+  name: string
+  type?: 'string' | 'number' | 'bool' | 'duration'
+  description?: string
+  required?: boolean
+  sensitive?: boolean
+  default?: string
+  example?: string
+  allowedValues?: string[]
+  isCert?: boolean
+  binding?: { input?: boolean; output?: boolean }
+  url?: { title: string; url: string }
+}
+
+export interface ComponentMetadataSchema {
+  type: string
+  name: string
+  version: string
+  title: string
+  status: string
+  description?: string
+  metadata?: MetadataField[]
+  authenticationProfiles?: AuthenticationProfile[]
+}
+```
+
+- [ ] **Step 4: Create `types/component.ts`**
+
+```ts
+export interface ComponentMetadataItem {
+  name: string
+  value?: string | number | boolean
+  secretKeyRef?: { name: string; key: string }
+}
+
+export interface ComponentSpec {
+  apiVersion: string
+  kind: string
+  metadata: { name: string; namespace: string; [key: string]: unknown }
+  scopes: string[]
+  spec: {
+    type: string
+    version: string
+    metadata: ComponentMetadataItem[]
+  }
+}
+
+export function defaultComponentSpec(): ComponentSpec {
+  return {
+    apiVersion: 'dapr.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: '', namespace: 'default' },
+    scopes: [],
+    spec: { type: '', version: '', metadata: [] },
+  }
+}
+```
+
+- [ ] **Step 5: Create `types/resiliency.ts`**
+
+Note: cloudgrid's type had a typo `grcpStatusCodes`; this port uses the correct `grpcStatusCodes` consistently.
+```ts
+export interface RetryPolicy {
+  policy?: 'constant' | 'exponential'
+  duration?: string
+  maxRetries?: number
+  maxInterval?: string
+  matching?: { httpStatusCodes?: string; grpcStatusCodes?: string }
+}
+
+export interface CircuitBreakerPolicy {
+  maxRequests?: number
+  timeout?: string
+  trip?: string
+  interval?: string
+}
+
+export type TimeoutPolicy = { [name: string]: string }
+
+export interface Policies {
+  timeouts: TimeoutPolicy
+  retries: { [name: string]: RetryPolicy }
+  circuitBreakers: { [name: string]: CircuitBreakerPolicy }
+}
+
+export interface AppTarget {
+  timeout?: string
+  retry?: string
+  circuitBreaker?: string
+}
+
+export interface ActorTarget {
+  timeout?: string
+  retry?: string
+  circuitBreaker?: string
+  circuitBreakerScope?: 'type' | 'id' | 'both' | ''
+  circuitBreakerCacheSize?: number
+}
+
+export interface ComponentTarget {
+  outbound?: { timeout?: string; retry?: string; circuitBreaker?: string }
+  inbound?: { timeout?: string; retry?: string; circuitBreaker?: string }
+}
+
+export interface Targets {
+  apps?: { [name: string]: AppTarget }
+  actors?: { [name: string]: ActorTarget }
+  components?: { [name: string]: ComponentTarget }
+}
+
+export interface DaprResiliency {
+  apiVersion: string
+  kind: string
+  metadata: { name: string; namespace?: string; [key: string]: unknown }
+  scopes: string[]
+  spec: { policies: Policies; targets: Targets }
+}
+
+export function defaultResiliencyConfig(): DaprResiliency {
+  return {
+    apiVersion: 'dapr.io/v1alpha1',
+    kind: 'Resiliency',
+    metadata: { name: '', namespace: '' },
+    scopes: [],
+    spec: {
+      policies: { timeouts: {}, retries: {}, circuitBreakers: {} },
+      targets: { apps: {}, actors: {}, components: {} },
+    },
+  }
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `npm test -- builders`
+Expected: PASS.
+
+- [ ] **Step 7: Type-check + full suite (metadata.ts is imported widely)**
+
+Run: `npx tsc -b` → exit 0. Then `npm test` → all green (extending `MetadataField`/`ComponentMetadataSchema` with optional fields must not break existing consumers like `useComponentCatalog`, `MetadataFieldInput`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/types/component.ts web/src/types/resiliency.ts web/src/types/metadata.ts web/src/types/builders.test.ts
+git commit -m "feat(web): add component/resiliency types + default factories; extend metadata types"
+```
+
+---
+
+## Task 5: Controlled form controls
+
+**Files:**
+- Create: `web/src/components/form/Field.tsx`
+- Create: `web/src/components/form/TextInput.tsx`
+- Create: `web/src/components/form/NumberInput.tsx`
+- Create: `web/src/components/form/SelectInput.tsx`
+- Create: `web/src/components/form/Toggle.tsx`
+- Create: `web/src/components/form/index.ts`
+- Create: `web/src/components/form/form.test.tsx`
+
+**Interfaces:**
+- Produces (all controlled, styled with existing theme.css `.field`/`.inp`/`.select`/`.field-err`/`.req` classes):
+  - `Field({ label, htmlFor?, required?, error?, children })`
+  - `TextInput({ id?, value, onChange, placeholder?, type?, 'aria-label'? })` — `onChange(value: string)`
+  - `NumberInput({ id?, value, onChange, placeholder? })` — `onChange(value: string)` (string-typed to allow empty)
+  - `SelectInput({ id?, value, onChange, options, 'aria-label'? })` — `options: { label: string; value: string }[]`
+  - `Toggle({ id?, checked, onChange, label })` — `onChange(checked: boolean)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/components/form/form.test.tsx`:
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { Field, TextInput, NumberInput, SelectInput, Toggle } from './index'
+
+describe('Field', () => {
+  it('renders label, required marker, and error', () => {
+    render(<Field label="Name" required error="bad"><input aria-label="Name" /></Field>)
+    expect(screen.getByText('Name')).toBeInTheDocument()
+    expect(screen.getByText('*')).toBeInTheDocument()
+    expect(screen.getByText('bad')).toBeInTheDocument()
+  })
+})
+
+describe('TextInput', () => {
+  it('is controlled and reports string values', () => {
+    const onChange = vi.fn()
+    render(<TextInput value="a" onChange={onChange} aria-label="f" />)
+    fireEvent.change(screen.getByLabelText('f'), { target: { value: 'ab' } })
+    expect(onChange).toHaveBeenCalledWith('ab')
+  })
+})
+
+describe('SelectInput', () => {
+  it('renders options and reports the chosen value', () => {
+    const onChange = vi.fn()
+    render(
+      <SelectInput value="" onChange={onChange} aria-label="pick"
+        options={[{ label: 'One', value: '1' }, { label: 'Two', value: '2' }]} />,
+    )
+    fireEvent.change(screen.getByLabelText('pick'), { target: { value: '2' } })
+    expect(onChange).toHaveBeenCalledWith('2')
+  })
+})
+
+describe('Toggle', () => {
+  it('reports boolean changes', () => {
+    const onChange = vi.fn()
+    render(<Toggle checked={false} onChange={onChange} label="on" />)
+    fireEvent.click(screen.getByLabelText('on'))
+    expect(onChange).toHaveBeenCalledWith(true)
+  })
+})
+
+describe('NumberInput', () => {
+  it('reports raw string value (allowing empty)', () => {
+    const onChange = vi.fn()
+    render(<NumberInput value="" onChange={onChange} aria-label="n" />)
+    fireEvent.change(screen.getByLabelText('n'), { target: { value: '5' } })
+    expect(onChange).toHaveBeenCalledWith('5')
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- form/form`
+Expected: FAIL — cannot resolve `./index`.
+
+- [ ] **Step 3: Implement the controls**
+
+Create `web/src/components/form/Field.tsx`:
+```tsx
+interface FieldProps {
+  label: string
+  htmlFor?: string
+  required?: boolean
+  error?: string | null
+  children: React.ReactNode
+}
+
+export function Field({ label, htmlFor, required, error, children }: FieldProps) {
+  return (
+    <div className="field">
+      <label htmlFor={htmlFor}>
+        {label}
+        {required && <span className="req"> *</span>}
+      </label>
+      {children}
+      {error && <div className="field-err">{error}</div>}
+    </div>
+  )
+}
+```
+
+Create `web/src/components/form/TextInput.tsx`:
+```tsx
+interface TextInputProps {
+  id?: string
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  type?: 'text' | 'password'
+  'aria-label'?: string
+}
+
+export function TextInput({ id, value, onChange, placeholder, type = 'text', ...rest }: TextInputProps) {
+  return (
+    <input
+      id={id}
+      className="inp"
+      type={type}
+      value={value}
+      placeholder={placeholder}
+      aria-label={rest['aria-label']}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  )
+}
+```
+
+Create `web/src/components/form/NumberInput.tsx`:
+```tsx
+interface NumberInputProps {
+  id?: string
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  'aria-label'?: string
+}
+
+// value is kept as a string so the field can be empty; callers coerce on emit.
+export function NumberInput({ id, value, onChange, placeholder, ...rest }: NumberInputProps) {
+  return (
+    <input
+      id={id}
+      className="inp"
+      type="number"
+      value={value}
+      placeholder={placeholder}
+      aria-label={rest['aria-label']}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  )
+}
+```
+
+Create `web/src/components/form/SelectInput.tsx`:
+```tsx
+interface SelectOption {
+  label: string
+  value: string
+}
+
+interface SelectInputProps {
+  id?: string
+  value: string
+  onChange: (value: string) => void
+  options: SelectOption[]
+  'aria-label'?: string
+}
+
+export function SelectInput({ id, value, onChange, options, ...rest }: SelectInputProps) {
+  return (
+    <select
+      id={id}
+      className="select"
+      value={value}
+      aria-label={rest['aria-label']}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="">—</option>
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>{o.label}</option>
+      ))}
+    </select>
+  )
+}
+```
+
+Create `web/src/components/form/Toggle.tsx`:
+```tsx
+interface ToggleProps {
+  id?: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+  label: string
+}
+
+export function Toggle({ id, checked, onChange, label }: ToggleProps) {
+  return (
+    <label className="childtoggle">
+      <input
+        id={id}
+        type="checkbox"
+        aria-label={label}
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      {label}
+    </label>
+  )
+}
+```
+
+Create `web/src/components/form/index.ts`:
+```ts
+export { Field } from './Field'
+export { TextInput } from './TextInput'
+export { NumberInput } from './NumberInput'
+export { SelectInput } from './SelectInput'
+export { Toggle } from './Toggle'
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- form/form`
+Expected: PASS.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc -b` → exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/components/form/
+git commit -m "feat(web): add controlled form controls (Field/TextInput/NumberInput/SelectInput/Toggle)"
+```
+
+---
+
+## Task 6: Wizard shell + monochrome button styles
+
+**Files:**
+- Create: `web/src/components/wizard/Stepper.tsx`
+- Create: `web/src/components/wizard/StepNav.tsx`
+- Create: `web/src/components/wizard/Wizard.tsx`
+- Create: `web/src/components/wizard/index.ts`
+- Create: `web/src/components/wizard/wizard.test.tsx`
+- Modify: `web/src/styles/theme.css` (append wizard styles)
+
+**Interfaces:**
+- Produces:
+  - `WizardStep = { label: string; content: React.ReactNode }`
+  - `Stepper({ steps: { label: string }[], activeStep: number })`
+  - `StepNav({ activeStep, stepCount, canContinue, onBack, onContinue, onFinish })` — Back hidden on step 0; last step shows "Finish" (calls `onFinish`), else "Continue" (calls `onContinue`); Continue/Finish disabled when `!canContinue`.
+  - `Wizard({ steps: WizardStep[], activeStep, canContinue, onBack, onContinue, onFinish })` — renders `Stepper` + active step content + `StepNav`. Presentational only; state lives in each builder's reducer (Plans 2–3).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/components/wizard/wizard.test.tsx`:
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { Wizard, StepNav } from './index'
+
+const steps = [
+  { label: 'One', content: <div>content-one</div> },
+  { label: 'Two', content: <div>content-two</div> },
+]
+
+describe('Wizard', () => {
+  it('renders step labels and only the active step content', () => {
+    render(<Wizard steps={steps} activeStep={0} canContinue onBack={() => {}} onContinue={() => {}} onFinish={() => {}} />)
+    expect(screen.getByText('One')).toBeInTheDocument()
+    expect(screen.getByText('Two')).toBeInTheDocument()
+    expect(screen.getByText('content-one')).toBeInTheDocument()
+    expect(screen.queryByText('content-two')).not.toBeInTheDocument()
+  })
+})
+
+describe('StepNav', () => {
+  it('hides Back on the first step and shows Continue', () => {
+    render(<StepNav activeStep={0} stepCount={2} canContinue onBack={() => {}} onContinue={() => {}} onFinish={() => {}} />)
+    expect(screen.queryByRole('button', { name: /back/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /continue/i })).toBeEnabled()
+  })
+  it('shows Finish (not Continue) on the last step', () => {
+    render(<StepNav activeStep={1} stepCount={2} canContinue onBack={() => {}} onContinue={() => {}} onFinish={() => {}} />)
+    expect(screen.getByRole('button', { name: /finish/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /continue/i })).not.toBeInTheDocument()
+  })
+  it('disables the primary action when canContinue is false', () => {
+    render(<StepNav activeStep={0} stepCount={2} canContinue={false} onBack={() => {}} onContinue={() => {}} onFinish={() => {}} />)
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled()
+  })
+  it('primary button uses the monochrome class, never the green .btn.primary', () => {
+    render(<StepNav activeStep={0} stepCount={2} canContinue onBack={() => {}} onContinue={() => {}} onFinish={() => {}} />)
+    const cont = screen.getByRole('button', { name: /continue/i })
+    expect(cont).toHaveClass('btn', 'mono')
+    expect(cont).not.toHaveClass('primary')
+  })
+  it('fires onContinue / onFinish / onBack', () => {
+    const onContinue = vi.fn(); const onFinish = vi.fn(); const onBack = vi.fn()
+    const { rerender } = render(<StepNav activeStep={0} stepCount={2} canContinue onBack={onBack} onContinue={onContinue} onFinish={onFinish} />)
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }))
+    expect(onContinue).toHaveBeenCalledOnce()
+    rerender(<StepNav activeStep={1} stepCount={2} canContinue onBack={onBack} onContinue={onContinue} onFinish={onFinish} />)
+    fireEvent.click(screen.getByRole('button', { name: /back/i }))
+    fireEvent.click(screen.getByRole('button', { name: /finish/i }))
+    expect(onBack).toHaveBeenCalledOnce()
+    expect(onFinish).toHaveBeenCalledOnce()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- wizard/wizard`
+Expected: FAIL — cannot resolve `./index`.
+
+- [ ] **Step 3: Append wizard styles to `theme.css`**
+
+Append to the end of `web/src/styles/theme.css`:
+```css
+/* ---- Wizard (component/resiliency builders) ---- */
+/* Monochrome primary button — deliberately NOT the green .btn.primary. */
+.btn.mono { background: var(--text); color: var(--bg); border-color: transparent; }
+.btn.mono:disabled { opacity: .45; cursor: default; }
+.wizard { display: flex; flex-direction: column; gap: 18px; }
+.stepper { display: flex; flex-wrap: wrap; gap: 8px; }
+.stepper .step { font-family: var(--mono); font-size: 11px; letter-spacing: .06em; text-transform: uppercase; color: var(--muted); border: 1px solid var(--line); border-radius: 999px; padding: 4px 11px; }
+.stepper .step.active { color: var(--text); border-color: var(--faint); background: var(--surface-2); }
+.stepper .step.done { color: var(--accent2); }
+.wizard-body { min-height: 120px; }
+.stepnav { display: flex; justify-content: space-between; gap: 10px; }
+.stepnav .spacer { flex: 1; }
+```
+
+- [ ] **Step 4: Implement the components**
+
+Create `web/src/components/wizard/Stepper.tsx`:
+```tsx
+interface StepperProps {
+  steps: { label: string }[]
+  activeStep: number
+}
+
+export function Stepper({ steps, activeStep }: StepperProps) {
+  return (
+    <div className="stepper" role="list" aria-label="Wizard steps">
+      {steps.map((s, i) => (
+        <span
+          key={s.label}
+          role="listitem"
+          aria-current={i === activeStep ? 'step' : undefined}
+          className={`step${i === activeStep ? ' active' : ''}${i < activeStep ? ' done' : ''}`}
+        >
+          {s.label}
+        </span>
+      ))}
+    </div>
+  )
+}
+```
+
+Create `web/src/components/wizard/StepNav.tsx`:
+```tsx
+interface StepNavProps {
+  activeStep: number
+  stepCount: number
+  canContinue: boolean
+  onBack: () => void
+  onContinue: () => void
+  onFinish: () => void
+}
+
+export function StepNav({ activeStep, stepCount, canContinue, onBack, onContinue, onFinish }: StepNavProps) {
+  const isLast = activeStep === stepCount - 1
+  return (
+    <div className="stepnav">
+      {activeStep > 0 ? (
+        <button type="button" className="btn ghost" onClick={onBack}>Back</button>
+      ) : (
+        <span className="spacer" />
+      )}
+      {isLast ? (
+        <button type="button" className="btn mono" disabled={!canContinue} onClick={onFinish}>Finish</button>
+      ) : (
+        <button type="button" className="btn mono" disabled={!canContinue} onClick={onContinue}>Continue</button>
+      )}
+    </div>
+  )
+}
+```
+
+Create `web/src/components/wizard/Wizard.tsx`:
+```tsx
+import { Stepper } from './Stepper'
+import { StepNav } from './StepNav'
+
+export interface WizardStep {
+  label: string
+  content: React.ReactNode
+}
+
+interface WizardProps {
+  steps: WizardStep[]
+  activeStep: number
+  canContinue: boolean
+  onBack: () => void
+  onContinue: () => void
+  onFinish: () => void
+}
+
+export function Wizard({ steps, activeStep, canContinue, onBack, onContinue, onFinish }: WizardProps) {
+  return (
+    <div className="wizard">
+      <Stepper steps={steps.map((s) => ({ label: s.label }))} activeStep={activeStep} />
+      <div className="wizard-body">{steps[activeStep]?.content}</div>
+      <StepNav
+        activeStep={activeStep}
+        stepCount={steps.length}
+        canContinue={canContinue}
+        onBack={onBack}
+        onContinue={onContinue}
+        onFinish={onFinish}
+      />
+    </div>
+  )
+}
+```
+
+Create `web/src/components/wizard/index.ts`:
+```ts
+export { Wizard, type WizardStep } from './Wizard'
+export { Stepper } from './Stepper'
+export { StepNav } from './StepNav'
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npm test -- wizard/wizard`
+Expected: PASS.
+
+- [ ] **Step 6: Type-check + full suite**
+
+Run: `npx tsc -b` → exit 0. Then `npm test` → all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/components/wizard/ web/src/styles/theme.css
+git commit -m "feat(web): add wizard shell (Stepper/StepNav/Wizard) + monochrome button styles"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (foundation portions only; wizard content + routing/nav ship in Plans 2–3):**
+- `js-yaml` dep + `lib/yaml-emit.ts` incl. `recursivelyRemoveEmptyValues` → Task 1. ✓
+- `lib/validation.ts` (`validateGoDuration` ported verbatim, name + status-code validators) → Task 2. ✓
+- `lib/download.ts` → Task 3. ✓
+- Types (`component.ts`, `resiliency.ts`, extend `metadata.ts` for `authenticationProfiles`) → Task 4. ✓
+- `components/form/` controlled controls → Task 5. ✓
+- `components/wizard/` + monochrome button styling (Global Constraint) → Task 6. ✓
+- Reuse of existing `Modal`, `MetadataFieldInput`, `copyText`, `useToast`, `highlightYaml`, `fetchJSON` — consumed in Plans 2–3, not rebuilt here. ✓
+- **Deferred to Plans 2–3 (documented):** routes `/components/new`, `/resiliency`, `/resiliency/new`; the `Resiliency` nav item; the `+ New component` button; the create-only `Resiliency` landing page; generalizing `useComponentCatalog`; the two 4-step wizard flows and their YAML assembly.
+
+**Placeholder scan:** No TBD/TODO; every code step contains complete code; commands include expected results.
+
+**Type consistency:** `dumpYaml`/`recursivelyRemoveEmptyValues` (Task 1) reused by builders; `validateGoDuration` returns `{valid,error}` and `validateResourceName`/`validateStatusCodes`/`requiredError`/`integerError` return `string|null` (Task 2) — consistent across the plan. `defaultComponentSpec`/`defaultResiliencyConfig` (Task 4) match the types they return. `WizardStep`, `Stepper`, `StepNav`, `Wizard` prop names (Task 6) are consistent between the components and the index re-exports. Form control `onChange` signatures (string for text/number/select, boolean for toggle) are stated in Task 5 interfaces and used consistently.
+
+**Note on grpcStatusCodes:** cloudgrid's type used the typo `grcpStatusCodes`; this port standardizes on `grpcStatusCodes` (Task 4) and Plans 2–3 must use that spelling in the retry-policy form + emit.

--- a/docs/superpowers/plans/2026-07-01-builders-02-component.md
+++ b/docs/superpowers/plans/2026-07-01-builders-02-component.md
@@ -1,0 +1,1193 @@
+# Builders — Plan 2: Component Builder Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the Component Builder — a 4-step wizard at `/components/new` that generates a Dapr Component YAML (copy/download), reachable via a "+ New component" button on the Components page.
+
+**Architecture:** Builds on Plan 1's foundation (`lib/yaml-emit`, `lib/validation`, `lib/download`, `types/component`, `components/form/*`, `components/wizard/*`). State lives in a typed `useReducer` in the `ComponentBuilder` page; each step is a controlled child driven by that state. YAML is assembled from the reducer state and shown in a shared editable `YamlPreview` finalizer (also created here, reused by Plan 3). No component-emission stripping — each metadata item is assembled with only its populated key.
+
+**Tech Stack:** React 19, TS, Vite, React Router v6, TanStack Query v5, Vitest + Testing Library. No new dependencies.
+
+**Prereq:** Plan 1 (`docs/superpowers/plans/2026-07-01-builders-01-foundation.md`) merged/complete on this branch.
+**Source spec:** `docs/superpowers/specs/2026-06-28-component-resiliency-builders-design.md`
+
+## Global Constraints
+
+- **No new dependencies.** No MUI/react-hook-form/Yup. Controlled components; vanilla CSS theme tokens.
+- **Wizard buttons monochrome** (Plan 1's `.btn.mono` / `.btn.ghost`); never the green `.btn.primary`. Copy/Download also neutral/ghost.
+- **`spec.type = `${schema.type}.${schema.name}`** (e.g. `state` + `redis` → `state.redis`); `spec.version` = the chosen schema `version` (e.g. `v1`).
+- **Metadata array assembly (from Plan 1 review):** `recursivelyRemoveEmptyValues` is NOT used for component emission. Build `spec.metadata` by including, per active field: `{ name, secretKeyRef }` when "use secret" is on, else `{ name, value }` when the value is non-empty, else OMIT the item entirely. Never emit both `value` and `secretKeyRef`.
+- **Reuse** existing `components/MetadataFieldInput.tsx` for field value controls, `lib/clipboard.ts` `copyText`, `lib/toast.tsx` `useToast`, `lib/yaml-highlight.tsx` `highlightYaml` (read-only views only), Plan 1 `components/form/*` and `components/wizard/*`.
+- **Do NOT modify** the existing `hooks/useComponentCatalog.ts` (it powers the state-store connection dialog with synthetic-field behavior). Add a separate hook for the builder.
+- **Tests:** Vitest + Testing Library, colocated. Run `npx tsc -b` before every commit. All `npm`/`npx` from `web/`.
+- **On finish or cancel:** navigate to `/components`.
+
+---
+
+## File Structure
+
+- Create `web/src/hooks/useComponentSchemas.ts` — all catalog schemas + grouping + active-fields helper.
+- Create `web/src/components/YamlPreview.tsx` — shared editable finalizer (reused by Plan 3).
+- Create `web/src/pages/component-builder/reducer.ts` — state, actions, reducer, `canContinue`, `assembleComponentSpec`.
+- Create `web/src/pages/component-builder/StepType.tsx` — step 0.
+- Create `web/src/pages/component-builder/StepAuth.tsx` — step 1.
+- Create `web/src/pages/component-builder/StepConfigure.tsx` — step 2.
+- Create `web/src/pages/component-builder/ComponentBuilder.tsx` — assembles wizard + preview + navigation.
+- Modify `web/src/router.tsx` — add `components/new` route (before `components/:name`).
+- Modify `web/src/pages/ResourceList.tsx` — add "+ New component" button (component kind only).
+
+---
+
+## Task 1: Catalog hook for the builder
+
+**Files:**
+- Create: `web/src/hooks/useComponentSchemas.ts`
+- Create: `web/src/hooks/useComponentSchemas.test.tsx`
+
+**Interfaces:**
+- Produces:
+  - `useComponentSchemas(): { schemas: ComponentMetadataSchema[]; byType: Record<string, ComponentMetadataSchema[]>; isLoading: boolean; isError: boolean }` — ALL components (no state-only filter), grouped by `type`.
+  - `activeFields(schema: ComponentMetadataSchema, authProfile?: AuthenticationProfile): { required: MetadataField[]; optional: MetadataField[] }` — merges schema `metadata` with the selected auth profile's `metadata`; splits by `required`.
+- Consumes: `lib/api.ts` `fetchJSON`; `types/metadata.ts` `MetadataBundle`, `ComponentMetadataSchema`, `MetadataField`, `AuthenticationProfile`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/hooks/useComponentSchemas.test.tsx`:
+```tsx
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { server } from '../test/setup'
+import { QueryProvider, makeQueryClient } from '../lib/query'
+import { useComponentSchemas, activeFields } from './useComponentSchemas'
+import type { ComponentMetadataSchema } from '../types/metadata'
+
+const bundle = {
+  schemaVersion: '1', date: '2026-01-01',
+  components: [
+    { type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable',
+      metadata: [{ name: 'redisHost', required: true }, { name: 'enableTLS', type: 'bool' }] },
+    { type: 'pubsub', name: 'redis', version: 'v1', title: 'Redis PubSub', status: 'stable', metadata: [] },
+  ],
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <QueryProvider client={makeQueryClient()}>{children}</QueryProvider>
+}
+
+describe('useComponentSchemas', () => {
+  it('returns all schemas grouped by type (no state-only filter)', async () => {
+    server.use(http.get('/api/metadata/components', () => HttpResponse.json(bundle)))
+    const { result } = renderHook(() => useComponentSchemas(), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.schemas).toHaveLength(2)
+    expect(Object.keys(result.current.byType).sort()).toEqual(['pubsub', 'state'])
+    expect(result.current.byType.state[0].name).toBe('redis')
+  })
+})
+
+describe('activeFields', () => {
+  const schema: ComponentMetadataSchema = {
+    type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable',
+    metadata: [{ name: 'redisHost', required: true }, { name: 'enableTLS', type: 'bool' }],
+  }
+  it('splits required vs optional and merges auth-profile fields', () => {
+    const { required, optional } = activeFields(schema, {
+      title: 'AWS IAM', metadata: [{ name: 'accessKey', required: true, sensitive: true }],
+    })
+    expect(required.map((f) => f.name).sort()).toEqual(['accessKey', 'redisHost'])
+    expect(optional.map((f) => f.name)).toEqual(['enableTLS'])
+  })
+  it('works with no auth profile', () => {
+    const { required, optional } = activeFields(schema)
+    expect(required.map((f) => f.name)).toEqual(['redisHost'])
+    expect(optional.map((f) => f.name)).toEqual(['enableTLS'])
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- useComponentSchemas`
+Expected: FAIL — cannot resolve `./useComponentSchemas`.
+
+- [ ] **Step 3: Implement**
+
+Create `web/src/hooks/useComponentSchemas.ts`:
+```ts
+import { useQuery } from '@tanstack/react-query'
+import { fetchJSON } from '../lib/api'
+import type { MetadataBundle, ComponentMetadataSchema, MetadataField, AuthenticationProfile } from '../types/metadata'
+
+export function useComponentSchemas() {
+  const query = useQuery<MetadataBundle>({
+    queryKey: ['metadata', 'components'],
+    queryFn: () => fetchJSON<MetadataBundle>('/metadata/components'),
+    staleTime: 60 * 60 * 1000,
+  })
+  const schemas = query.data?.components ?? []
+  const byType: Record<string, ComponentMetadataSchema[]> = {}
+  for (const s of schemas) {
+    ;(byType[s.type] ??= []).push(s)
+  }
+  return { schemas, byType, isLoading: query.isLoading, isError: query.isError }
+}
+
+/** Merge schema metadata with the chosen auth-profile metadata, split by required. */
+export function activeFields(
+  schema: ComponentMetadataSchema,
+  authProfile?: AuthenticationProfile,
+): { required: MetadataField[]; optional: MetadataField[] } {
+  const all: MetadataField[] = [...(schema.metadata ?? []), ...(authProfile?.metadata ?? [])]
+  const required = all.filter((f) => f.required)
+  const optional = all.filter((f) => !f.required)
+  return { required, optional }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- useComponentSchemas`
+Expected: PASS.
+
+- [ ] **Step 5: Type-check + full suite**
+
+Run: `npx tsc -b` → 0. Then `npm test` → all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/hooks/useComponentSchemas.ts web/src/hooks/useComponentSchemas.test.tsx
+git commit -m "feat(web): add useComponentSchemas hook for the component builder"
+```
+
+---
+
+## Task 2: Shared editable YAML finalizer
+
+**Files:**
+- Create: `web/src/components/YamlPreview.tsx`
+- Create: `web/src/components/YamlPreview.test.tsx`
+
+**Interfaces:**
+- Produces: `YamlPreview({ yaml, filename, onEditedChange })` where
+  - `yaml: string` — the generated YAML (regenerated by the parent when inputs change).
+  - `filename: string` — download filename, e.g. `order.yaml`.
+  - `onEditedChange?: (edited: boolean) => void` — fires `true` once the user manually edits the textarea, so the parent can disable Back (matches cloudgrid). "Reset to generated" restores and fires `false`.
+  - Renders: a `<textarea className="inp code">` seeded with `yaml`; a "Reset to generated" button (`.btn.ghost`); Copy (`.btn.ghost`, uses `copyText` + `useToast`) and Download (`.btn.mono`, uses `downloadText`) acting on the CURRENT buffer.
+- Consumes: `lib/clipboard.ts` `copyText`, `lib/toast.tsx` `useToast`, `lib/download.ts` `downloadText`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/components/YamlPreview.test.tsx`:
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { YamlPreview } from './YamlPreview'
+
+describe('YamlPreview', () => {
+  beforeEach(() => {
+    ;(URL as unknown as { createObjectURL: unknown }).createObjectURL = vi.fn(() => 'blob:mock')
+    ;(URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = vi.fn()
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('seeds the textarea with the generated yaml', () => {
+    render(<YamlPreview yaml={'a: 1\n'} filename="c.yaml" />)
+    expect(screen.getByRole('textbox')).toHaveValue('a: 1\n')
+  })
+
+  it('reports edited=true on manual edit and edited=false on reset', () => {
+    const onEditedChange = vi.fn()
+    render(<YamlPreview yaml={'a: 1\n'} filename="c.yaml" onEditedChange={onEditedChange} />)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'a: 2\n' } })
+    expect(onEditedChange).toHaveBeenLastCalledWith(true)
+    fireEvent.click(screen.getByRole('button', { name: /reset to generated/i }))
+    expect(screen.getByRole('textbox')).toHaveValue('a: 1\n')
+    expect(onEditedChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('download button uses the current buffer and the monochrome class', () => {
+    render(<YamlPreview yaml={'a: 1\n'} filename="order.yaml" />)
+    const dl = screen.getByRole('button', { name: /download/i })
+    expect(dl).toHaveClass('btn', 'mono')
+    fireEvent.click(dl)
+    expect(URL.createObjectURL).toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- YamlPreview`
+Expected: FAIL — cannot resolve `./YamlPreview`.
+
+- [ ] **Step 3: Implement**
+
+Create `web/src/components/YamlPreview.tsx`:
+```tsx
+import { useEffect, useState } from 'react'
+import { copyText } from '../lib/clipboard'
+import { useToast } from '../lib/toast'
+import { downloadText } from '../lib/download'
+
+interface YamlPreviewProps {
+  yaml: string
+  filename: string
+  onEditedChange?: (edited: boolean) => void
+}
+
+export function YamlPreview({ yaml, filename, onEditedChange }: YamlPreviewProps) {
+  const [buffer, setBuffer] = useState(yaml)
+  const [edited, setEdited] = useState(false)
+  const { toast, toastNode } = useToast()
+
+  // Re-seed when the generated yaml changes AND the user hasn't manually edited.
+  useEffect(() => {
+    if (!edited) setBuffer(yaml)
+  }, [yaml, edited])
+
+  function onInput(value: string) {
+    setBuffer(value)
+    if (!edited) {
+      setEdited(true)
+      onEditedChange?.(true)
+    }
+  }
+
+  function reset() {
+    setBuffer(yaml)
+    setEdited(false)
+    onEditedChange?.(false)
+  }
+
+  return (
+    <div>
+      <textarea
+        className="inp code"
+        aria-label="Generated YAML"
+        rows={16}
+        value={buffer}
+        onChange={(e) => onInput(e.target.value)}
+      />
+      <div className="stepnav" style={{ marginTop: 10 }}>
+        <button type="button" className="btn ghost" onClick={reset}>Reset to generated</button>
+        <div className="spacer" />
+        <button
+          type="button"
+          className="btn ghost"
+          onClick={() => { copyText(buffer); toast.show('Copied') }}
+        >
+          Copy
+        </button>
+        <button
+          type="button"
+          className="btn mono"
+          onClick={() => downloadText(filename, buffer)}
+        >
+          Download
+        </button>
+      </div>
+      {toastNode}
+    </div>
+  )
+}
+```
+Note: confirm `useToast()`'s returned handle has a `show(msg)` method; if the API differs (e.g. `toast(msg)`), adapt the call. Check `web/src/lib/toast.tsx` before writing the test's expectations — the test above does not assert on the toast, so only the implementation call must match the real API.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- YamlPreview`
+Expected: PASS.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc -b` → 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/components/YamlPreview.tsx web/src/components/YamlPreview.test.tsx
+git commit -m "feat(web): add shared editable YamlPreview finalizer"
+```
+
+---
+
+## Task 3: Component builder reducer + spec assembly
+
+**Files:**
+- Create: `web/src/pages/component-builder/reducer.ts`
+- Create: `web/src/pages/component-builder/reducer.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `ComponentBuilderState` (below), `initialState()`, `reducer(state, action)`, `canContinue(state): boolean`, `assembleComponentSpec(state): ComponentSpec`.
+  - Actions (discriminated union `Action`): `{type:'SELECT_SCHEMA', schema, version}`, `{type:'SET_AUTH_PROFILE', profile?: AuthenticationProfile}`, `{type:'SET_NAME', name}`, `{type:'SET_NAMESPACE', namespace}`, `{type:'SET_VALUE', field, value}`, `{type:'TOGGLE_SECRET', field, on}`, `{type:'SET_SECRET', field, ref}`, `{type:'ADD_OPTIONAL', field}`, `{type:'REMOVE_OPTIONAL', field}`, `{type:'NEXT'}`, `{type:'BACK'}`.
+- Consumes: `types/component.ts` (`ComponentSpec`, `defaultComponentSpec`), `types/metadata.ts` (`ComponentMetadataSchema`, `AuthenticationProfile`), `lib/validation.ts` (`validateResourceName`), `hooks/useComponentSchemas.ts` (`activeFields`).
+
+State shape:
+```ts
+export interface ComponentBuilderState {
+  activeStep: number // 0..3
+  schema?: ComponentMetadataSchema
+  version: string
+  authProfile?: AuthenticationProfile
+  hasAuthProfiles: boolean // schema has >=1 auth profile
+  name: string
+  namespace: string
+  values: Record<string, string>
+  secretRefs: Record<string, { name: string; key: string }>
+  useSecret: Record<string, boolean>
+  optionalAdded: string[]
+}
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/pages/component-builder/reducer.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { initialState, reducer, canContinue, assembleComponentSpec } from './reducer'
+import type { ComponentMetadataSchema } from '../../types/metadata'
+
+const redis: ComponentMetadataSchema = {
+  type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable',
+  metadata: [{ name: 'redisHost', required: true }, { name: 'enableTLS', type: 'bool' }],
+}
+
+function withSchema() {
+  return reducer(initialState(), { type: 'SELECT_SCHEMA', schema: redis, version: 'v1' })
+}
+
+describe('reducer / canContinue', () => {
+  it('step 0 requires a schema', () => {
+    expect(canContinue(initialState())).toBe(false)
+    expect(canContinue(withSchema())).toBe(true)
+  })
+
+  it('SELECT_SCHEMA advances to step 1 and detects no auth profiles', () => {
+    const s = withSchema()
+    expect(s.activeStep).toBe(1)
+    expect(s.hasAuthProfiles).toBe(false)
+  })
+
+  it('step 2 requires a valid name and all required fields filled', () => {
+    let s = withSchema()
+    s = reducer(s, { type: 'NEXT' }) // 1 -> 2
+    expect(s.activeStep).toBe(2)
+    expect(canContinue(s)).toBe(false) // no name, redisHost empty
+    s = reducer(s, { type: 'SET_NAME', name: 'order-store' })
+    s = reducer(s, { type: 'SET_VALUE', field: 'redisHost', value: 'localhost:6379' })
+    expect(canContinue(s)).toBe(true)
+  })
+
+  it('a required field satisfied by a secret ref also passes the gate', () => {
+    let s = withSchema()
+    s = reducer(s, { type: 'NEXT' })
+    s = reducer(s, { type: 'SET_NAME', name: 'order-store' })
+    s = reducer(s, { type: 'TOGGLE_SECRET', field: 'redisHost', on: true })
+    s = reducer(s, { type: 'SET_SECRET', field: 'redisHost', ref: { name: 'sec', key: 'host' } })
+    expect(canContinue(s)).toBe(true)
+  })
+})
+
+describe('assembleComponentSpec', () => {
+  it('builds spec.type from type.name and emits only populated metadata keys', () => {
+    let s = withSchema()
+    s = reducer(s, { type: 'NEXT' })
+    s = reducer(s, { type: 'SET_NAME', name: 'order-store' })
+    s = reducer(s, { type: 'SET_VALUE', field: 'redisHost', value: 'localhost:6379' })
+    const spec = assembleComponentSpec(s)
+    expect(spec.spec.type).toBe('state.redis')
+    expect(spec.spec.version).toBe('v1')
+    expect(spec.metadata.name).toBe('order-store')
+    expect(spec.spec.metadata).toEqual([{ name: 'redisHost', value: 'localhost:6379' }])
+  })
+
+  it('emits secretKeyRef (never value) when use-secret is on', () => {
+    let s = withSchema()
+    s = reducer(s, { type: 'NEXT' })
+    s = reducer(s, { type: 'SET_NAME', name: 'order-store' })
+    s = reducer(s, { type: 'TOGGLE_SECRET', field: 'redisHost', on: true })
+    s = reducer(s, { type: 'SET_SECRET', field: 'redisHost', ref: { name: 'sec', key: 'host' } })
+    const spec = assembleComponentSpec(s)
+    expect(spec.spec.metadata).toEqual([{ name: 'redisHost', secretKeyRef: { name: 'sec', key: 'host' } }])
+  })
+
+  it('coerces number and bool field values', () => {
+    const schema: ComponentMetadataSchema = {
+      type: 'state', name: 'x', version: 'v1', title: 'X', status: 'stable',
+      metadata: [{ name: 'port', type: 'number', required: true }, { name: 'tls', type: 'bool', required: true }],
+    }
+    let s = reducer(initialState(), { type: 'SELECT_SCHEMA', schema, version: 'v1' })
+    s = reducer(s, { type: 'NEXT' })
+    s = reducer(s, { type: 'SET_NAME', name: 'x1' })
+    s = reducer(s, { type: 'SET_VALUE', field: 'port', value: '6379' })
+    s = reducer(s, { type: 'SET_VALUE', field: 'tls', value: 'true' })
+    const spec = assembleComponentSpec(s)
+    expect(spec.spec.metadata).toEqual([{ name: 'port', value: 6379 }, { name: 'tls', value: true }])
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- component-builder/reducer`
+Expected: FAIL — cannot resolve `./reducer`.
+
+- [ ] **Step 3: Implement**
+
+Create `web/src/pages/component-builder/reducer.ts`:
+```ts
+import { defaultComponentSpec, type ComponentSpec } from '../../types/component'
+import type { ComponentMetadataSchema, AuthenticationProfile, MetadataField } from '../../types/metadata'
+import { validateResourceName } from '../../lib/validation'
+import { activeFields } from '../../hooks/useComponentSchemas'
+
+export interface ComponentBuilderState {
+  activeStep: number
+  schema?: ComponentMetadataSchema
+  version: string
+  authProfile?: AuthenticationProfile
+  hasAuthProfiles: boolean
+  name: string
+  namespace: string
+  values: Record<string, string>
+  secretRefs: Record<string, { name: string; key: string }>
+  useSecret: Record<string, boolean>
+  optionalAdded: string[]
+}
+
+export type Action =
+  | { type: 'SELECT_SCHEMA'; schema: ComponentMetadataSchema; version: string }
+  | { type: 'SET_AUTH_PROFILE'; profile?: AuthenticationProfile }
+  | { type: 'SET_NAME'; name: string }
+  | { type: 'SET_NAMESPACE'; namespace: string }
+  | { type: 'SET_VALUE'; field: string; value: string }
+  | { type: 'TOGGLE_SECRET'; field: string; on: boolean }
+  | { type: 'SET_SECRET'; field: string; ref: { name: string; key: string } }
+  | { type: 'ADD_OPTIONAL'; field: string }
+  | { type: 'REMOVE_OPTIONAL'; field: string }
+  | { type: 'NEXT' }
+  | { type: 'BACK' }
+
+export function initialState(): ComponentBuilderState {
+  return {
+    activeStep: 0,
+    version: '',
+    hasAuthProfiles: false,
+    name: '',
+    namespace: 'default',
+    values: {},
+    secretRefs: {},
+    useSecret: {},
+    optionalAdded: [],
+  }
+}
+
+export function reducer(state: ComponentBuilderState, action: Action): ComponentBuilderState {
+  switch (action.type) {
+    case 'SELECT_SCHEMA': {
+      const hasAuthProfiles = (action.schema.authenticationProfiles?.length ?? 0) > 0
+      return { ...state, schema: action.schema, version: action.version, hasAuthProfiles, activeStep: 1 }
+    }
+    case 'SET_AUTH_PROFILE':
+      return { ...state, authProfile: action.profile }
+    case 'SET_NAME':
+      return { ...state, name: action.name }
+    case 'SET_NAMESPACE':
+      return { ...state, namespace: action.namespace }
+    case 'SET_VALUE':
+      return { ...state, values: { ...state.values, [action.field]: action.value } }
+    case 'TOGGLE_SECRET':
+      return { ...state, useSecret: { ...state.useSecret, [action.field]: action.on } }
+    case 'SET_SECRET':
+      return { ...state, secretRefs: { ...state.secretRefs, [action.field]: action.ref } }
+    case 'ADD_OPTIONAL':
+      return state.optionalAdded.includes(action.field)
+        ? state
+        : { ...state, optionalAdded: [...state.optionalAdded, action.field] }
+    case 'REMOVE_OPTIONAL':
+      return { ...state, optionalAdded: state.optionalAdded.filter((f) => f !== action.field) }
+    case 'NEXT':
+      return { ...state, activeStep: state.activeStep + 1 }
+    case 'BACK':
+      return { ...state, activeStep: Math.max(0, state.activeStep - 1) }
+    default:
+      return state
+  }
+}
+
+// The fields shown on the Configure step: all required + any optional the user added.
+function configureFields(state: ComponentBuilderState): MetadataField[] {
+  if (!state.schema) return []
+  const { required, optional } = activeFields(state.schema, state.authProfile)
+  const added = optional.filter((f) => state.optionalAdded.includes(f.name))
+  return [...required, ...added]
+}
+
+function fieldSatisfied(state: ComponentBuilderState, f: MetadataField): boolean {
+  if (state.useSecret[f.name]) {
+    const ref = state.secretRefs[f.name]
+    return !!ref && ref.name.trim() !== '' && ref.key.trim() !== ''
+  }
+  return (state.values[f.name] ?? '').trim() !== ''
+}
+
+export function canContinue(state: ComponentBuilderState): boolean {
+  switch (state.activeStep) {
+    case 0:
+      return !!state.schema && state.version !== ''
+    case 1:
+      return true // auth profile optional
+    case 2: {
+      if (validateResourceName(state.name) !== null) return false
+      const required = configureFields(state).filter((f) => f.required)
+      return required.every((f) => fieldSatisfied(state, f))
+    }
+    default:
+      return true
+  }
+}
+
+export function assembleComponentSpec(state: ComponentBuilderState): ComponentSpec {
+  const spec = defaultComponentSpec()
+  spec.metadata.name = state.name
+  if (state.namespace.trim() !== '') spec.metadata.namespace = state.namespace
+  spec.spec.type = state.schema ? `${state.schema.type}.${state.schema.name}` : ''
+  spec.spec.version = state.version
+  const byName = new Map(configureFields(state).map((f) => [f.name, f]))
+  spec.spec.metadata = []
+  for (const [name, field] of byName) {
+    if (state.useSecret[name]) {
+      const ref = state.secretRefs[name]
+      if (ref && ref.name && ref.key) spec.spec.metadata.push({ name, secretKeyRef: ref })
+      continue
+    }
+    const raw = (state.values[name] ?? '').trim()
+    if (raw === '') continue
+    let value: string | number | boolean = raw
+    if (field.type === 'number') value = Number(raw)
+    else if (field.type === 'bool') value = raw === 'true'
+    spec.spec.metadata.push({ name, value })
+  }
+  return spec
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- component-builder/reducer`
+Expected: PASS.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc -b` → 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/pages/component-builder/reducer.ts web/src/pages/component-builder/reducer.test.ts
+git commit -m "feat(web): add component builder reducer + spec assembly"
+```
+
+---
+
+## Task 4: Step 0 — Type picker
+
+**Files:**
+- Create: `web/src/pages/component-builder/StepType.tsx`
+- Create: `web/src/pages/component-builder/StepType.test.tsx`
+
+**Interfaces:**
+- Produces: `StepType({ state, dispatch })` where `state: ComponentBuilderState`, `dispatch: (a: Action) => void`. Renders a search box + a list of schemas grouped by type (from `useComponentSchemas`); clicking a schema dispatches `SELECT_SCHEMA` with that schema and its `version`. Uses `.md`/`.complist`/`.ci`/`.ci.sel` classes (master-detail list styling that already exists).
+- Consumes: `useComponentSchemas`, reducer `Action`/`ComponentBuilderState`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/pages/component-builder/StepType.test.tsx`:
+```tsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../test/setup'
+import { QueryProvider, makeQueryClient } from '../../lib/query'
+import { StepType } from './StepType'
+import { initialState } from './reducer'
+
+const bundle = {
+  schemaVersion: '1', date: '2026-01-01',
+  components: [
+    { type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable', metadata: [] },
+    { type: 'pubsub', name: 'kafka', version: 'v1', title: 'Apache Kafka', status: 'stable', metadata: [] },
+  ],
+}
+
+function renderStep(dispatch = vi.fn()) {
+  server.use(http.get('/api/metadata/components', () => HttpResponse.json(bundle)))
+  return render(
+    <QueryProvider client={makeQueryClient()}>
+      <StepType state={initialState()} dispatch={dispatch} />
+    </QueryProvider>,
+  )
+}
+
+describe('StepType', () => {
+  it('lists schemas and filters by search text', async () => {
+    renderStep()
+    await screen.findByText('Redis')
+    expect(screen.getByText('Apache Kafka')).toBeInTheDocument()
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'kafka' } })
+    expect(screen.queryByText('Redis')).not.toBeInTheDocument()
+    expect(screen.getByText('Apache Kafka')).toBeInTheDocument()
+  })
+
+  it('dispatches SELECT_SCHEMA with schema + version on click', async () => {
+    const dispatch = vi.fn()
+    renderStep(dispatch)
+    fireEvent.click(await screen.findByText('Redis'))
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SELECT_SCHEMA', version: 'v1' }),
+    )
+    expect(dispatch.mock.calls[0][0].schema.name).toBe('redis')
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- component-builder/StepType`
+Expected: FAIL — cannot resolve `./StepType`.
+
+- [ ] **Step 3: Implement**
+
+Create `web/src/pages/component-builder/StepType.tsx`:
+```tsx
+import { useState } from 'react'
+import { useComponentSchemas } from '../../hooks/useComponentSchemas'
+import type { Action, ComponentBuilderState } from './reducer'
+
+interface Props {
+  state: ComponentBuilderState
+  dispatch: (a: Action) => void
+}
+
+export function StepType({ state, dispatch }: Props) {
+  const { byType, isLoading } = useComponentSchemas()
+  const [q, setQ] = useState('')
+
+  if (isLoading) return <p className="muted">Loading catalog…</p>
+
+  const query = q.trim().toLowerCase()
+  const types = Object.keys(byType).sort()
+
+  return (
+    <div>
+      <div className="search" style={{ marginBottom: 12 }}>
+        <input
+          type="search"
+          aria-label="Search components"
+          placeholder="Search components…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+      </div>
+      <div className="complist card">
+        {types.map((type) => {
+          const matches = byType[type].filter(
+            (s) => !query || s.title.toLowerCase().includes(query) || s.name.toLowerCase().includes(query),
+          )
+          if (matches.length === 0) return null
+          return (
+            <div key={type} className="sbsection">
+              <div className="sbtitle">{type}</div>
+              {matches.map((s) => {
+                const selected = state.schema?.type === s.type && state.schema?.name === s.name
+                return (
+                  <div
+                    key={`${s.type}.${s.name}`}
+                    className={`ci${selected ? ' sel' : ''}`}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => dispatch({ type: 'SELECT_SCHEMA', schema: s, version: s.version })}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') dispatch({ type: 'SELECT_SCHEMA', schema: s, version: s.version })
+                    }}
+                  >
+                    <span className="cn">{s.title}</span>
+                    <span className="ct">{`${s.type}.${s.name}`} · {s.version} · {s.status}</span>
+                  </div>
+                )
+              })}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- component-builder/StepType`
+Expected: PASS.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc -b` → 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/pages/component-builder/StepType.tsx web/src/pages/component-builder/StepType.test.tsx
+git commit -m "feat(web): add component builder Step 0 (type picker)"
+```
+
+---
+
+## Task 5: Step 1 — Auth profile picker
+
+**Files:**
+- Create: `web/src/pages/component-builder/StepAuth.tsx`
+- Create: `web/src/pages/component-builder/StepAuth.test.tsx`
+
+**Interfaces:**
+- Produces: `StepAuth({ state, dispatch })`. If `state.schema` has no `authenticationProfiles`, renders a "This component has no authentication profiles — continue." message. Otherwise renders a `SelectInput` of profile titles; choosing one dispatches `SET_AUTH_PROFILE` with the matching profile; choosing the blank option dispatches `SET_AUTH_PROFILE` with `undefined`.
+- Consumes: `components/form` `Field`, `SelectInput`; reducer types.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/pages/component-builder/StepAuth.test.tsx`:
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { StepAuth } from './StepAuth'
+import { initialState, reducer } from './reducer'
+import type { ComponentMetadataSchema } from '../../types/metadata'
+
+const withProfiles: ComponentMetadataSchema = {
+  type: 'bindings', name: 'aws.s3', version: 'v1', title: 'AWS S3', status: 'stable', metadata: [],
+  authenticationProfiles: [
+    { title: 'AWS IAM', metadata: [{ name: 'accessKey', required: true }] },
+    { title: 'AWS STS', metadata: [{ name: 'sessionToken', required: true }] },
+  ],
+}
+
+function stateWith(schema: ComponentMetadataSchema) {
+  return reducer(initialState(), { type: 'SELECT_SCHEMA', schema, version: 'v1' })
+}
+
+describe('StepAuth', () => {
+  it('shows a no-profiles message when the schema has none', () => {
+    const schema: ComponentMetadataSchema = { type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable', metadata: [] }
+    render(<StepAuth state={stateWith(schema)} dispatch={vi.fn()} />)
+    expect(screen.getByText(/no authentication profiles/i)).toBeInTheDocument()
+  })
+
+  it('dispatches SET_AUTH_PROFILE with the chosen profile', () => {
+    const dispatch = vi.fn()
+    render(<StepAuth state={stateWith(withProfiles)} dispatch={dispatch} />)
+    fireEvent.change(screen.getByLabelText(/authentication profile/i), { target: { value: 'AWS STS' } })
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SET_AUTH_PROFILE', profile: expect.objectContaining({ title: 'AWS STS' }) }),
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- component-builder/StepAuth`
+Expected: FAIL — cannot resolve `./StepAuth`.
+
+- [ ] **Step 3: Implement**
+
+Create `web/src/pages/component-builder/StepAuth.tsx`:
+```tsx
+import { Field, SelectInput } from '../../components/form'
+import type { Action, ComponentBuilderState } from './reducer'
+
+interface Props {
+  state: ComponentBuilderState
+  dispatch: (a: Action) => void
+}
+
+export function StepAuth({ state, dispatch }: Props) {
+  const profiles = state.schema?.authenticationProfiles ?? []
+  if (profiles.length === 0) {
+    return <p className="muted">This component has no authentication profiles — continue.</p>
+  }
+  return (
+    <Field label="Authentication profile" htmlFor="auth-profile">
+      <SelectInput
+        id="auth-profile"
+        aria-label="Authentication profile"
+        value={state.authProfile?.title ?? ''}
+        options={profiles.map((p) => ({ label: p.title, value: p.title }))}
+        onChange={(title) =>
+          dispatch({ type: 'SET_AUTH_PROFILE', profile: profiles.find((p) => p.title === title) })
+        }
+      />
+    </Field>
+  )
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- component-builder/StepAuth`
+Expected: PASS.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc -b` → 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/pages/component-builder/StepAuth.tsx web/src/pages/component-builder/StepAuth.test.tsx
+git commit -m "feat(web): add component builder Step 1 (auth profile)"
+```
+
+---
+
+## Task 6: Step 2 — Configure (name + metadata editor)
+
+**Files:**
+- Create: `web/src/pages/component-builder/StepConfigure.tsx`
+- Create: `web/src/pages/component-builder/StepConfigure.test.tsx`
+
+**Interfaces:**
+- Produces: `StepConfigure({ state, dispatch })`. Renders: a `Field`+`TextInput` for `name` (with `validateResourceName` error shown), an optional `namespace` `TextInput`; the required + added-optional fields, each row = `Field` (label, `required`, description) + either a "use secret" `Toggle` → two `TextInput`s (secret name + key) OR the value control via reused `MetadataFieldInput`; and a "+ add optional field" `SelectInput` listing not-yet-added optional fields (dispatch `ADD_OPTIONAL`).
+- Consumes: `components/form` (`Field`, `TextInput`, `Toggle`, `SelectInput`), `components/MetadataFieldInput`, `lib/validation` (`validateResourceName`), `hooks/useComponentSchemas` (`activeFields`), reducer types.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/pages/component-builder/StepConfigure.test.tsx`:
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { StepConfigure } from './StepConfigure'
+import { initialState, reducer } from './reducer'
+import type { ComponentMetadataSchema } from '../../types/metadata'
+
+const redis: ComponentMetadataSchema = {
+  type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable',
+  metadata: [{ name: 'redisHost', required: true }, { name: 'enableTLS', type: 'bool' }],
+}
+function configureState() {
+  let s = reducer(initialState(), { type: 'SELECT_SCHEMA', schema: redis, version: 'v1' })
+  s = reducer(s, { type: 'NEXT' }) // -> step 2
+  return s
+}
+
+describe('StepConfigure', () => {
+  it('dispatches SET_NAME and shows a validation error for a bad name', () => {
+    const dispatch = vi.fn()
+    render(<StepConfigure state={configureState()} dispatch={dispatch} />)
+    const name = screen.getByLabelText(/^name/i)
+    fireEvent.change(name, { target: { value: 'Bad Name' } })
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NAME', name: 'Bad Name' })
+  })
+
+  it('renders the required field and dispatches SET_VALUE', () => {
+    const dispatch = vi.fn()
+    render(<StepConfigure state={configureState()} dispatch={dispatch} />)
+    fireEvent.change(screen.getByLabelText('redisHost'), { target: { value: 'localhost:6379' } })
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_VALUE', field: 'redisHost', value: 'localhost:6379' })
+  })
+
+  it('toggling "use secret" for a field dispatches TOGGLE_SECRET', () => {
+    const dispatch = vi.fn()
+    render(<StepConfigure state={configureState()} dispatch={dispatch} />)
+    fireEvent.click(screen.getByLabelText(/use secret for redisHost/i))
+    expect(dispatch).toHaveBeenCalledWith({ type: 'TOGGLE_SECRET', field: 'redisHost', on: true })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- component-builder/StepConfigure`
+Expected: FAIL — cannot resolve `./StepConfigure`.
+
+- [ ] **Step 3: Implement**
+
+Create `web/src/pages/component-builder/StepConfigure.tsx`:
+```tsx
+import { Field, TextInput, Toggle, SelectInput } from '../../components/form'
+import { MetadataFieldInput } from '../../components/MetadataFieldInput'
+import { validateResourceName } from '../../lib/validation'
+import { activeFields } from '../../hooks/useComponentSchemas'
+import type { Action, ComponentBuilderState } from './reducer'
+import type { MetadataField } from '../../types/metadata'
+
+interface Props {
+  state: ComponentBuilderState
+  dispatch: (a: Action) => void
+}
+
+export function StepConfigure({ state, dispatch }: Props) {
+  if (!state.schema) return null
+  const { required, optional } = activeFields(state.schema, state.authProfile)
+  const addedOptional = optional.filter((f) => state.optionalAdded.includes(f.name))
+  const shown: MetadataField[] = [...required, ...addedOptional]
+  const notAdded = optional.filter((f) => !state.optionalAdded.includes(f.name))
+  const nameError = state.name === '' ? null : validateResourceName(state.name)
+
+  return (
+    <div>
+      <Field label="Name" htmlFor="c-name" required error={nameError}>
+        <TextInput id="c-name" aria-label="Name" value={state.name} onChange={(v) => dispatch({ type: 'SET_NAME', name: v })} />
+      </Field>
+      <Field label="Namespace" htmlFor="c-ns">
+        <TextInput id="c-ns" aria-label="Namespace" value={state.namespace} onChange={(v) => dispatch({ type: 'SET_NAMESPACE', namespace: v })} />
+      </Field>
+
+      <div className="sec-title">Metadata</div>
+      {shown.map((f) => {
+        const useSecret = !!state.useSecret[f.name]
+        const ref = state.secretRefs[f.name] ?? { name: '', key: '' }
+        return (
+          <Field key={f.name} label={f.name} required={f.required} error={undefined}>
+            {f.description && <div className="muted" style={{ fontSize: 12, marginBottom: 4 }}>{f.description}</div>}
+            <Toggle
+              label={`Use secret for ${f.name}`}
+              checked={useSecret}
+              onChange={(on) => dispatch({ type: 'TOGGLE_SECRET', field: f.name, on })}
+            />
+            {useSecret ? (
+              <div className="field-row">
+                <TextInput aria-label={`${f.name} secret name`} placeholder="secret name" value={ref.name}
+                  onChange={(v) => dispatch({ type: 'SET_SECRET', field: f.name, ref: { ...ref, name: v } })} />
+                <TextInput aria-label={`${f.name} secret key`} placeholder="secret key" value={ref.key}
+                  onChange={(v) => dispatch({ type: 'SET_SECRET', field: f.name, ref: { ...ref, key: v } })} />
+              </div>
+            ) : (
+              <MetadataFieldInput field={f} value={state.values[f.name] ?? ''} onChange={(v) => dispatch({ type: 'SET_VALUE', field: f.name, value: v })} />
+            )}
+          </Field>
+        )
+      })}
+
+      {notAdded.length > 0 && (
+        <Field label="Add optional field" htmlFor="add-opt">
+          <SelectInput
+            id="add-opt"
+            aria-label="Add optional field"
+            value=""
+            options={notAdded.map((f) => ({ label: f.name, value: f.name }))}
+            onChange={(field) => field && dispatch({ type: 'ADD_OPTIONAL', field })}
+          />
+        </Field>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- component-builder/StepConfigure`
+Expected: PASS.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc -b` → 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/pages/component-builder/StepConfigure.tsx web/src/pages/component-builder/StepConfigure.test.tsx
+git commit -m "feat(web): add component builder Step 2 (configure)"
+```
+
+---
+
+## Task 7: Assemble ComponentBuilder + route + entry button
+
+**Files:**
+- Create: `web/src/pages/component-builder/ComponentBuilder.tsx`
+- Create: `web/src/pages/component-builder/ComponentBuilder.test.tsx`
+- Modify: `web/src/router.tsx`
+- Modify: `web/src/pages/ResourceList.tsx`
+
+**Interfaces:**
+- Consumes: `components/wizard` (`Wizard`, `WizardStep`), `components/YamlPreview`, reducer (`initialState`, `reducer`, `canContinue`, `assembleComponentSpec`), `lib/yaml-emit` (`dumpYaml`), the three step components, `react-router-dom` (`useNavigate`).
+- Produces: `ComponentBuilder` page (default export not required; named export `ComponentBuilder`). Route `/components/new`. A `+ New component` button on the Components `ResourceList`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/pages/component-builder/ComponentBuilder.test.tsx`:
+```tsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
+import { describe, it, expect } from 'vitest'
+import { server } from '../../test/setup'
+import { QueryProvider, makeQueryClient } from '../../lib/query'
+import { ComponentBuilder } from './ComponentBuilder'
+
+const bundle = {
+  schemaVersion: '1', date: '2026-01-01',
+  components: [{ type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable',
+    metadata: [{ name: 'redisHost', required: true }] }],
+}
+
+function renderBuilder() {
+  server.use(http.get('/api/metadata/components', () => HttpResponse.json(bundle)))
+  const router = createMemoryRouter(
+    [{ path: '/components/new', element: <ComponentBuilder /> }, { path: '/components', element: <div>components list</div> }],
+    { initialEntries: ['/components/new'], future: { v7_relativeSplatPath: true } },
+  )
+  return render(<QueryProvider client={makeQueryClient()}><RouterProvider router={router} future={{ v7_startTransition: true }} /></QueryProvider>)
+}
+
+describe('ComponentBuilder', () => {
+  it('walks type → (auth) → configure → preview and shows generated YAML', async () => {
+    renderBuilder()
+    fireEvent.click(await screen.findByText('Redis')) // step 0 -> 1
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // step 1 -> 2 (no profiles)
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'order-store' } })
+    fireEvent.change(screen.getByLabelText('redisHost'), { target: { value: 'localhost:6379' } })
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // step 2 -> 3
+    await waitFor(() => expect(screen.getByRole('textbox', { name: /generated yaml/i })).toHaveValue(
+      expect.stringContaining('type: state.redis'),
+    ))
+    expect(screen.getByRole('textbox', { name: /generated yaml/i })).toHaveValue(expect.stringContaining('name: order-store'))
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- component-builder/ComponentBuilder`
+Expected: FAIL — cannot resolve `./ComponentBuilder`.
+
+- [ ] **Step 3: Implement the page**
+
+Create `web/src/pages/component-builder/ComponentBuilder.tsx`:
+```tsx
+import { useMemo, useReducer, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Wizard, type WizardStep } from '../../components/wizard'
+import { YamlPreview } from '../../components/YamlPreview'
+import { dumpYaml } from '../../lib/yaml-emit'
+import { initialState, reducer, canContinue, assembleComponentSpec } from './reducer'
+import { StepType } from './StepType'
+import { StepAuth } from './StepAuth'
+import { StepConfigure } from './StepConfigure'
+
+export function ComponentBuilder() {
+  const navigate = useNavigate()
+  const [state, dispatch] = useReducer(reducer, undefined, initialState)
+  const [previewEdited, setPreviewEdited] = useState(false)
+
+  const yaml = useMemo(
+    () => (state.activeStep === 3 ? dumpYaml(assembleComponentSpec(state)) : ''),
+    [state],
+  )
+
+  const steps: WizardStep[] = [
+    { label: 'Type', content: <StepType state={state} dispatch={dispatch} /> },
+    { label: 'Auth', content: <StepAuth state={state} dispatch={dispatch} /> },
+    { label: 'Configure', content: <StepConfigure state={state} dispatch={dispatch} /> },
+    {
+      label: 'Preview',
+      content: (
+        <YamlPreview yaml={yaml} filename={`${state.name || 'component'}.yaml`} onEditedChange={setPreviewEdited} />
+      ),
+    },
+  ]
+
+  return (
+    <div className="page">
+      <div className="phead">
+        <div>
+          <h1>New component</h1>
+          <div className="sub">Build a Dapr component YAML to copy or download</div>
+        </div>
+        <button type="button" className="btn ghost" onClick={() => navigate('/components')}>Cancel</button>
+      </div>
+      <div className="card" style={{ padding: 18 }}>
+        <Wizard
+          steps={steps}
+          activeStep={state.activeStep}
+          canContinue={state.activeStep === 3 ? !previewEdited : canContinue(state)}
+          onBack={() => dispatch({ type: 'BACK' })}
+          onContinue={() => dispatch({ type: 'NEXT' })}
+          onFinish={() => navigate('/components')}
+        />
+      </div>
+    </div>
+  )
+}
+```
+Note: on the last step, `canContinue` is gated on `!previewEdited` so Finish is disabled once the user has manually edited the YAML (matches cloudgrid's "Back disabled after edit" intent; here it guards Finish so a hand-edited buffer isn't silently discarded — Download/Copy still act on the buffer). If product prefers Finish always enabled, drop that clause.
+
+- [ ] **Step 4: Add the route**
+
+Modify `web/src/router.tsx`: import `ComponentBuilder` and add the static route BEFORE `components/:name`:
+```tsx
+import { ComponentBuilder } from './pages/component-builder/ComponentBuilder'
+// ...
+      { path: 'components/new', element: <ComponentBuilder /> },
+      { path: 'components', element: <ResourceList kind="component" /> },
+      { path: 'components/:name', element: <ResourceList kind="component" /> },
+```
+(Place `components/new` before `components/:name`.)
+
+- [ ] **Step 5: Add the "+ New component" button on the Components page**
+
+Modify `web/src/pages/ResourceList.tsx`: import `Link` from `react-router-dom` (if not already) and render a button in the `.phead` for the component kind. In each of the three `.phead` blocks (loading, empty, populated), change the header to include the action for `kind === 'component'`:
+```tsx
+        <div className="phead">
+          <div>
+            <h1>{title}</h1>
+            <div className="sub">{sub}</div>
+          </div>
+          {kind === 'component' && (
+            <Link className="btn mono" to="/components/new">+ New component</Link>
+          )}
+        </div>
+```
+Apply this to all three `.phead` occurrences so the button is present in every state. (`.btn.mono` is defined by Plan 1; the button is monochrome, consistent with the builder.)
+
+- [ ] **Step 6: Run the builder test + full suite**
+
+Run: `npm test -- component-builder/ComponentBuilder` → PASS.
+Run: `npm test` → all green (ResourceList tests still pass; if a ResourceList test asserts exact `.phead` contents, update it to allow the new button — prefer role/text queries).
+
+- [ ] **Step 7: Type-check**
+
+Run: `npx tsc -b` → 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/pages/component-builder/ComponentBuilder.tsx web/src/pages/component-builder/ComponentBuilder.test.tsx web/src/router.tsx web/src/pages/ResourceList.tsx
+git commit -m "feat(web): wire Component Builder route + New component button"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Component Builder):**
+- Catalog fetch generalized (all types, auth profiles) → Task 1 (new hook; existing `useComponentCatalog` untouched, documented). ✓
+- 4-step flow: Type → Auth (conditional) → Configure → Preview → Tasks 4, 5, 6, 7. ✓
+- Auth profile seeds required fields → `activeFields` merges profile metadata (Task 1) consumed by reducer/Configure. ✓
+- Metadata editor: value OR secret toggle; field-type control via `MetadataFieldInput`; validation gates Continue → Task 6 + reducer `canContinue`/`fieldSatisfied` (Task 3). ✓
+- Editable YAML finalizer, Copy + Download → Task 2 (`YamlPreview`), used in Task 7. ✓
+- `spec.type = type.name`, version from schema; only-populated-key metadata assembly (no stripper) → Task 3 `assembleComponentSpec`. ✓
+- Routing `/components/new` (before `:name`) + "+ New component" button → Task 7. ✓
+- Monochrome buttons throughout (`.btn.mono`/`.btn.ghost`) → Tasks 2, 7. ✓
+- Dropped connected-mode "Access & Scopes" step (scopes free-text only; v1 omits scopes UI entirely) → not built. ✓
+- Finish/Cancel → `/components` → Task 7. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code + commands with expected results. Two explicit "verify the real API" notes (Task 2 `useToast` shape; Task 7 ResourceList test adjustment) are verification steps, not placeholders.
+
+**Type consistency:** `ComponentBuilderState`/`Action` (Task 3) are consumed identically by Steps (Tasks 4–6) and the page (Task 7). `useComponentSchemas`/`activeFields` (Task 1) are used by StepType, reducer, StepConfigure with the same signatures. `assembleComponentSpec`→`dumpYaml`→`YamlPreview` chain is consistent. `SELECT_SCHEMA` carries `{schema, version}` everywhere.
+
+**Open verification note for implementers:** Task 2 must confirm `useToast()`'s handle API (`toast.show(...)` vs `toast(...)`) against `web/src/lib/toast.tsx` and adapt the call; the test does not depend on it. Task 7 Step 5 may require updating a ResourceList test if it asserts exact header contents.

--- a/docs/superpowers/plans/2026-07-01-builders-03-resiliency.md
+++ b/docs/superpowers/plans/2026-07-01-builders-03-resiliency.md
@@ -979,10 +979,8 @@ describe('ResiliencyBuilder', () => {
     fireEvent.change(screen.getByLabelText(/^timeout policy/i), { target: { value: 'timeout1' } })
     fireEvent.click(screen.getByRole('button', { name: /save/i }))
     fireEvent.click(screen.getByRole('button', { name: /continue/i })) // 2->3
-    await waitFor(() => expect(screen.getByRole('textbox', { name: /generated yaml/i })).toHaveValue(
-      expect.stringContaining('kind: Resiliency'),
-    ))
-    expect(screen.getByRole('textbox', { name: /generated yaml/i })).toHaveValue(expect.stringContaining('name: my-res'))
+    await waitFor(() => expect(document.querySelector('pre.code')?.textContent).toContain('kind: Resiliency'))
+    expect(document.querySelector('pre.code')?.textContent).toContain('name: my-res')
   })
 })
 ```
@@ -995,7 +993,7 @@ Expected: FAIL — cannot resolve modules.
 - [ ] **Step 3: Implement `ResiliencyBuilder.tsx`**
 
 ```tsx
-import { useMemo, useReducer, useState } from 'react'
+import { useMemo, useReducer } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Wizard, type WizardStep } from '../../components/wizard'
 import { YamlPreview } from '../../components/YamlPreview'
@@ -1008,7 +1006,6 @@ import { StepTargets } from './StepTargets'
 export function ResiliencyBuilder() {
   const navigate = useNavigate()
   const [state, dispatch] = useReducer(reducer, undefined, initialState)
-  const [previewEdited, setPreviewEdited] = useState(false)
 
   const yaml = useMemo(
     () => (state.activeStep === 3 ? dumpYaml(assembleResiliency(state.config)) : ''),
@@ -1019,7 +1016,7 @@ export function ResiliencyBuilder() {
     { label: 'General', content: <StepGeneral state={state} dispatch={dispatch} /> },
     { label: 'Policies', content: <StepPolicies state={state} dispatch={dispatch} /> },
     { label: 'Targets', content: <StepTargets state={state} dispatch={dispatch} /> },
-    { label: 'Preview', content: <YamlPreview yaml={yaml} filename={`${state.config.metadata.name || 'resiliency'}.yaml`} onEditedChange={setPreviewEdited} /> },
+    { label: 'Preview', content: <YamlPreview yaml={yaml} filename={`${state.config.metadata.name || 'resiliency'}.yaml`} /> },
   ]
 
   return (
@@ -1035,7 +1032,7 @@ export function ResiliencyBuilder() {
         <Wizard
           steps={steps}
           activeStep={state.activeStep}
-          canContinue={state.activeStep === 3 ? !previewEdited : canContinue(state)}
+          canContinue={canContinue(state)}
           onBack={() => dispatch({ type: 'BACK' })}
           onContinue={() => dispatch({ type: 'NEXT' })}
           onFinish={() => navigate('/resiliency')}
@@ -1121,7 +1118,7 @@ git commit -m "feat(web): wire Resiliency Builder route, landing page, and nav i
 - Policies: timeouts/retries/circuitBreakers, each list + Add dialog; ≥1 policy to proceed → Tasks 2, 4 + reducer gating (Task 1). ✓
 - Targets: apps/actors/components referencing named policies via dropdowns; actors add scope + cache size; components add inbound/outbound; ≥1 target to proceed → Tasks 3, 4 + gating (Task 1). ✓
 - DaprBuiltIn default-policy override table DROPPED for v1 → documented in Global Constraints. ✓
-- Preview: `recursivelyRemoveEmptyValues` over spec, editable, copy/download → Task 1 `assembleResiliency` + Task 5 using `YamlPreview`. ✓
+- Preview: `recursivelyRemoveEmptyValues` over spec, read-only highlighted `<pre>`, copy/download → Task 1 `assembleResiliency` + Task 5 using `YamlPreview`. ✓
 - `grpcStatusCodes` spelling → RetryDialog + types (Task 2). ✓
 - Sequential policy/target naming (`retry1`…) → `nextName` (Task 1), used by StepPolicies. ✓
 - Monochrome buttons in wizard + dialogs (`.btn.mono`/`.btn.ghost`) → Tasks 2, 3, 5. ✓
@@ -1131,6 +1128,6 @@ git commit -m "feat(web): wire Resiliency Builder route, landing page, and nav i
 
 **Placeholder scan:** No TBD/TODO; every code step has complete code + commands with expected results. Two "confirm the real API" notes (Task 5 `useDocumentTitle`; Task 5 `TopNav.test.tsx` update) are verification steps, not placeholders.
 
-**Type consistency:** `ResiliencyState`/`Action` (Task 1) consumed identically by steps (Task 4) and page (Task 5). `RetryPolicy`/`CircuitBreakerPolicy`/`AppTarget`/`ActorTarget`/`ComponentTarget` from `types/resiliency` used consistently across dialogs (Tasks 2–3) and reducer (Task 1). `PolicyNames` shape shared between target dialogs and StepTargets. `UPSERT_*`/`REMOVE_*` action names match between reducer, steps, and tests. `nextName(prefix, existing)` and `assembleResiliency(config)` signatures consistent. `YamlPreview` (Plan 2) prop shape (`yaml`, `filename`, `onEditedChange`) matches usage.
+**Type consistency:** `ResiliencyState`/`Action` (Task 1) consumed identically by steps (Task 4) and page (Task 5). `RetryPolicy`/`CircuitBreakerPolicy`/`AppTarget`/`ActorTarget`/`ComponentTarget` from `types/resiliency` used consistently across dialogs (Tasks 2–3) and reducer (Task 1). `PolicyNames` shape shared between target dialogs and StepTargets. `UPSERT_*`/`REMOVE_*` action names match between reducer, steps, and tests. `nextName(prefix, existing)` and `assembleResiliency(config)` signatures consistent. `YamlPreview` (Plan 2, updated in Plan 2 Task 4) read-only API `({ yaml, filename })` — no `onEditedChange`, no `previewEdited` state. `canContinue(state)` used directly; Finish always enabled on preview step.
 
 **Cross-plan note:** This plan depends on Plan 2's `components/YamlPreview.tsx`. If Plans are executed out of order, Task 5 (and its test) will fail until `YamlPreview` exists — execute Plan 2 first.

--- a/docs/superpowers/plans/2026-07-01-builders-03-resiliency.md
+++ b/docs/superpowers/plans/2026-07-01-builders-03-resiliency.md
@@ -14,7 +14,7 @@
 ## Global Constraints
 
 - **No new dependencies.** No MUI/react-hook-form/Yup. Controlled components; vanilla CSS theme tokens.
-- **Wizard/dialog buttons monochrome** (`.btn.mono` primary / `.btn.ghost` secondary); never green `.btn.primary`.
+- **Wizard/dialog buttons use the transparent `.btn.ghost` style** (disabled = light border + faint text); never green `.btn.primary` or filled `.btn.mono`.
 - **`grpcStatusCodes`** spelling (matches `types/resiliency.ts`; cloudgrid's `grcpStatusCodes` typo is NOT used).
 - **Emit rule:** clean ONLY `spec` with `recursivelyRemoveEmptyValues` before `dumpYaml`; assemble the emit object with `metadata.name` (+ `namespace` only if non-empty); omit empty `scopes`.
 - **Policy/target naming:** sequential defaults `timeout1`/`retry1`/`circuitBreaker1` etc. (count of existing + 1), editable in the dialog.
@@ -381,7 +381,7 @@ function DialogShell({ open, title, onClose, onSave, canSave, children }: {
       {children}
       <div className="modal-actions">
         <button type="button" className="btn ghost" onClick={onClose}>Cancel</button>
-        <button type="button" className="btn mono" disabled={!canSave} onClick={onSave}>Save</button>
+        <button type="button" className="btn ghost" disabled={!canSave} onClick={onSave}>Save</button>
       </div>
     </Modal>
   )
@@ -609,7 +609,7 @@ function Shell({ open, title, onClose, onSave, canSave, children }: {
       {children}
       <div className="modal-actions">
         <button type="button" className="btn ghost" onClick={onClose}>Cancel</button>
-        <button type="button" className="btn mono" disabled={!canSave} onClick={onSave}>Save</button>
+        <button type="button" className="btn ghost" disabled={!canSave} onClick={onSave}>Save</button>
       </div>
     </Modal>
   )
@@ -1058,7 +1058,7 @@ export function Resiliency() {
           <h1>Resiliency</h1>
           <div className="sub">Dapr resiliency policies</div>
         </div>
-        <Link className="btn mono" to="/resiliency/new">+ New resiliency policy</Link>
+        <Link className="btn ghost" to="/resiliency/new">+ New resiliency policy</Link>
       </div>
       <div className="md">
         <div className="card complist" />

--- a/docs/superpowers/plans/2026-07-01-builders-03-resiliency.md
+++ b/docs/superpowers/plans/2026-07-01-builders-03-resiliency.md
@@ -1,0 +1,1136 @@
+# Builders — Plan 3: Resiliency Builder Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the Resiliency Builder — a 4-step wizard at `/resiliency/new` that generates a Dapr Resiliency YAML (copy/download) — plus a "Resiliency" nav item and a create-only `/resiliency` landing page.
+
+**Architecture:** Builds on Plan 1 (`lib/yaml-emit`, `lib/validation`, `lib/download`, `types/resiliency`, `components/form/*`, `components/wizard/*`, `components/Modal`) and reuses Plan 2's `components/YamlPreview`. State is a typed `useReducer` holding a `DaprResiliency` config; policies and targets are added/edited via `Modal` dialogs and rendered as named lists. Preview runs `recursivelyRemoveEmptyValues` over `spec` before emitting (per spec).
+
+**Tech Stack:** React 19, TS, Vite, React Router v6, Vitest + Testing Library. No new dependencies.
+
+**Prereqs:** Plan 1 complete; Plan 2 complete (provides `components/YamlPreview.tsx`).
+**Source spec:** `docs/superpowers/specs/2026-06-28-component-resiliency-builders-design.md`
+
+## Global Constraints
+
+- **No new dependencies.** No MUI/react-hook-form/Yup. Controlled components; vanilla CSS theme tokens.
+- **Wizard/dialog buttons monochrome** (`.btn.mono` primary / `.btn.ghost` secondary); never green `.btn.primary`.
+- **`grpcStatusCodes`** spelling (matches `types/resiliency.ts`; cloudgrid's `grcpStatusCodes` typo is NOT used).
+- **Emit rule:** clean ONLY `spec` with `recursivelyRemoveEmptyValues` before `dumpYaml`; assemble the emit object with `metadata.name` (+ `namespace` only if non-empty); omit empty `scopes`.
+- **Policy/target naming:** sequential defaults `timeout1`/`retry1`/`circuitBreaker1` etc. (count of existing + 1), editable in the dialog.
+- **v1 scope (YAGNI, documented):** DROP cloudgrid's connected-mode `ResiliencyAccess` (cluster/namespace/scope pickers) — step 0 is just the name. DROP the read-only "DaprBuiltIn default-policy overrides" table on the Targets step (advanced; future enhancement). Targets step gates on **≥1 target of any type**.
+- **Reuse** `components/Modal.tsx`, Plan 1 `components/form/*` + `components/wizard/*`, Plan 2 `components/YamlPreview.tsx`, `lib/validation`, `lib/yaml-emit`.
+- **Tests:** Vitest + Testing Library, colocated. Run `npx tsc -b` before every commit. All `npm`/`npx` from `web/`.
+- **On finish or cancel:** navigate to `/resiliency`.
+
+---
+
+## File Structure
+
+- Create `web/src/pages/resiliency-builder/reducer.ts` — state, actions, reducer, gating, name-gen, `assembleResiliency`.
+- Create `web/src/pages/resiliency-builder/NamedList.tsx` — reusable "named entries + Add/Remove" list.
+- Create `web/src/pages/resiliency-builder/policyDialogs.tsx` — `TimeoutDialog`, `RetryDialog`, `CircuitBreakerDialog`.
+- Create `web/src/pages/resiliency-builder/targetDialogs.tsx` — `AppTargetDialog`, `ActorTargetDialog`, `ComponentTargetDialog`.
+- Create `web/src/pages/resiliency-builder/StepGeneral.tsx`, `StepPolicies.tsx`, `StepTargets.tsx`.
+- Create `web/src/pages/resiliency-builder/ResiliencyBuilder.tsx` — assembles wizard + preview.
+- Create `web/src/pages/Resiliency.tsx` — create-only landing page.
+- Modify `web/src/router.tsx` — add `resiliency` and `resiliency/new` routes.
+- Modify `web/src/components/TopNav.tsx` — add the `Resiliency` nav item.
+
+---
+
+## Task 1: Resiliency reducer + assembly + gating
+
+**Files:**
+- Create: `web/src/pages/resiliency-builder/reducer.ts`
+- Create: `web/src/pages/resiliency-builder/reducer.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `ResiliencyState = { config: DaprResiliency; activeStep: number }`, `initialState()`, `reducer(state, action)`, `canContinue(state): boolean`, `assembleResiliency(config: DaprResiliency): Record<string, unknown>`, and `nextName(prefix: string, existing: Record<string, unknown>): string`.
+  - Actions (`Action`): `{type:'SET_NAME',name}`, `{type:'SET_NAMESPACE',namespace}`, `{type:'UPSERT_TIMEOUT',name,duration}`, `{type:'REMOVE_TIMEOUT',name}`, `{type:'UPSERT_RETRY',name,policy}`, `{type:'REMOVE_RETRY',name}`, `{type:'UPSERT_CB',name,policy}`, `{type:'REMOVE_CB',name}`, `{type:'UPSERT_APP',name,target}`, `{type:'REMOVE_APP',name}`, `{type:'UPSERT_ACTOR',name,target}`, `{type:'REMOVE_ACTOR',name}`, `{type:'UPSERT_COMPONENT',name,target}`, `{type:'REMOVE_COMPONENT',name}`, `{type:'NEXT'}`, `{type:'BACK'}`.
+- Consumes: `types/resiliency.ts` (all types + `defaultResiliencyConfig`), `lib/validation.ts` (`validateResourceName`), `lib/yaml-emit.ts` (`recursivelyRemoveEmptyValues`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/pages/resiliency-builder/reducer.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { initialState, reducer, canContinue, assembleResiliency, nextName } from './reducer'
+
+describe('nextName', () => {
+  it('produces sequential names by count of existing keys', () => {
+    expect(nextName('retry', {})).toBe('retry1')
+    expect(nextName('retry', { retry1: {}, retry2: {} })).toBe('retry3')
+  })
+})
+
+describe('canContinue', () => {
+  it('step 0 needs a valid name', () => {
+    let s = initialState()
+    expect(canContinue(s)).toBe(false)
+    s = reducer(s, { type: 'SET_NAME', name: 'my-resiliency' })
+    expect(canContinue(s)).toBe(true)
+  })
+  it('step 1 needs at least one policy of any kind', () => {
+    let s = reducer(initialState(), { type: 'SET_NAME', name: 'r' })
+    s = reducer(s, { type: 'NEXT' }) // -> 1
+    expect(canContinue(s)).toBe(false)
+    s = reducer(s, { type: 'UPSERT_TIMEOUT', name: 'timeout1', duration: '30s' })
+    expect(canContinue(s)).toBe(true)
+  })
+  it('step 2 needs at least one target of any kind', () => {
+    let s = reducer(initialState(), { type: 'SET_NAME', name: 'r' })
+    s = reducer(s, { type: 'UPSERT_TIMEOUT', name: 'timeout1', duration: '30s' })
+    s = reducer(s, { type: 'NEXT' }) // 0->1
+    s = reducer(s, { type: 'NEXT' }) // 1->2
+    expect(canContinue(s)).toBe(false)
+    s = reducer(s, { type: 'UPSERT_APP', name: 'orders', target: { timeout: 'timeout1' } })
+    expect(canContinue(s)).toBe(true)
+  })
+})
+
+describe('reducer upserts/removes', () => {
+  it('adds and removes a retry policy', () => {
+    let s = reducer(initialState(), { type: 'UPSERT_RETRY', name: 'retry1', policy: { policy: 'constant', duration: '5s', maxRetries: 3 } })
+    expect(s.config.spec.policies.retries.retry1.duration).toBe('5s')
+    s = reducer(s, { type: 'REMOVE_RETRY', name: 'retry1' })
+    expect(s.config.spec.policies.retries.retry1).toBeUndefined()
+  })
+})
+
+describe('assembleResiliency', () => {
+  it('cleans spec, keeps name, omits empty namespace/scopes', () => {
+    let s = reducer(initialState(), { type: 'SET_NAME', name: 'r' })
+    s = reducer(s, { type: 'UPSERT_RETRY', name: 'retry1', policy: { policy: 'constant', duration: '5s', maxRetries: 3, maxInterval: '', matching: { httpStatusCodes: '', grpcStatusCodes: '' } } })
+    const out = assembleResiliency(s.config) as any
+    expect(out.metadata).toEqual({ name: 'r' }) // no empty namespace
+    expect(out.scopes).toBeUndefined()
+    // empty maxInterval + empty matching pruned by recursivelyRemoveEmptyValues:
+    expect(out.spec.policies.retries.retry1).toEqual({ policy: 'constant', duration: '5s', maxRetries: 3 })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- resiliency-builder/reducer`
+Expected: FAIL — cannot resolve `./reducer`.
+
+- [ ] **Step 3: Implement**
+
+Create `web/src/pages/resiliency-builder/reducer.ts`:
+```ts
+import {
+  defaultResiliencyConfig, type DaprResiliency, type RetryPolicy, type CircuitBreakerPolicy,
+  type AppTarget, type ActorTarget, type ComponentTarget,
+} from '../../types/resiliency'
+import { validateResourceName } from '../../lib/validation'
+import { recursivelyRemoveEmptyValues } from '../../lib/yaml-emit'
+
+export interface ResiliencyState {
+  config: DaprResiliency
+  activeStep: number
+}
+
+export type Action =
+  | { type: 'SET_NAME'; name: string }
+  | { type: 'SET_NAMESPACE'; namespace: string }
+  | { type: 'UPSERT_TIMEOUT'; name: string; duration: string }
+  | { type: 'REMOVE_TIMEOUT'; name: string }
+  | { type: 'UPSERT_RETRY'; name: string; policy: RetryPolicy }
+  | { type: 'REMOVE_RETRY'; name: string }
+  | { type: 'UPSERT_CB'; name: string; policy: CircuitBreakerPolicy }
+  | { type: 'REMOVE_CB'; name: string }
+  | { type: 'UPSERT_APP'; name: string; target: AppTarget }
+  | { type: 'REMOVE_APP'; name: string }
+  | { type: 'UPSERT_ACTOR'; name: string; target: ActorTarget }
+  | { type: 'REMOVE_ACTOR'; name: string }
+  | { type: 'UPSERT_COMPONENT'; name: string; target: ComponentTarget }
+  | { type: 'REMOVE_COMPONENT'; name: string }
+  | { type: 'NEXT' }
+  | { type: 'BACK' }
+
+export function initialState(): ResiliencyState {
+  return { config: defaultResiliencyConfig(), activeStep: 0 }
+}
+
+/** `retry1`, `retry2`, ... based on the count of existing keys (matches cloudgrid). */
+export function nextName(prefix: string, existing: Record<string, unknown>): string {
+  return `${prefix}${Object.keys(existing).length + 1}`
+}
+
+function withoutKey<T>(map: Record<string, T>, key: string): Record<string, T> {
+  const next = { ...map }
+  delete next[key]
+  return next
+}
+
+export function reducer(state: ResiliencyState, action: Action): ResiliencyState {
+  const cfg = state.config
+  const pol = cfg.spec.policies
+  const tgt = cfg.spec.targets
+  const set = (patch: Partial<DaprResiliency['spec']>): ResiliencyState => ({
+    ...state,
+    config: { ...cfg, spec: { ...cfg.spec, ...patch } },
+  })
+  switch (action.type) {
+    case 'SET_NAME':
+      return { ...state, config: { ...cfg, metadata: { ...cfg.metadata, name: action.name } } }
+    case 'SET_NAMESPACE':
+      return { ...state, config: { ...cfg, metadata: { ...cfg.metadata, namespace: action.namespace } } }
+    case 'UPSERT_TIMEOUT':
+      return set({ policies: { ...pol, timeouts: { ...pol.timeouts, [action.name]: action.duration } } })
+    case 'REMOVE_TIMEOUT':
+      return set({ policies: { ...pol, timeouts: withoutKey(pol.timeouts, action.name) } })
+    case 'UPSERT_RETRY':
+      return set({ policies: { ...pol, retries: { ...pol.retries, [action.name]: action.policy } } })
+    case 'REMOVE_RETRY':
+      return set({ policies: { ...pol, retries: withoutKey(pol.retries, action.name) } })
+    case 'UPSERT_CB':
+      return set({ policies: { ...pol, circuitBreakers: { ...pol.circuitBreakers, [action.name]: action.policy } } })
+    case 'REMOVE_CB':
+      return set({ policies: { ...pol, circuitBreakers: withoutKey(pol.circuitBreakers, action.name) } })
+    case 'UPSERT_APP':
+      return set({ targets: { ...tgt, apps: { ...(tgt.apps ?? {}), [action.name]: action.target } } })
+    case 'REMOVE_APP':
+      return set({ targets: { ...tgt, apps: withoutKey(tgt.apps ?? {}, action.name) } })
+    case 'UPSERT_ACTOR':
+      return set({ targets: { ...tgt, actors: { ...(tgt.actors ?? {}), [action.name]: action.target } } })
+    case 'REMOVE_ACTOR':
+      return set({ targets: { ...tgt, actors: withoutKey(tgt.actors ?? {}, action.name) } })
+    case 'UPSERT_COMPONENT':
+      return set({ targets: { ...tgt, components: { ...(tgt.components ?? {}), [action.name]: action.target } } })
+    case 'REMOVE_COMPONENT':
+      return set({ targets: { ...tgt, components: withoutKey(tgt.components ?? {}, action.name) } })
+    case 'NEXT':
+      return { ...state, activeStep: state.activeStep + 1 }
+    case 'BACK':
+      return { ...state, activeStep: Math.max(0, state.activeStep - 1) }
+    default:
+      return state
+  }
+}
+
+function countAll(map: Record<string, unknown> | undefined): number {
+  return map ? Object.keys(map).length : 0
+}
+
+export function canContinue(state: ResiliencyState): boolean {
+  const { config, activeStep } = state
+  const { policies, targets } = config.spec
+  switch (activeStep) {
+    case 0:
+      return validateResourceName(config.metadata.name) === null
+    case 1:
+      return countAll(policies.timeouts) + countAll(policies.retries) + countAll(policies.circuitBreakers) > 0
+    case 2:
+      return countAll(targets.apps) + countAll(targets.actors) + countAll(targets.components) > 0
+    default:
+      return true
+  }
+}
+
+/** Build the emit object: name (+ namespace if set), no empty scopes, spec cleaned. */
+export function assembleResiliency(config: DaprResiliency): Record<string, unknown> {
+  const metadata: Record<string, unknown> = { name: config.metadata.name }
+  if ((config.metadata.namespace ?? '').trim() !== '') metadata.namespace = config.metadata.namespace
+  return {
+    apiVersion: config.apiVersion,
+    kind: config.kind,
+    metadata,
+    spec: recursivelyRemoveEmptyValues(config.spec),
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- resiliency-builder/reducer`
+Expected: PASS.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc -b` → 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/pages/resiliency-builder/reducer.ts web/src/pages/resiliency-builder/reducer.test.ts
+git commit -m "feat(web): add resiliency builder reducer + assembly + gating"
+```
+
+---
+
+## Task 2: NamedList + policy dialogs
+
+**Files:**
+- Create: `web/src/pages/resiliency-builder/NamedList.tsx`
+- Create: `web/src/pages/resiliency-builder/policyDialogs.tsx`
+- Create: `web/src/pages/resiliency-builder/policyDialogs.test.tsx`
+
+**Interfaces:**
+- Produces:
+  - `NamedList({ title, names, onAdd, onRemove })` — renders a section titled `title`, a chip/row per `name` with a remove button (`aria-label={`Remove ${name}`}`), and an "Add" button (`.btn.ghost`, `aria-label={`Add ${title}`}`) calling `onAdd`.
+  - `TimeoutDialog({ open, initialName, onClose, onSave })` — `onSave(name: string, duration: string)`. Fields: name (`validateResourceName`) + duration (`validateGoDuration`). Confirm disabled until both valid.
+  - `RetryDialog({ open, initialName, onClose, onSave })` — `onSave(name, policy: RetryPolicy)`. Fields: name; policy `constant|exponential` (SelectInput); duration (constant) / maxInterval (exponential), both go-duration; maxRetries (integer, default -1); matching.httpStatusCodes + matching.grpcStatusCodes (`validateStatusCodes`).
+  - `CircuitBreakerDialog({ open, initialName, onClose, onSave })` — `onSave(name, policy: CircuitBreakerPolicy)`. Fields: name; maxRequests (integer); timeout (go-duration); trip (text, CEL); interval (go-duration).
+- Consumes: `components/Modal`, `components/form/*`, `lib/validation`, `types/resiliency`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/pages/resiliency-builder/policyDialogs.test.tsx`:
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { NamedList, TimeoutDialog, RetryDialog } from './policyDialogs'
+
+describe('NamedList', () => {
+  it('renders names, add, and remove', () => {
+    const onAdd = vi.fn(); const onRemove = vi.fn()
+    render(<NamedList title="Timeouts" names={['timeout1']} onAdd={onAdd} onRemove={onRemove} />)
+    expect(screen.getByText('timeout1')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /add timeouts/i }))
+    expect(onAdd).toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: /remove timeout1/i }))
+    expect(onRemove).toHaveBeenCalledWith('timeout1')
+  })
+})
+
+describe('TimeoutDialog', () => {
+  it('saves a valid name + duration and blocks invalid duration', () => {
+    const onSave = vi.fn(); const onClose = vi.fn()
+    render(<TimeoutDialog open initialName="timeout1" onClose={onClose} onSave={onSave} />)
+    const confirm = screen.getByRole('button', { name: /save/i })
+    fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: 'nope' } })
+    expect(confirm).toBeDisabled()
+    fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: '30s' } })
+    expect(confirm).toBeEnabled()
+    fireEvent.click(confirm)
+    expect(onSave).toHaveBeenCalledWith('timeout1', '30s')
+  })
+})
+
+describe('RetryDialog', () => {
+  it('saves a constant retry policy', () => {
+    const onSave = vi.fn()
+    render(<RetryDialog open initialName="retry1" onClose={vi.fn()} onSave={onSave} />)
+    fireEvent.change(screen.getByLabelText(/^duration/i), { target: { value: '5s' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(onSave).toHaveBeenCalledWith('retry1', expect.objectContaining({ policy: 'constant', duration: '5s' }))
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- resiliency-builder/policyDialogs`
+Expected: FAIL — cannot resolve `./policyDialogs`.
+
+- [ ] **Step 3: Implement `NamedList.tsx`**
+
+Create `web/src/pages/resiliency-builder/NamedList.tsx`:
+```tsx
+interface NamedListProps {
+  title: string
+  names: string[]
+  onAdd: () => void
+  onRemove: (name: string) => void
+}
+
+export function NamedList({ title, names, onAdd, onRemove }: NamedListProps) {
+  return (
+    <div className="sbsection">
+      <div className="sech">
+        {title}
+        <button type="button" className="btn ghost" style={{ marginLeft: 'auto' }} aria-label={`Add ${title}`} onClick={onAdd}>
+          + Add
+        </button>
+      </div>
+      {names.length === 0 ? (
+        <p className="none">None yet.</p>
+      ) : (
+        names.map((name) => (
+          <div key={name} className="chip k" style={{ marginRight: 6, marginBottom: 6 }}>
+            <b>{name}</b>
+            <button type="button" className="copybtn" aria-label={`Remove ${name}`} onClick={() => onRemove(name)}>✕</button>
+          </div>
+        ))
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Implement `policyDialogs.tsx`**
+
+Create `web/src/pages/resiliency-builder/policyDialogs.tsx`:
+```tsx
+import { useState } from 'react'
+import { Modal } from '../../components/Modal'
+import { Field, TextInput, NumberInput, SelectInput } from '../../components/form'
+import { validateResourceName, validateGoDuration, validateStatusCodes, integerError } from '../../lib/validation'
+import type { RetryPolicy, CircuitBreakerPolicy } from '../../types/resiliency'
+export { NamedList } from './NamedList'
+
+function DialogShell({ open, title, onClose, onSave, canSave, children }: {
+  open: boolean; title: string; onClose: () => void; onSave: () => void; canSave: boolean; children: React.ReactNode
+}) {
+  return (
+    <Modal open={open} title={title} onClose={onClose}>
+      {children}
+      <div className="modal-actions">
+        <button type="button" className="btn ghost" onClick={onClose}>Cancel</button>
+        <button type="button" className="btn mono" disabled={!canSave} onClick={onSave}>Save</button>
+      </div>
+    </Modal>
+  )
+}
+
+export function TimeoutDialog({ open, initialName, onClose, onSave }: {
+  open: boolean; initialName: string; onClose: () => void; onSave: (name: string, duration: string) => void
+}) {
+  const [name, setName] = useState(initialName)
+  const [duration, setDuration] = useState('')
+  const nameErr = name === '' ? 'Name is required' : validateResourceName(name)
+  const durOk = duration !== '' && validateGoDuration(duration).valid
+  return (
+    <DialogShell open={open} title="Add timeout policy" onClose={onClose} canSave={!nameErr && durOk}
+      onSave={() => onSave(name, duration)}>
+      <Field label="Name" required error={name === '' ? null : nameErr}>
+        <TextInput aria-label="Timeout name" value={name} onChange={setName} />
+      </Field>
+      <Field label="Duration" required error={duration === '' ? null : (durOk ? null : validateGoDuration(duration).error)}>
+        <TextInput aria-label="Duration" placeholder="30s" value={duration} onChange={setDuration} />
+      </Field>
+    </DialogShell>
+  )
+}
+
+export function RetryDialog({ open, initialName, onClose, onSave }: {
+  open: boolean; initialName: string; onClose: () => void; onSave: (name: string, policy: RetryPolicy) => void
+}) {
+  const [name, setName] = useState(initialName)
+  const [policy, setPolicy] = useState<'constant' | 'exponential'>('constant')
+  const [duration, setDuration] = useState('5s')
+  const [maxInterval, setMaxInterval] = useState('60s')
+  const [maxRetries, setMaxRetries] = useState('-1')
+  const [http, setHttp] = useState('')
+  const [grpc, setGrpc] = useState('')
+  const nameErr = name === '' ? 'Name is required' : validateResourceName(name)
+  const durField = policy === 'constant' ? duration : maxInterval
+  const durOk = validateGoDuration(durField).valid
+  const numOk = integerError(maxRetries) === null
+  const codesOk = validateStatusCodes(http) === null && validateStatusCodes(grpc) === null
+  const canSave = !nameErr && durOk && numOk && codesOk
+  function save() {
+    const p: RetryPolicy = {
+      policy,
+      maxRetries: maxRetries === '' ? undefined : Number(maxRetries),
+      matching: { httpStatusCodes: http, grpcStatusCodes: grpc },
+    }
+    if (policy === 'constant') p.duration = duration
+    else p.maxInterval = maxInterval
+    onSave(name, p)
+  }
+  return (
+    <DialogShell open={open} title="Add retry policy" onClose={onClose} canSave={canSave} onSave={save}>
+      <Field label="Name" required error={name === '' ? null : nameErr}>
+        <TextInput aria-label="Retry name" value={name} onChange={setName} />
+      </Field>
+      <Field label="Policy" required>
+        <SelectInput aria-label="Retry policy type" value={policy}
+          options={[{ label: 'constant', value: 'constant' }, { label: 'exponential', value: 'exponential' }]}
+          onChange={(v) => setPolicy(v === 'exponential' ? 'exponential' : 'constant')} />
+      </Field>
+      {policy === 'constant' ? (
+        <Field label="Duration" required error={durOk ? null : validateGoDuration(duration).error}>
+          <TextInput aria-label="Duration" placeholder="5s" value={duration} onChange={setDuration} />
+        </Field>
+      ) : (
+        <Field label="Max interval" required error={durOk ? null : validateGoDuration(maxInterval).error}>
+          <TextInput aria-label="Max interval" placeholder="60s" value={maxInterval} onChange={setMaxInterval} />
+        </Field>
+      )}
+      <Field label="Max retries" error={numOk ? null : 'Must be an integer'}>
+        <NumberInput aria-label="Max retries" value={maxRetries} onChange={setMaxRetries} />
+      </Field>
+      <Field label="HTTP status codes" error={validateStatusCodes(http)}>
+        <TextInput aria-label="HTTP status codes" placeholder="429,500-504" value={http} onChange={setHttp} />
+      </Field>
+      <Field label="gRPC status codes" error={validateStatusCodes(grpc)}>
+        <TextInput aria-label="gRPC status codes" placeholder="4,8,14" value={grpc} onChange={setGrpc} />
+      </Field>
+    </DialogShell>
+  )
+}
+
+export function CircuitBreakerDialog({ open, initialName, onClose, onSave }: {
+  open: boolean; initialName: string; onClose: () => void; onSave: (name: string, policy: CircuitBreakerPolicy) => void
+}) {
+  const [name, setName] = useState(initialName)
+  const [maxRequests, setMaxRequests] = useState('')
+  const [timeout, setTimeout] = useState('')
+  const [trip, setTrip] = useState('')
+  const [interval, setInterval] = useState('')
+  const nameErr = name === '' ? 'Name is required' : validateResourceName(name)
+  const numOk = integerError(maxRequests) === null
+  const toOk = validateGoDuration(timeout).valid
+  const ivOk = validateGoDuration(interval).valid
+  const canSave = !nameErr && numOk && toOk && ivOk
+  function save() {
+    onSave(name, {
+      maxRequests: maxRequests === '' ? undefined : Number(maxRequests),
+      timeout, trip, interval,
+    })
+  }
+  return (
+    <DialogShell open={open} title="Add circuit breaker policy" onClose={onClose} canSave={canSave} onSave={save}>
+      <Field label="Name" required error={name === '' ? null : nameErr}>
+        <TextInput aria-label="Circuit breaker name" value={name} onChange={setName} />
+      </Field>
+      <Field label="Max requests" error={numOk ? null : 'Must be an integer'}>
+        <NumberInput aria-label="Max requests" value={maxRequests} onChange={setMaxRequests} />
+      </Field>
+      <Field label="Timeout" error={timeout === '' ? null : (toOk ? null : validateGoDuration(timeout).error)}>
+        <TextInput aria-label="Timeout" placeholder="30s" value={timeout} onChange={setTimeout} />
+      </Field>
+      <Field label="Trip (CEL)">
+        <TextInput aria-label="Trip" placeholder="consecutiveFailures >= 5" value={trip} onChange={setTrip} />
+      </Field>
+      <Field label="Interval" error={interval === '' ? null : (ivOk ? null : validateGoDuration(interval).error)}>
+        <TextInput aria-label="Interval" placeholder="8s" value={interval} onChange={setInterval} />
+      </Field>
+    </DialogShell>
+  )
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npm test -- resiliency-builder/policyDialogs`
+Expected: PASS.
+
+- [ ] **Step 6: Type-check**
+
+Run: `npx tsc -b` → 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/pages/resiliency-builder/NamedList.tsx web/src/pages/resiliency-builder/policyDialogs.tsx web/src/pages/resiliency-builder/policyDialogs.test.tsx
+git commit -m "feat(web): add resiliency NamedList + policy dialogs"
+```
+
+---
+
+## Task 3: Target dialogs
+
+**Files:**
+- Create: `web/src/pages/resiliency-builder/targetDialogs.tsx`
+- Create: `web/src/pages/resiliency-builder/targetDialogs.test.tsx`
+
+**Interfaces:**
+- Produces:
+  - `AppTargetDialog({ open, policies, onClose, onSave })` — `onSave(name, target: AppTarget)`. Fields: target name (`validateResourceName`) + `timeout`/`retry`/`circuitBreaker` SelectInputs sourced from `policies` (below). Confirm disabled until name valid AND ≥1 policy reference chosen.
+  - `ActorTargetDialog({ open, policies, onClose, onSave })` — like App plus `circuitBreakerScope` (`type|id|both`, shown when circuitBreaker set) and `circuitBreakerCacheSize` (integer, shown when circuitBreaker set).
+  - `ComponentTargetDialog({ open, policies, onClose, onSave })` — `onSave(name, target: ComponentTarget)`. Fields: name + direction (`outbound|inbound|both`) + timeout/retry/circuitBreaker for the applicable direction(s); ≥1 policy ref in the applicable direction required.
+  - Shared prop `policies: { timeouts: string[]; retries: string[]; circuitBreakers: string[] }` (the named policies defined on step 1).
+- Consumes: `components/Modal`, `components/form/*`, `lib/validation`, `types/resiliency`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/pages/resiliency-builder/targetDialogs.test.tsx`:
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { AppTargetDialog, ComponentTargetDialog } from './targetDialogs'
+
+const policies = { timeouts: ['timeout1'], retries: ['retry1'], circuitBreakers: ['cb1'] }
+
+describe('AppTargetDialog', () => {
+  it('requires a name and at least one policy reference', () => {
+    const onSave = vi.fn()
+    render(<AppTargetDialog open policies={policies} onClose={vi.fn()} onSave={onSave} />)
+    const save = screen.getByRole('button', { name: /save/i })
+    expect(save).toBeDisabled()
+    fireEvent.change(screen.getByLabelText(/app id/i), { target: { value: 'orders' } })
+    expect(save).toBeDisabled() // no policy chosen yet
+    fireEvent.change(screen.getByLabelText(/^timeout/i), { target: { value: 'timeout1' } })
+    expect(save).toBeEnabled()
+    fireEvent.click(save)
+    expect(onSave).toHaveBeenCalledWith('orders', expect.objectContaining({ timeout: 'timeout1' }))
+  })
+})
+
+describe('ComponentTargetDialog', () => {
+  it('saves an outbound-only component target', () => {
+    const onSave = vi.fn()
+    render(<ComponentTargetDialog open policies={policies} onClose={vi.fn()} onSave={onSave} />)
+    fireEvent.change(screen.getByLabelText(/component name/i), { target: { value: 'statestore' } })
+    fireEvent.change(screen.getByLabelText(/direction/i), { target: { value: 'outbound' } })
+    fireEvent.change(screen.getByLabelText(/^retry/i), { target: { value: 'retry1' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(onSave).toHaveBeenCalledWith('statestore', { outbound: { retry: 'retry1' } })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- resiliency-builder/targetDialogs`
+Expected: FAIL — cannot resolve `./targetDialogs`.
+
+- [ ] **Step 3: Implement `targetDialogs.tsx`**
+
+Create `web/src/pages/resiliency-builder/targetDialogs.tsx`:
+```tsx
+import { useState } from 'react'
+import { Modal } from '../../components/Modal'
+import { Field, TextInput, NumberInput, SelectInput } from '../../components/form'
+import { validateResourceName, integerError } from '../../lib/validation'
+import type { AppTarget, ActorTarget, ComponentTarget } from '../../types/resiliency'
+
+export interface PolicyNames {
+  timeouts: string[]
+  retries: string[]
+  circuitBreakers: string[]
+}
+
+function opts(names: string[]) {
+  return names.map((n) => ({ label: n, value: n }))
+}
+
+function Shell({ open, title, onClose, onSave, canSave, children }: {
+  open: boolean; title: string; onClose: () => void; onSave: () => void; canSave: boolean; children: React.ReactNode
+}) {
+  return (
+    <Modal open={open} title={title} onClose={onClose}>
+      {children}
+      <div className="modal-actions">
+        <button type="button" className="btn ghost" onClick={onClose}>Cancel</button>
+        <button type="button" className="btn mono" disabled={!canSave} onClick={onSave}>Save</button>
+      </div>
+    </Modal>
+  )
+}
+
+function PolicyPickers({ policies, timeout, retry, cb, setTimeout, setRetry, setCb }: {
+  policies: PolicyNames
+  timeout: string; retry: string; cb: string
+  setTimeout: (v: string) => void; setRetry: (v: string) => void; setCb: (v: string) => void
+}) {
+  return (
+    <>
+      <Field label="Timeout policy"><SelectInput aria-label="Timeout policy" value={timeout} options={opts(policies.timeouts)} onChange={setTimeout} /></Field>
+      <Field label="Retry policy"><SelectInput aria-label="Retry policy" value={retry} options={opts(policies.retries)} onChange={setRetry} /></Field>
+      <Field label="Circuit breaker policy"><SelectInput aria-label="Circuit breaker policy" value={cb} options={opts(policies.circuitBreakers)} onChange={setCb} /></Field>
+    </>
+  )
+}
+
+export function AppTargetDialog({ open, policies, onClose, onSave }: {
+  open: boolean; policies: PolicyNames; onClose: () => void; onSave: (name: string, target: AppTarget) => void
+}) {
+  const [name, setName] = useState('')
+  const [timeout, setTimeout] = useState('')
+  const [retry, setRetry] = useState('')
+  const [cb, setCb] = useState('')
+  const nameOk = validateResourceName(name) === null
+  const anyPolicy = !!(timeout || retry || cb)
+  function save() {
+    const t: AppTarget = {}
+    if (timeout) t.timeout = timeout
+    if (retry) t.retry = retry
+    if (cb) t.circuitBreaker = cb
+    onSave(name, t)
+  }
+  return (
+    <Shell open={open} title="Add app target" onClose={onClose} canSave={nameOk && anyPolicy} onSave={save}>
+      <Field label="App ID" required error={name === '' ? null : validateResourceName(name)}>
+        <TextInput aria-label="App ID" value={name} onChange={setName} />
+      </Field>
+      <PolicyPickers policies={policies} timeout={timeout} retry={retry} cb={cb} setTimeout={setTimeout} setRetry={setRetry} setCb={setCb} />
+    </Shell>
+  )
+}
+
+export function ActorTargetDialog({ open, policies, onClose, onSave }: {
+  open: boolean; policies: PolicyNames; onClose: () => void; onSave: (name: string, target: ActorTarget) => void
+}) {
+  const [name, setName] = useState('')
+  const [timeout, setTimeout] = useState('')
+  const [retry, setRetry] = useState('')
+  const [cb, setCb] = useState('')
+  const [scope, setScope] = useState<'' | 'type' | 'id' | 'both'>('')
+  const [cacheSize, setCacheSize] = useState('')
+  const nameOk = validateResourceName(name) === null
+  const anyPolicy = !!(timeout || retry || cb)
+  const cacheOk = integerError(cacheSize) === null
+  function save() {
+    const t: ActorTarget = {}
+    if (timeout) t.timeout = timeout
+    if (retry) t.retry = retry
+    if (cb) {
+      t.circuitBreaker = cb
+      if (scope) t.circuitBreakerScope = scope
+      if (cacheSize) t.circuitBreakerCacheSize = Number(cacheSize)
+    }
+    onSave(name, t)
+  }
+  return (
+    <Shell open={open} title="Add actor target" onClose={onClose} canSave={nameOk && anyPolicy && cacheOk} onSave={save}>
+      <Field label="Actor type" required error={name === '' ? null : validateResourceName(name)}>
+        <TextInput aria-label="Actor type" value={name} onChange={setName} />
+      </Field>
+      <PolicyPickers policies={policies} timeout={timeout} retry={retry} cb={cb} setTimeout={setTimeout} setRetry={setRetry} setCb={setCb} />
+      {cb && (
+        <>
+          <Field label="Circuit breaker scope">
+            <SelectInput aria-label="Circuit breaker scope" value={scope}
+              options={[{ label: 'type', value: 'type' }, { label: 'id', value: 'id' }, { label: 'both', value: 'both' }]}
+              onChange={(v) => setScope((v as '' | 'type' | 'id' | 'both'))} />
+          </Field>
+          <Field label="Circuit breaker cache size" error={cacheOk ? null : 'Must be an integer'}>
+            <NumberInput aria-label="Circuit breaker cache size" value={cacheSize} onChange={setCacheSize} />
+          </Field>
+        </>
+      )}
+    </Shell>
+  )
+}
+
+export function ComponentTargetDialog({ open, policies, onClose, onSave }: {
+  open: boolean; policies: PolicyNames; onClose: () => void; onSave: (name: string, target: ComponentTarget) => void
+}) {
+  const [name, setName] = useState('')
+  const [direction, setDirection] = useState<'outbound' | 'inbound' | 'both'>('outbound')
+  const [timeout, setTimeout] = useState('')
+  const [retry, setRetry] = useState('')
+  const [cb, setCb] = useState('')
+  const nameOk = validateResourceName(name) === null
+  const anyPolicy = !!(timeout || retry || cb)
+  function leg() {
+    const l: { timeout?: string; retry?: string; circuitBreaker?: string } = {}
+    if (timeout) l.timeout = timeout
+    if (retry) l.retry = retry
+    if (cb) l.circuitBreaker = cb
+    return l
+  }
+  function save() {
+    const t: ComponentTarget = {}
+    if (direction === 'outbound' || direction === 'both') t.outbound = leg()
+    if (direction === 'inbound' || direction === 'both') t.inbound = leg()
+    onSave(name, t)
+  }
+  return (
+    <Shell open={open} title="Add component target" onClose={onClose} canSave={nameOk && anyPolicy} onSave={save}>
+      <Field label="Component name" required error={name === '' ? null : validateResourceName(name)}>
+        <TextInput aria-label="Component name" value={name} onChange={setName} />
+      </Field>
+      <Field label="Direction" required>
+        <SelectInput aria-label="Direction" value={direction}
+          options={[{ label: 'outbound', value: 'outbound' }, { label: 'inbound', value: 'inbound' }, { label: 'both', value: 'both' }]}
+          onChange={(v) => setDirection(v === 'inbound' ? 'inbound' : v === 'both' ? 'both' : 'outbound')} />
+      </Field>
+      <PolicyPickers policies={policies} timeout={timeout} retry={retry} cb={cb} setTimeout={setTimeout} setRetry={setRetry} setCb={setCb} />
+    </Shell>
+  )
+}
+```
+Note: `SelectInput` renders a leading blank `—` option (value `''`), so an unset policy picker yields `''` and is omitted from the target — matching the test's outbound-only `{ outbound: { retry: 'retry1' } }` expectation.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- resiliency-builder/targetDialogs`
+Expected: PASS.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc -b` → 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/pages/resiliency-builder/targetDialogs.tsx web/src/pages/resiliency-builder/targetDialogs.test.tsx
+git commit -m "feat(web): add resiliency target dialogs (app/actor/component)"
+```
+
+---
+
+## Task 4: Step components (General, Policies, Targets)
+
+**Files:**
+- Create: `web/src/pages/resiliency-builder/StepGeneral.tsx`
+- Create: `web/src/pages/resiliency-builder/StepPolicies.tsx`
+- Create: `web/src/pages/resiliency-builder/StepTargets.tsx`
+- Create: `web/src/pages/resiliency-builder/steps.test.tsx`
+
+**Interfaces:**
+- Produces (all take `{ state, dispatch }` with reducer types):
+  - `StepGeneral` — name (`validateResourceName` error) + optional namespace.
+  - `StepPolicies` — three `NamedList`s (Timeouts/Retries/Circuit breakers); "+ Add" opens the matching dialog with a defaulted `nextName`; dialog save dispatches the matching `UPSERT_*`; remove dispatches `REMOVE_*`.
+  - `StepTargets` — three `NamedList`s (Apps/Actors/Components); "+ Add" opens the matching target dialog seeded with the named policies from state; save dispatches the matching `UPSERT_*`; remove dispatches `REMOVE_*`.
+- Consumes: `NamedList`, policy + target dialogs, reducer (`nextName`, `Action`, `ResiliencyState`), `components/form`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/pages/resiliency-builder/steps.test.tsx`:
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { StepGeneral } from './StepGeneral'
+import { StepPolicies } from './StepPolicies'
+import { initialState, reducer } from './reducer'
+
+describe('StepGeneral', () => {
+  it('dispatches SET_NAME', () => {
+    const dispatch = vi.fn()
+    render(<StepGeneral state={initialState()} dispatch={dispatch} />)
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'my-res' } })
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NAME', name: 'my-res' })
+  })
+})
+
+describe('StepPolicies', () => {
+  it('opens the timeout dialog and dispatches UPSERT_TIMEOUT on save', () => {
+    const dispatch = vi.fn()
+    render(<StepPolicies state={initialState()} dispatch={dispatch} />)
+    fireEvent.click(screen.getByRole('button', { name: /add timeouts/i }))
+    fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: '30s' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(dispatch).toHaveBeenCalledWith({ type: 'UPSERT_TIMEOUT', name: 'timeout1', duration: '30s' })
+  })
+  it('lists an existing retry and removes it', () => {
+    const dispatch = vi.fn()
+    const s = reducer(initialState(), { type: 'UPSERT_RETRY', name: 'retry1', policy: { policy: 'constant', duration: '5s' } })
+    render(<StepPolicies state={s} dispatch={dispatch} />)
+    fireEvent.click(screen.getByRole('button', { name: /remove retry1/i }))
+    expect(dispatch).toHaveBeenCalledWith({ type: 'REMOVE_RETRY', name: 'retry1' })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- resiliency-builder/steps`
+Expected: FAIL — cannot resolve `./StepGeneral`.
+
+- [ ] **Step 3: Implement `StepGeneral.tsx`**
+
+```tsx
+import { Field, TextInput } from '../../components/form'
+import { validateResourceName } from '../../lib/validation'
+import type { Action, ResiliencyState } from './reducer'
+
+export function StepGeneral({ state, dispatch }: { state: ResiliencyState; dispatch: (a: Action) => void }) {
+  const name = state.config.metadata.name
+  const nameErr = name === '' ? null : validateResourceName(name)
+  return (
+    <div>
+      <Field label="Name" htmlFor="r-name" required error={nameErr}>
+        <TextInput id="r-name" aria-label="Name" value={name} onChange={(v) => dispatch({ type: 'SET_NAME', name: v })} />
+      </Field>
+      <Field label="Namespace" htmlFor="r-ns">
+        <TextInput id="r-ns" aria-label="Namespace" value={state.config.metadata.namespace ?? ''} onChange={(v) => dispatch({ type: 'SET_NAMESPACE', namespace: v })} />
+      </Field>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Implement `StepPolicies.tsx`**
+
+```tsx
+import { useState } from 'react'
+import { NamedList } from './NamedList'
+import { TimeoutDialog, RetryDialog, CircuitBreakerDialog } from './policyDialogs'
+import { nextName, type Action, type ResiliencyState } from './reducer'
+
+type Open = null | 'timeout' | 'retry' | 'cb'
+
+export function StepPolicies({ state, dispatch }: { state: ResiliencyState; dispatch: (a: Action) => void }) {
+  const [open, setOpen] = useState<Open>(null)
+  const pol = state.config.spec.policies
+  return (
+    <div>
+      <NamedList title="Timeouts" names={Object.keys(pol.timeouts)} onAdd={() => setOpen('timeout')} onRemove={(name) => dispatch({ type: 'REMOVE_TIMEOUT', name })} />
+      <NamedList title="Retries" names={Object.keys(pol.retries)} onAdd={() => setOpen('retry')} onRemove={(name) => dispatch({ type: 'REMOVE_RETRY', name })} />
+      <NamedList title="Circuit breakers" names={Object.keys(pol.circuitBreakers)} onAdd={() => setOpen('cb')} onRemove={(name) => dispatch({ type: 'REMOVE_CB', name })} />
+
+      <TimeoutDialog open={open === 'timeout'} initialName={nextName('timeout', pol.timeouts)} onClose={() => setOpen(null)}
+        onSave={(name, duration) => { dispatch({ type: 'UPSERT_TIMEOUT', name, duration }); setOpen(null) }} />
+      <RetryDialog open={open === 'retry'} initialName={nextName('retry', pol.retries)} onClose={() => setOpen(null)}
+        onSave={(name, policy) => { dispatch({ type: 'UPSERT_RETRY', name, policy }); setOpen(null) }} />
+      <CircuitBreakerDialog open={open === 'cb'} initialName={nextName('circuitBreaker', pol.circuitBreakers)} onClose={() => setOpen(null)}
+        onSave={(name, policy) => { dispatch({ type: 'UPSERT_CB', name, policy }); setOpen(null) }} />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 5: Implement `StepTargets.tsx`**
+
+```tsx
+import { useState } from 'react'
+import { NamedList } from './NamedList'
+import { AppTargetDialog, ActorTargetDialog, ComponentTargetDialog, type PolicyNames } from './targetDialogs'
+import { type Action, type ResiliencyState } from './reducer'
+
+type Open = null | 'app' | 'actor' | 'component'
+
+export function StepTargets({ state, dispatch }: { state: ResiliencyState; dispatch: (a: Action) => void }) {
+  const [open, setOpen] = useState<Open>(null)
+  const { policies, targets } = state.config.spec
+  const names: PolicyNames = {
+    timeouts: Object.keys(policies.timeouts),
+    retries: Object.keys(policies.retries),
+    circuitBreakers: Object.keys(policies.circuitBreakers),
+  }
+  return (
+    <div>
+      <NamedList title="Apps" names={Object.keys(targets.apps ?? {})} onAdd={() => setOpen('app')} onRemove={(name) => dispatch({ type: 'REMOVE_APP', name })} />
+      <NamedList title="Actors" names={Object.keys(targets.actors ?? {})} onAdd={() => setOpen('actor')} onRemove={(name) => dispatch({ type: 'REMOVE_ACTOR', name })} />
+      <NamedList title="Components" names={Object.keys(targets.components ?? {})} onAdd={() => setOpen('component')} onRemove={(name) => dispatch({ type: 'REMOVE_COMPONENT', name })} />
+
+      <AppTargetDialog open={open === 'app'} policies={names} onClose={() => setOpen(null)}
+        onSave={(name, target) => { dispatch({ type: 'UPSERT_APP', name, target }); setOpen(null) }} />
+      <ActorTargetDialog open={open === 'actor'} policies={names} onClose={() => setOpen(null)}
+        onSave={(name, target) => { dispatch({ type: 'UPSERT_ACTOR', name, target }); setOpen(null) }} />
+      <ComponentTargetDialog open={open === 'component'} policies={names} onClose={() => setOpen(null)}
+        onSave={(name, target) => { dispatch({ type: 'UPSERT_COMPONENT', name, target }); setOpen(null) }} />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 6: Run the test + type-check**
+
+Run: `npm test -- resiliency-builder/steps` → PASS. Run: `npx tsc -b` → 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/pages/resiliency-builder/StepGeneral.tsx web/src/pages/resiliency-builder/StepPolicies.tsx web/src/pages/resiliency-builder/StepTargets.tsx web/src/pages/resiliency-builder/steps.test.tsx
+git commit -m "feat(web): add resiliency builder step components"
+```
+
+---
+
+## Task 5: Assemble ResiliencyBuilder + landing + nav + routes
+
+**Files:**
+- Create: `web/src/pages/resiliency-builder/ResiliencyBuilder.tsx`
+- Create: `web/src/pages/resiliency-builder/ResiliencyBuilder.test.tsx`
+- Create: `web/src/pages/Resiliency.tsx`
+- Create: `web/src/pages/Resiliency.test.tsx`
+- Modify: `web/src/router.tsx`
+- Modify: `web/src/components/TopNav.tsx`
+
+**Interfaces:**
+- Consumes: `components/wizard` (`Wizard`, `WizardStep`), `components/YamlPreview`, reducer (`initialState`, `reducer`, `canContinue`, `assembleResiliency`), `lib/yaml-emit` (`dumpYaml`), the three step components, `react-router-dom`.
+- Produces: `ResiliencyBuilder` page; `Resiliency` landing page; routes `/resiliency` and `/resiliency/new`; `Resiliency` nav item.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `web/src/pages/Resiliency.test.tsx`:
+```tsx
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import { Resiliency } from './Resiliency'
+
+describe('Resiliency landing', () => {
+  it('shows the empty state and a New resiliency policy link', () => {
+    render(<MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}><Resiliency /></MemoryRouter>)
+    expect(screen.getByText(/no resiliency policies/i)).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: /new resiliency policy/i })
+    expect(link).toHaveAttribute('href', '/resiliency/new')
+  })
+})
+```
+
+Create `web/src/pages/resiliency-builder/ResiliencyBuilder.test.tsx`:
+```tsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import { ResiliencyBuilder } from './ResiliencyBuilder'
+
+function renderBuilder() {
+  const router = createMemoryRouter(
+    [{ path: '/resiliency/new', element: <ResiliencyBuilder /> }, { path: '/resiliency', element: <div>resiliency list</div> }],
+    { initialEntries: ['/resiliency/new'], future: { v7_relativeSplatPath: true } },
+  )
+  return render(<RouterProvider router={router} future={{ v7_startTransition: true }} />)
+}
+
+describe('ResiliencyBuilder', () => {
+  it('walks general → policies → targets → preview and emits YAML', async () => {
+    renderBuilder()
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'my-res' } })
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // 0->1
+    fireEvent.click(screen.getByRole('button', { name: /add timeouts/i }))
+    fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: '30s' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // 1->2
+    fireEvent.click(screen.getByRole('button', { name: /add apps/i }))
+    fireEvent.change(screen.getByLabelText(/app id/i), { target: { value: 'orders' } })
+    fireEvent.change(screen.getByLabelText(/^timeout policy/i), { target: { value: 'timeout1' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // 2->3
+    await waitFor(() => expect(screen.getByRole('textbox', { name: /generated yaml/i })).toHaveValue(
+      expect.stringContaining('kind: Resiliency'),
+    ))
+    expect(screen.getByRole('textbox', { name: /generated yaml/i })).toHaveValue(expect.stringContaining('name: my-res'))
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test -- Resiliency` (both files)
+Expected: FAIL — cannot resolve modules.
+
+- [ ] **Step 3: Implement `ResiliencyBuilder.tsx`**
+
+```tsx
+import { useMemo, useReducer, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Wizard, type WizardStep } from '../../components/wizard'
+import { YamlPreview } from '../../components/YamlPreview'
+import { dumpYaml } from '../../lib/yaml-emit'
+import { initialState, reducer, canContinue, assembleResiliency } from './reducer'
+import { StepGeneral } from './StepGeneral'
+import { StepPolicies } from './StepPolicies'
+import { StepTargets } from './StepTargets'
+
+export function ResiliencyBuilder() {
+  const navigate = useNavigate()
+  const [state, dispatch] = useReducer(reducer, undefined, initialState)
+  const [previewEdited, setPreviewEdited] = useState(false)
+
+  const yaml = useMemo(
+    () => (state.activeStep === 3 ? dumpYaml(assembleResiliency(state.config)) : ''),
+    [state],
+  )
+
+  const steps: WizardStep[] = [
+    { label: 'General', content: <StepGeneral state={state} dispatch={dispatch} /> },
+    { label: 'Policies', content: <StepPolicies state={state} dispatch={dispatch} /> },
+    { label: 'Targets', content: <StepTargets state={state} dispatch={dispatch} /> },
+    { label: 'Preview', content: <YamlPreview yaml={yaml} filename={`${state.config.metadata.name || 'resiliency'}.yaml`} onEditedChange={setPreviewEdited} /> },
+  ]
+
+  return (
+    <div className="page">
+      <div className="phead">
+        <div>
+          <h1>New resiliency policy</h1>
+          <div className="sub">Build a Dapr resiliency YAML to copy or download</div>
+        </div>
+        <button type="button" className="btn ghost" onClick={() => navigate('/resiliency')}>Cancel</button>
+      </div>
+      <div className="card" style={{ padding: 18 }}>
+        <Wizard
+          steps={steps}
+          activeStep={state.activeStep}
+          canContinue={state.activeStep === 3 ? !previewEdited : canContinue(state)}
+          onBack={() => dispatch({ type: 'BACK' })}
+          onContinue={() => dispatch({ type: 'NEXT' })}
+          onFinish={() => navigate('/resiliency')}
+        />
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Implement `Resiliency.tsx` (landing)**
+
+```tsx
+import { Link } from 'react-router-dom'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
+
+export function Resiliency() {
+  useDocumentTitle('Resiliency')
+  return (
+    <div className="page">
+      <div className="phead">
+        <div>
+          <h1>Resiliency</h1>
+          <div className="sub">Dapr resiliency policies</div>
+        </div>
+        <Link className="btn mono" to="/resiliency/new">+ New resiliency policy</Link>
+      </div>
+      <div className="md">
+        <div className="card complist" />
+        <div className="card">
+          <p className="hint" style={{ padding: '14px' }}>
+            No resiliency policies. Use "New resiliency policy" to build one.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+Note: confirm `useDocumentTitle` is exported from `web/src/lib/useDocumentTitle.ts` (it is used by `ResourceList`); if the import path/signature differs, match the existing usage.
+
+- [ ] **Step 5: Add routes + nav item**
+
+Modify `web/src/router.tsx`: import both pages and add routes (order doesn't matter — no param collision):
+```tsx
+import { Resiliency } from './pages/Resiliency'
+import { ResiliencyBuilder } from './pages/resiliency-builder/ResiliencyBuilder'
+// ...
+      { path: 'resiliency', element: <Resiliency /> },
+      { path: 'resiliency/new', element: <ResiliencyBuilder /> },
+```
+
+Modify `web/src/components/TopNav.tsx`: add the nav item between Configurations and Logs in `NAV_ITEMS`:
+```tsx
+  { label: 'Configurations', to: '/configurations' },
+  { label: 'Resiliency', to: '/resiliency' },
+  { label: 'Logs', to: '/logs' },
+```
+
+- [ ] **Step 6: Run the tests + full suite**
+
+Run: `npm test -- Resiliency` → both PASS.
+Run: `npm test` → all green. Note: `TopNav.test.tsx` asserts exactly 7 nav items in a specific order — UPDATE it to expect 8 items with `Resiliency` inserted between `Configurations` and `Logs` (both the labels array and the paths array). This is a legitimate spec change (new nav item), not a weakening.
+
+- [ ] **Step 7: Type-check**
+
+Run: `npx tsc -b` → 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/pages/resiliency-builder/ResiliencyBuilder.tsx web/src/pages/resiliency-builder/ResiliencyBuilder.test.tsx web/src/pages/Resiliency.tsx web/src/pages/Resiliency.test.tsx web/src/router.tsx web/src/components/TopNav.tsx web/src/components/TopNav.test.tsx
+git commit -m "feat(web): wire Resiliency Builder route, landing page, and nav item"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Resiliency Builder):**
+- 4-step flow General → Policies → Targets → Preview → Tasks 4, 5. ✓
+- Step 0 = name only (connected-mode `ResiliencyAccess` dropped) → StepGeneral (Task 4); documented in Global Constraints. ✓
+- Policies: timeouts/retries/circuitBreakers, each list + Add dialog; ≥1 policy to proceed → Tasks 2, 4 + reducer gating (Task 1). ✓
+- Targets: apps/actors/components referencing named policies via dropdowns; actors add scope + cache size; components add inbound/outbound; ≥1 target to proceed → Tasks 3, 4 + gating (Task 1). ✓
+- DaprBuiltIn default-policy override table DROPPED for v1 → documented in Global Constraints. ✓
+- Preview: `recursivelyRemoveEmptyValues` over spec, editable, copy/download → Task 1 `assembleResiliency` + Task 5 using `YamlPreview`. ✓
+- `grpcStatusCodes` spelling → RetryDialog + types (Task 2). ✓
+- Sequential policy/target naming (`retry1`…) → `nextName` (Task 1), used by StepPolicies. ✓
+- Monochrome buttons in wizard + dialogs (`.btn.mono`/`.btn.ghost`) → Tasks 2, 3, 5. ✓
+- Resiliency nav item + `/resiliency` create-only landing + `/resiliency/new` → Task 5. ✓
+- Finish/Cancel → `/resiliency` → Task 5. ✓
+- Reuse of `Modal`, Plan 1 form/wizard, Plan 2 `YamlPreview` → throughout. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code + commands with expected results. Two "confirm the real API" notes (Task 5 `useDocumentTitle`; Task 5 `TopNav.test.tsx` update) are verification steps, not placeholders.
+
+**Type consistency:** `ResiliencyState`/`Action` (Task 1) consumed identically by steps (Task 4) and page (Task 5). `RetryPolicy`/`CircuitBreakerPolicy`/`AppTarget`/`ActorTarget`/`ComponentTarget` from `types/resiliency` used consistently across dialogs (Tasks 2–3) and reducer (Task 1). `PolicyNames` shape shared between target dialogs and StepTargets. `UPSERT_*`/`REMOVE_*` action names match between reducer, steps, and tests. `nextName(prefix, existing)` and `assembleResiliency(config)` signatures consistent. `YamlPreview` (Plan 2) prop shape (`yaml`, `filename`, `onEditedChange`) matches usage.
+
+**Cross-plan note:** This plan depends on Plan 2's `components/YamlPreview.tsx`. If Plans are executed out of order, Task 5 (and its test) will fail until `YamlPreview` exists — execute Plan 2 first.

--- a/docs/superpowers/plans/2026-07-02-component-builder-type-filter-and-preview.md
+++ b/docs/superpowers/plans/2026-07-02-component-builder-type-filter-and-preview.md
@@ -1,0 +1,682 @@
+# Component Builder — Category Filter + Highlighted Preview + Removable Optionals — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enhance the existing Component Builder: a category filter on step 1, removable optional fields on step 3, and a read-only syntax-highlighted YAML preview on step 4 (reusing the Components detail view's rendering).
+
+**Architecture:** Modifies the existing `pages/component-builder/*` and the shared `components/YamlPreview.tsx`. Reducer gains a `category` field + `SELECT_CATEGORY`; `StepType` becomes category-gated; `StepConfigure` reuses the state-connection dialog's add/remove UI; `YamlPreview` becomes read-only via `highlightYaml`. No new dependencies.
+
+**Tech Stack:** React 19, TS, Vite, React Router v6, TanStack Query v5, Vitest + Testing Library.
+
+**Prereq:** Component Builder (Plan 2, `2026-07-01-builders-02-component.md`) complete on this branch.
+**Source spec:** `docs/superpowers/specs/2026-07-02-component-builder-type-filter-and-preview-design.md`
+
+## Global Constraints
+
+- No new dependencies. No MUI/react-hook-form/Yup. Controlled components; vanilla CSS theme tokens.
+- Monochrome buttons only (`.btn.mono` primary / `.btn.ghost` secondary); never green `.btn.primary`.
+- Category chips are single-select, use existing `.filters` container + `.lvchip` buttons with `aria-pressed`.
+- Preview reuses the Components detail rendering verbatim: `<pre className="code">{highlightYaml(yaml)}</pre>` (read-only). Copy + Download act on the generated `yaml`.
+- Removable optional fields reuse the `StateStoreConnectionDialog.tsx` pattern: a ghost `✕` button `aria-label={`remove ${field}`}` per added optional field, plus the existing `+ add optional field…` select.
+- Switching to a different category clears the selected schema + downstream config; `REMOVE_OPTIONAL` clears the field's `values`/`secretRefs`/`useSecret`.
+- Tests: Vitest + Testing Library, colocated. Run `npx tsc -b` before every commit. All `npm`/`npx` from `web/`.
+
+---
+
+## File Structure
+
+- Modify `web/src/pages/component-builder/reducer.ts` (+ `reducer.test.ts`) — `category`, `SELECT_CATEGORY`, `SELECT_SCHEMA` sync, `REMOVE_OPTIONAL` clears state.
+- Modify `web/src/pages/component-builder/StepType.tsx` (+ `StepType.test.tsx`) — category chips + gated list/search.
+- Modify `web/src/pages/component-builder/StepConfigure.tsx` (+ `StepConfigure.test.tsx`) — ✕ remove per added optional field.
+- Modify `web/src/components/YamlPreview.tsx` (+ `YamlPreview.test.tsx`) — read-only highlighted.
+- Modify `web/src/pages/component-builder/ComponentBuilder.tsx` (+ `ComponentBuilder.test.tsx`) — selection bar; drop `previewEdited`; new preview usage.
+- Modify `docs/superpowers/plans/2026-07-01-builders-03-resiliency.md` — read-only `YamlPreview` API (doc-only).
+
+---
+
+## Task 1: Reducer — category + SELECT_CATEGORY + REMOVE_OPTIONAL clears state
+
+**Files:**
+- Modify: `web/src/pages/component-builder/reducer.ts`
+- Modify: `web/src/pages/component-builder/reducer.test.ts`
+
+**Interfaces:**
+- Produces: `ComponentBuilderState` gains `category?: string`; `Action` gains `{ type: 'SELECT_CATEGORY'; category: string }`. `SELECT_SCHEMA` now also sets `category = schema.type`. `REMOVE_OPTIONAL` also deletes the field from `values`/`secretRefs`/`useSecret`.
+- Consumes: unchanged (`types/component`, `types/metadata`, `lib/validation`, `activeFields`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `web/src/pages/component-builder/reducer.test.ts`:
+```ts
+describe('SELECT_CATEGORY', () => {
+  const redis = {
+    type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable',
+    metadata: [{ name: 'redisHost', required: true }, { name: 'enableTLS', type: 'bool' as const }],
+  }
+  it('sets the active category', () => {
+    const s = reducer(initialState(), { type: 'SELECT_CATEGORY', category: 'state' })
+    expect(s.category).toBe('state')
+    expect(s.activeStep).toBe(0)
+  })
+  it('SELECT_SCHEMA sets category = schema.type', () => {
+    const s = reducer(initialState(), { type: 'SELECT_SCHEMA', schema: redis, version: 'v1' })
+    expect(s.category).toBe('state')
+  })
+  it('switching to a different category clears schema + config', () => {
+    let s = reducer(initialState(), { type: 'SELECT_SCHEMA', schema: redis, version: 'v1' })
+    s = reducer(s, { type: 'SET_VALUE', field: 'redisHost', value: 'x' })
+    s = reducer(s, { type: 'SELECT_CATEGORY', category: 'pubsub' })
+    expect(s.category).toBe('pubsub')
+    expect(s.schema).toBeUndefined()
+    expect(s.version).toBe('')
+    expect(s.values).toEqual({})
+  })
+  it('re-selecting the same category keeps the schema', () => {
+    let s = reducer(initialState(), { type: 'SELECT_SCHEMA', schema: redis, version: 'v1' })
+    s = reducer(s, { type: 'SELECT_CATEGORY', category: 'state' })
+    expect(s.schema?.name).toBe('redis')
+  })
+})
+
+describe('REMOVE_OPTIONAL clears field state', () => {
+  it('removes the field from optionalAdded and clears its value/secret/useSecret', () => {
+    let s = initialState()
+    s = reducer(s, { type: 'ADD_OPTIONAL', field: 'enableTLS' })
+    s = reducer(s, { type: 'SET_VALUE', field: 'enableTLS', value: 'true' })
+    s = reducer(s, { type: 'TOGGLE_SECRET', field: 'enableTLS', on: true })
+    s = reducer(s, { type: 'SET_SECRET', field: 'enableTLS', ref: { name: 'n', key: 'k' } })
+    s = reducer(s, { type: 'REMOVE_OPTIONAL', field: 'enableTLS' })
+    expect(s.optionalAdded).not.toContain('enableTLS')
+    expect(s.values.enableTLS).toBeUndefined()
+    expect(s.secretRefs.enableTLS).toBeUndefined()
+    expect(s.useSecret.enableTLS).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test -- component-builder/reducer`
+Expected: FAIL — `SELECT_CATEGORY` not handled (category undefined); `REMOVE_OPTIONAL` leaves value set.
+
+- [ ] **Step 3: Implement**
+
+In `web/src/pages/component-builder/reducer.ts`:
+
+Add `category?: string` to the `ComponentBuilderState` interface (after `activeStep`):
+```ts
+export interface ComponentBuilderState {
+  activeStep: number
+  category?: string
+  schema?: ComponentMetadataSchema
+  // …rest unchanged…
+}
+```
+
+Add to the `Action` union:
+```ts
+  | { type: 'SELECT_CATEGORY'; category: string }
+```
+
+Update the `SELECT_SCHEMA` case to also set `category`:
+```ts
+    case 'SELECT_SCHEMA': {
+      const hasAuthProfiles = (action.schema.authenticationProfiles?.length ?? 0) > 0
+      return {
+        ...state,
+        category: action.schema.type,
+        schema: action.schema,
+        version: action.version,
+        hasAuthProfiles,
+        activeStep: 1,
+      }
+    }
+```
+
+Add the `SELECT_CATEGORY` case (place it before `SET_AUTH_PROFILE`):
+```ts
+    case 'SELECT_CATEGORY':
+      if (action.category === state.schema?.type) {
+        return { ...state, category: action.category }
+      }
+      // Switching category invalidates the chosen component + its config.
+      return {
+        ...state,
+        category: action.category,
+        schema: undefined,
+        version: '',
+        authProfile: undefined,
+        hasAuthProfiles: false,
+        values: {},
+        secretRefs: {},
+        useSecret: {},
+        optionalAdded: [],
+      }
+```
+
+Replace the `REMOVE_OPTIONAL` case:
+```ts
+    case 'REMOVE_OPTIONAL': {
+      const values = { ...state.values }
+      const secretRefs = { ...state.secretRefs }
+      const useSecret = { ...state.useSecret }
+      delete values[action.field]
+      delete secretRefs[action.field]
+      delete useSecret[action.field]
+      return {
+        ...state,
+        optionalAdded: state.optionalAdded.filter((f) => f !== action.field),
+        values,
+        secretRefs,
+        useSecret,
+      }
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm test -- component-builder/reducer`
+Expected: PASS (existing + new).
+
+- [ ] **Step 5: Type-check + full suite**
+
+Run: `npx tsc -b` → 0. Then `npm test` → all green (the new optional `category` and unused-yet `SELECT_CATEGORY` don't affect existing consumers).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/pages/component-builder/reducer.ts web/src/pages/component-builder/reducer.test.ts
+git commit -m "feat(web): component builder reducer gains category + SELECT_CATEGORY; REMOVE_OPTIONAL clears field state"
+```
+
+---
+
+## Task 2: StepType — category chips gate the list + search
+
+**Files:**
+- Modify: `web/src/pages/component-builder/StepType.tsx`
+- Modify: `web/src/pages/component-builder/StepType.test.tsx`
+- Modify: `web/src/pages/component-builder/ComponentBuilder.test.tsx` (add the category-select step so the integration walk stays green)
+
+**Interfaces:**
+- Consumes: `useComponentSchemas` (`byType`), reducer `Action`/`ComponentBuilderState` (incl. `category`, `SELECT_CATEGORY`).
+- Produces: `StepType` renders category chips; before a category is chosen shows a hint; after, shows the scoped search + filtered list.
+
+- [ ] **Step 1: Rewrite the StepType test**
+
+Replace `web/src/pages/component-builder/StepType.test.tsx` with:
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../test/setup'
+import { QueryProvider, makeQueryClient } from '../../lib/query'
+import { StepType } from './StepType'
+import { initialState, reducer } from './reducer'
+import type { ComponentBuilderState } from './reducer'
+
+const bundle = {
+  schemaVersion: '1', date: '2026-01-01',
+  components: [
+    { type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable', metadata: [] },
+    { type: 'state', name: 'postgresql', version: 'v1', title: 'PostgreSQL', status: 'stable', metadata: [] },
+    { type: 'pubsub', name: 'kafka', version: 'v1', title: 'Apache Kafka', status: 'stable', metadata: [] },
+  ],
+}
+
+function renderStep(state: ComponentBuilderState, dispatch = vi.fn()) {
+  server.use(http.get('/api/metadata/components', () => HttpResponse.json(bundle)))
+  return render(
+    <QueryProvider client={makeQueryClient()}>
+      <StepType state={state} dispatch={dispatch} />
+    </QueryProvider>,
+  )
+}
+
+describe('StepType category filter', () => {
+  it('shows category chips and a hint before any category is chosen', async () => {
+    renderStep(initialState())
+    expect(await screen.findByRole('button', { name: 'state' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'pubsub' })).toBeInTheDocument()
+    expect(screen.getByText(/choose a category/i)).toBeInTheDocument()
+    expect(screen.queryByText('Redis')).not.toBeInTheDocument()
+  })
+
+  it('clicking a category chip dispatches SELECT_CATEGORY', async () => {
+    const dispatch = vi.fn()
+    renderStep(initialState(), dispatch)
+    fireEvent.click(await screen.findByRole('button', { name: 'state' }))
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SELECT_CATEGORY', category: 'state' })
+  })
+
+  it('with a category selected, lists only that category and scopes search', async () => {
+    const state = reducer(initialState(), { type: 'SELECT_CATEGORY', category: 'state' })
+    renderStep(state)
+    expect(await screen.findByText('Redis')).toBeInTheDocument()
+    expect(screen.getByText('PostgreSQL')).toBeInTheDocument()
+    expect(screen.queryByText('Apache Kafka')).not.toBeInTheDocument()
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'postgres' } })
+    expect(screen.queryByText('Redis')).not.toBeInTheDocument()
+    expect(screen.getByText('PostgreSQL')).toBeInTheDocument()
+  })
+
+  it('clicking a component dispatches SELECT_SCHEMA with its version', async () => {
+    const dispatch = vi.fn()
+    const state = reducer(initialState(), { type: 'SELECT_CATEGORY', category: 'state' })
+    renderStep(state, dispatch)
+    fireEvent.click(await screen.findByText('Redis'))
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'SELECT_SCHEMA', version: 'v1' }))
+    expect(dispatch.mock.calls.at(-1)?.[0].schema.name).toBe('redis')
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- component-builder/StepType`
+Expected: FAIL — chips not rendered; hint absent.
+
+- [ ] **Step 3: Rewrite `StepType.tsx`**
+
+Replace `web/src/pages/component-builder/StepType.tsx` with:
+```tsx
+import { useState } from 'react'
+import { useComponentSchemas } from '../../hooks/useComponentSchemas'
+import type { Action, ComponentBuilderState } from './reducer'
+
+interface Props {
+  state: ComponentBuilderState
+  dispatch: (a: Action) => void
+}
+
+export function StepType({ state, dispatch }: Props) {
+  const { byType, isLoading } = useComponentSchemas()
+  const [q, setQ] = useState('')
+
+  if (isLoading) return <p className="muted">Loading catalog…</p>
+
+  const categories = Object.keys(byType).sort()
+  const category = state.category
+  const query = q.trim().toLowerCase()
+
+  return (
+    <div>
+      <div className="filters" style={{ marginBottom: 12 }}>
+        {categories.map((c) => (
+          <button
+            key={c}
+            type="button"
+            className="lvchip"
+            aria-pressed={category === c}
+            onClick={() => dispatch({ type: 'SELECT_CATEGORY', category: c })}
+          >
+            {c}
+          </button>
+        ))}
+      </div>
+
+      {!category ? (
+        <p className="muted">Choose a category to browse components.</p>
+      ) : (
+        <>
+          <div className="search" style={{ marginBottom: 12 }}>
+            <input
+              type="search"
+              aria-label="Search components"
+              placeholder={`Search ${category} components…`}
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+            />
+          </div>
+          <div className="complist card">
+            {(byType[category] ?? [])
+              .filter((s) => !query || s.title.toLowerCase().includes(query) || s.name.toLowerCase().includes(query))
+              .map((s) => {
+                const selected = state.schema?.type === s.type && state.schema?.name === s.name
+                return (
+                  <div
+                    key={`${s.type}.${s.name}`}
+                    className={`ci${selected ? ' sel' : ''}`}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => dispatch({ type: 'SELECT_SCHEMA', schema: s, version: s.version })}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') dispatch({ type: 'SELECT_SCHEMA', schema: s, version: s.version })
+                    }}
+                  >
+                    <span className="cn">{s.title}</span>
+                    <span className="ct">{`${s.type}.${s.name}`} · {s.version} · {s.status}</span>
+                  </div>
+                )
+              })}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run the StepType test to verify it passes**
+
+Run: `npm test -- component-builder/StepType`
+Expected: PASS.
+
+- [ ] **Step 5: Keep the integration test green (category-first)**
+
+The `ComponentBuilder.test.tsx` walk clicks "Redis" directly; now a category must be chosen first. In `web/src/pages/component-builder/ComponentBuilder.test.tsx`, insert a category-chip click immediately before the line that clicks `Redis`:
+```tsx
+    fireEvent.click(await screen.findByRole('button', { name: 'state' })) // pick category
+    fireEvent.click(await screen.findByText('Redis'))                     // then component
+```
+(Leave the rest of that test unchanged for now — Task 4 updates the preview assertion.)
+
+- [ ] **Step 6: Full suite + type-check**
+
+Run: `npm test` → all green. Run: `npx tsc -b` → 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/pages/component-builder/StepType.tsx web/src/pages/component-builder/StepType.test.tsx web/src/pages/component-builder/ComponentBuilder.test.tsx
+git commit -m "feat(web): component builder Step 1 category filter chips"
+```
+
+---
+
+## Task 3: StepConfigure — removable optional fields
+
+**Files:**
+- Modify: `web/src/pages/component-builder/StepConfigure.tsx`
+- Modify: `web/src/pages/component-builder/StepConfigure.test.tsx`
+
+**Interfaces:**
+- Consumes: reducer `REMOVE_OPTIONAL` (now clears field state), `activeFields`, form components, `MetadataFieldInput`.
+- Produces: each added optional field row shows a ✕ remove button (`aria-label={`remove ${field}`}`).
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `web/src/pages/component-builder/StepConfigure.test.tsx` (reuse the existing `redis`/`configureState` helpers in that file; the redis schema there has optional `enableTLS`):
+```tsx
+describe('StepConfigure optional field removal', () => {
+  it('shows a remove button for an added optional field and dispatches REMOVE_OPTIONAL', () => {
+    const dispatch = vi.fn()
+    let s = configureState()
+    s = reducer(s, { type: 'ADD_OPTIONAL', field: 'enableTLS' })
+    render(<StepConfigure state={s} dispatch={dispatch} />)
+    const removeBtn = screen.getByRole('button', { name: /remove enableTLS/i })
+    fireEvent.click(removeBtn)
+    expect(dispatch).toHaveBeenCalledWith({ type: 'REMOVE_OPTIONAL', field: 'enableTLS' })
+  })
+
+  it('does not show a remove button for required fields', () => {
+    render(<StepConfigure state={configureState()} dispatch={vi.fn()} />)
+    expect(screen.queryByRole('button', { name: /remove redisHost/i })).not.toBeInTheDocument()
+  })
+})
+```
+If the existing test file does not already import `reducer`, add `reducer` to its import from `./reducer`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- component-builder/StepConfigure`
+Expected: FAIL — no remove button.
+
+- [ ] **Step 3: Update `StepConfigure.tsx`**
+
+Replace the `shown.map(...)` block in `web/src/pages/component-builder/StepConfigure.tsx` with one that wraps the value control + ✕ in a `.field-row` and shows ✕ for non-required (optional-added) fields:
+```tsx
+      <div className="sec-title">Metadata</div>
+      {shown.map((f) => {
+        const useSecret = !!state.useSecret[f.name]
+        const ref = state.secretRefs[f.name] ?? { name: '', key: '' }
+        const removable = !f.required
+        return (
+          <Field key={f.name} label={f.name} required={f.required}>
+            {f.description && <div className="muted" style={{ fontSize: 12, marginBottom: 4 }}>{f.description}</div>}
+            <Toggle
+              label={`Use secret for ${f.name}`}
+              checked={useSecret}
+              onChange={(on) => dispatch({ type: 'TOGGLE_SECRET', field: f.name, on })}
+            />
+            <div className="field-row">
+              {useSecret ? (
+                <>
+                  <TextInput aria-label={`${f.name} secret name`} placeholder="secret name" value={ref.name}
+                    onChange={(v) => dispatch({ type: 'SET_SECRET', field: f.name, ref: { ...ref, name: v } })} />
+                  <TextInput aria-label={`${f.name} secret key`} placeholder="secret key" value={ref.key}
+                    onChange={(v) => dispatch({ type: 'SET_SECRET', field: f.name, ref: { ...ref, key: v } })} />
+                </>
+              ) : (
+                <MetadataFieldInput field={f} value={state.values[f.name] ?? ''} onChange={(v) => dispatch({ type: 'SET_VALUE', field: f.name, value: v })} />
+              )}
+              {removable && (
+                <button type="button" className="btn ghost" aria-label={`remove ${f.name}`}
+                  onClick={() => dispatch({ type: 'REMOVE_OPTIONAL', field: f.name })}>✕</button>
+              )}
+            </div>
+          </Field>
+        )
+      })}
+```
+(The `+ add optional field…` `SelectInput` block below stays unchanged.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- component-builder/StepConfigure`
+Expected: PASS (existing + new).
+
+- [ ] **Step 5: Full suite + type-check**
+
+Run: `npm test` → green. Run: `npx tsc -b` → 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/pages/component-builder/StepConfigure.tsx web/src/pages/component-builder/StepConfigure.test.tsx
+git commit -m "feat(web): component builder Step 3 removable optional fields"
+```
+
+---
+
+## Task 4: Read-only highlighted preview + ComponentBuilder selection bar
+
+**Files:**
+- Modify: `web/src/components/YamlPreview.tsx`
+- Modify: `web/src/components/YamlPreview.test.tsx`
+- Modify: `web/src/pages/component-builder/ComponentBuilder.tsx`
+- Modify: `web/src/pages/component-builder/ComponentBuilder.test.tsx`
+- Modify: `docs/superpowers/plans/2026-07-01-builders-03-resiliency.md`
+
+**Interfaces:**
+- Produces: `YamlPreview({ yaml, filename })` — read-only, `<pre className="code">{highlightYaml(yaml)}</pre>` + Copy/Download. No `onEditedChange`. `ComponentBuilder` renders a persistent selection bar and passes `yaml`/`filename` only.
+- Consumes: `lib/yaml-highlight` `highlightYaml`, `lib/clipboard` `copyText`, `lib/toast` `useToast`, `lib/download` `downloadText`, reducer `state.category`/`state.schema`.
+
+- [ ] **Step 1: Rewrite the YamlPreview test**
+
+Replace `web/src/components/YamlPreview.test.tsx` with:
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { YamlPreview } from './YamlPreview'
+import { copyText } from '../lib/clipboard'
+
+vi.mock('../lib/clipboard', () => ({ copyText: vi.fn() }))
+
+describe('YamlPreview (read-only)', () => {
+  beforeEach(() => {
+    ;(URL as unknown as { createObjectURL: unknown }).createObjectURL = vi.fn(() => 'blob:mock')
+    ;(URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = vi.fn()
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('renders the yaml read-only in a <pre> (no textbox)', () => {
+    const { container } = render(<YamlPreview yaml={'a: 1\nb: x\n'} filename="c.yaml" />)
+    const pre = container.querySelector('pre.code')
+    expect(pre).not.toBeNull()
+    expect(pre?.textContent).toContain('a: 1')
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+  })
+
+  it('Copy copies the yaml', () => {
+    render(<YamlPreview yaml={'a: 1\n'} filename="c.yaml" />)
+    fireEvent.click(screen.getByRole('button', { name: /^copy$/i }))
+    expect(copyText).toHaveBeenCalledWith('a: 1\n')
+  })
+
+  it('Download uses the monochrome class and triggers a download', () => {
+    render(<YamlPreview yaml={'a: 1\n'} filename="order.yaml" />)
+    const dl = screen.getByRole('button', { name: /download/i })
+    expect(dl).toHaveClass('btn', 'mono')
+    fireEvent.click(dl)
+    expect(URL.createObjectURL).toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- YamlPreview`
+Expected: FAIL — current YamlPreview renders a textbox / exports the old API.
+
+- [ ] **Step 3: Rewrite `YamlPreview.tsx`**
+
+Replace `web/src/components/YamlPreview.tsx` with:
+```tsx
+import { highlightYaml } from '../lib/yaml-highlight'
+import { copyText } from '../lib/clipboard'
+import { useToast } from '../lib/toast'
+import { downloadText } from '../lib/download'
+
+interface YamlPreviewProps {
+  yaml: string
+  filename: string
+}
+
+export function YamlPreview({ yaml, filename }: YamlPreviewProps) {
+  const { toast, toastNode } = useToast()
+  return (
+    <div>
+      <pre className="code">{highlightYaml(yaml)}</pre>
+      <div className="stepnav" style={{ marginTop: 10 }}>
+        <div className="spacer" />
+        <button type="button" className="btn ghost" onClick={() => { copyText(yaml); toast.show('Copied') }}>
+          Copy
+        </button>
+        <button type="button" className="btn mono" onClick={() => downloadText(filename, yaml)}>
+          Download
+        </button>
+      </div>
+      {toastNode}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Update `ComponentBuilder.tsx`**
+
+Replace `web/src/pages/component-builder/ComponentBuilder.tsx` with (drops `previewEdited`; adds selection bar; new preview usage):
+```tsx
+import { useMemo, useReducer } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Wizard, type WizardStep } from '../../components/wizard'
+import { YamlPreview } from '../../components/YamlPreview'
+import { dumpYaml } from '../../lib/yaml-emit'
+import { initialState, reducer, canContinue, assembleComponentSpec } from './reducer'
+import { StepType } from './StepType'
+import { StepAuth } from './StepAuth'
+import { StepConfigure } from './StepConfigure'
+
+export function ComponentBuilder() {
+  const navigate = useNavigate()
+  const [state, dispatch] = useReducer(reducer, undefined, initialState)
+
+  const yaml = useMemo(
+    () => (state.activeStep === 3 ? dumpYaml(assembleComponentSpec(state)) : ''),
+    [state],
+  )
+
+  const steps: WizardStep[] = [
+    { label: 'Type', content: <StepType state={state} dispatch={dispatch} /> },
+    { label: 'Auth', content: <StepAuth state={state} dispatch={dispatch} /> },
+    { label: 'Configure', content: <StepConfigure state={state} dispatch={dispatch} /> },
+    { label: 'Preview', content: <YamlPreview yaml={yaml} filename={`${state.name || 'component'}.yaml`} /> },
+  ]
+
+  return (
+    <div className="page">
+      <div className="phead">
+        <div>
+          <h1>New component</h1>
+          <div className="sub">Build a Dapr component YAML to copy or download</div>
+        </div>
+        <button type="button" className="btn ghost" onClick={() => navigate('/components')}>Cancel</button>
+      </div>
+      {(state.category || state.schema) && (
+        <div className="crumbs" aria-label="Selected component" style={{ marginBottom: 12 }}>
+          {state.category && <span className="typechip">{state.category}</span>}
+          {state.schema && <span className="b">{state.schema.title} · {state.version}</span>}
+        </div>
+      )}
+      <div className="card" style={{ padding: 18 }}>
+        <Wizard
+          steps={steps}
+          activeStep={state.activeStep}
+          canContinue={canContinue(state)}
+          onBack={() => dispatch({ type: 'BACK' })}
+          onContinue={() => dispatch({ type: 'NEXT' })}
+          onFinish={() => navigate('/components')}
+        />
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 5: Update the ComponentBuilder integration test**
+
+In `web/src/pages/component-builder/ComponentBuilder.test.tsx`: the Preview step is now a read-only `<pre>`, not a textbox. Replace the preview assertions (the `getByRole('textbox', { name: /generated yaml/i })` reads) with reads of the `<pre>` text, and **delete the back-then-forward Finish probe** (there is no editable buffer any more). The final assertions become:
+```tsx
+    // after Continue into Preview:
+    await screen.findByText(/kind: Component/i) // highlighted YAML is present
+    const pre = document.querySelector('pre.code') as HTMLPreElement
+    expect(pre.textContent).toContain('type: state.redis')
+    expect(pre.textContent).toContain('name: order-store')
+    expect(screen.getByRole('button', { name: /finish/i })).toBeEnabled()
+```
+Keep the earlier steps (category click, Redis click, Continue past Auth, fill Name + redisHost, Continue) as-is. If `findByText(/kind: Component/i)` is split across highlight spans and does not match, fall back to `await waitFor(() => expect(document.querySelector('pre.code')?.textContent).toContain('kind: Component'))` (import `waitFor`).
+
+- [ ] **Step 6: Update the Plan 3 doc for the read-only YamlPreview API**
+
+In `docs/superpowers/plans/2026-07-01-builders-03-resiliency.md`, Task 5 uses `YamlPreview` with `onEditedChange`/`previewEdited` gating in `ResiliencyBuilder.tsx`. Update that task's code and prose to the read-only API: `<YamlPreview yaml={yaml} filename={...} />` (no `onEditedChange`), remove the `previewEdited` state and the `state.activeStep === 3 ? !previewEdited : canContinue(state)` clause (use `canContinue(state)` directly; Finish always enabled on the preview step). This is a documentation edit only — no Plan 3 code exists yet.
+
+- [ ] **Step 7: Run the touched tests, full suite, type-check**
+
+Run: `npm test -- YamlPreview component-builder/ComponentBuilder` → PASS.
+Run: `npm test` → all green. Run: `npx tsc -b` → 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/components/YamlPreview.tsx web/src/components/YamlPreview.test.tsx web/src/pages/component-builder/ComponentBuilder.tsx web/src/pages/component-builder/ComponentBuilder.test.tsx docs/superpowers/plans/2026-07-01-builders-03-resiliency.md
+git commit -m "feat(web): read-only highlighted preview + builder selection bar; update Plan 3 doc"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Category filter chips on step 1 + scoped search + "pick a category" hint → Task 2. ✓
+- Selected category + component visible across steps (selection bar) → Task 4 (`ComponentBuilder`). ✓
+- Switching category clears schema + config → Task 1 (`SELECT_CATEGORY`). ✓
+- Removable optional fields (reuse state-connection dialog ✕ pattern) → Task 3 + `REMOVE_OPTIONAL` clears field state (Task 1). ✓
+- Read-only highlighted preview (reuse `highlightYaml`/`pre.code`), Copy + Download → Task 4. ✓
+- Drop `previewEdited` gate; Finish always enabled → Task 4. ✓
+- Plan 3 doc updated to read-only `YamlPreview` → Task 4 Step 6. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code + commands with expected results. The `findByText(/kind: Component/i)` fallback in Task 4 Step 5 is a stated contingency (highlight-span splitting), with the exact alternative given — not a placeholder.
+
+**Type consistency:** `category?: string` + `SELECT_CATEGORY` (Task 1) consumed by StepType (Task 2) and the selection bar (Task 4) with matching names. `REMOVE_OPTIONAL` payload `{ field }` consistent between reducer (Task 1), StepConfigure (Task 3), and tests. `YamlPreview({ yaml, filename })` (Task 4) matches its sole consumer `ComponentBuilder` (Task 4) and the updated Plan 3 doc. `SELECT_SCHEMA` payload `{ schema, version }` unchanged and consistent.
+
+**Cross-task note:** Tasks 2–4 depend on Task 1's reducer changes; execute in order. Tasks 2 and 4 both edit `ComponentBuilder.test.tsx` (Task 2 adds the category click; Task 4 updates the preview assertions) — non-overlapping edits.

--- a/docs/superpowers/plans/2026-07-02-resiliency-builder-enhancements.md
+++ b/docs/superpowers/plans/2026-07-02-resiliency-builder-enhancements.md
@@ -1,0 +1,1158 @@
+# Resiliency Builder Enhancements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enhance the shipped Resiliency Builder: default the namespace to `default`, show real (editable) default values in dialogs, make policy AND target chips editable by clicking them, and add cloudgrid's "override default Dapr policies" feature (the reserved `DaprBuiltIn*` retries).
+
+**Architecture:** Additive changes to the existing `web/src/pages/resiliency-builder/*` wizard. The `DaprResiliency` type and `useReducer` actions are reused unchanged except the namespace default and the Targets-step gating. Editing reuses the existing `UPSERT_*` actions (rename = `REMOVE_<old>` + `UPSERT_<new>`). A new `defaultPolicies.ts` module holds the built-in retry presets and helpers.
+
+**Tech Stack:** React 19, TS, Vite, React Router v6, Vitest + Testing Library. No new dependencies.
+
+**Prereq:** The Resiliency Builder exists and passes on branch `feat/component-resiliency-builders`.
+**Source spec:** `docs/superpowers/specs/2026-07-02-resiliency-builder-enhancements-design.md`
+
+## Global Constraints
+
+- **No new dependencies.** Controlled components; vanilla CSS theme tokens; reuse `components/form/*`, `components/Modal`.
+- **Wizard/dialog buttons stay `btn ghost`** (never green `btn.primary`), matching existing dialogs.
+- **Emit rule (unchanged):** `assembleResiliency` cleans only `spec` with `recursivelyRemoveEmptyValues`; assembles `metadata.name` (+ `namespace` only when its trimmed value is non-empty); omits empty `scopes`.
+- **Reserved override keys:** the 4 `DaprBuiltIn*` names are stored under `spec.policies.retries`; their name is locked in the dialog and they render only in the overrides section (filtered out of the regular Retries list).
+- **Do NOT modify** shared `components/form/TextInput.tsx` — a locked name renders as static read-only text inside the dialog instead.
+- **Tests:** Vitest + Testing Library, colocated. Run `npx tsc -b` before every commit. All `npm`/`npx` from `web/`.
+
+---
+
+## File Structure
+
+- Modify `web/src/types/resiliency.ts` — namespace default `'default'`.
+- Create `web/src/pages/resiliency-builder/defaultPolicies.ts` — built-in retry presets + `isDefaultPolicyName` + `presetToRetryPolicy`.
+- Modify `web/src/pages/resiliency-builder/reducer.ts` — override-aware Targets gating.
+- Modify `web/src/pages/resiliency-builder/policyDialogs.tsx` — real defaults; edit-mode + lock-name + keep-duration props; mode-aware titles.
+- Modify `web/src/pages/resiliency-builder/targetDialogs.tsx` — edit-mode props; mode-aware titles; component-direction derivation.
+- Modify `web/src/pages/resiliency-builder/NamedList.tsx` — optional `onEdit` + clickable chip body.
+- Modify `web/src/pages/resiliency-builder/StepPolicies.tsx` — edit wiring; overrides section; retries filter.
+- Modify `web/src/pages/resiliency-builder/StepTargets.tsx` — edit wiring.
+- Test files (colocated): `reducer.test.ts`, `defaultPolicies.test.ts` (new), `policyDialogs.test.tsx`, `targetDialogs.test.tsx`, `steps.test.tsx`, `ResiliencyBuilder.test.tsx`.
+
+---
+
+## Task 1: Namespace defaults to `default`
+
+**Files:**
+- Modify: `web/src/types/resiliency.ts:61` (`defaultResiliencyConfig` metadata)
+- Test: `web/src/pages/resiliency-builder/reducer.test.ts`
+
+**Interfaces:**
+- Consumes: `defaultResiliencyConfig(): DaprResiliency`, `assembleResiliency(config): Record<string, unknown>`, `reducer`, `initialState` (existing).
+- Produces: `defaultResiliencyConfig()` now returns `metadata.namespace === 'default'`.
+
+- [ ] **Step 1: Update the assemble test to expect the default namespace**
+
+In `reducer.test.ts`, replace the `assembleResiliency` describe block (currently lines ~45-55) with:
+
+```ts
+describe('assembleResiliency', () => {
+  it('keeps name + default namespace, cleans spec, omits empty scopes', () => {
+    let s = reducer(initialState(), { type: 'SET_NAME', name: 'r' })
+    s = reducer(s, { type: 'UPSERT_RETRY', name: 'retry1', policy: { policy: 'constant', duration: '5s', maxRetries: 3, maxInterval: '', matching: { httpStatusCodes: '', grpcStatusCodes: '' } } })
+    const out = assembleResiliency(s.config) as any
+    expect(out.metadata).toEqual({ name: 'r', namespace: 'default' })
+    expect(out.scopes).toBeUndefined()
+    expect(out.spec.policies.retries.retry1).toEqual({ policy: 'constant', duration: '5s', maxRetries: 3 })
+  })
+  it('omits namespace when cleared', () => {
+    let s = reducer(initialState(), { type: 'SET_NAME', name: 'r' })
+    s = reducer(s, { type: 'SET_NAMESPACE', namespace: '' })
+    const out = assembleResiliency(s.config) as any
+    expect(out.metadata).toEqual({ name: 'r' })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/reducer.test.ts`
+Expected: FAIL — `metadata` is `{ name: 'r' }`, expected `{ name: 'r', namespace: 'default' }`.
+
+- [ ] **Step 3: Set the default namespace**
+
+In `web/src/types/resiliency.ts`, in `defaultResiliencyConfig()`, change:
+
+```ts
+    metadata: { name: '', namespace: '' },
+```
+
+to:
+
+```ts
+    metadata: { name: '', namespace: 'default' },
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/reducer.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+cd web && npx tsc -b
+git add web/src/types/resiliency.ts web/src/pages/resiliency-builder/reducer.test.ts
+git commit -m "feat(web): default resiliency namespace to 'default'"
+```
+
+---
+
+## Task 2: Built-in retry presets module
+
+**Files:**
+- Create: `web/src/pages/resiliency-builder/defaultPolicies.ts`
+- Test: `web/src/pages/resiliency-builder/defaultPolicies.test.ts`
+
+**Interfaces:**
+- Consumes: `RetryPolicy` from `../../types/resiliency`.
+- Produces:
+  - `interface DefaultPolicyPreset { label: string; policy: 'constant' | 'exponential'; duration: string; maxInterval: string; maxRetries: number }`
+  - `DEFAULT_DAPR_RETRY_POLICIES: DefaultPolicyPreset[]` (length 4)
+  - `isDefaultPolicyName(name: string): boolean`
+  - `presetToRetryPolicy(p: DefaultPolicyPreset): RetryPolicy`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/pages/resiliency-builder/defaultPolicies.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { DEFAULT_DAPR_RETRY_POLICIES, isDefaultPolicyName, presetToRetryPolicy } from './defaultPolicies'
+
+describe('DEFAULT_DAPR_RETRY_POLICIES', () => {
+  it('has the four Dapr built-in retry policies with documented defaults', () => {
+    expect(DEFAULT_DAPR_RETRY_POLICIES).toHaveLength(4)
+    const service = DEFAULT_DAPR_RETRY_POLICIES.find((p) => p.label === 'DaprBuiltInServiceRetries')
+    expect(service).toEqual({ label: 'DaprBuiltInServiceRetries', policy: 'constant', duration: '1s', maxInterval: '', maxRetries: 3 })
+    const reminder = DEFAULT_DAPR_RETRY_POLICIES.find((p) => p.label === 'DaprBuiltInActorReminderRetries')
+    expect(reminder).toEqual({ label: 'DaprBuiltInActorReminderRetries', policy: 'exponential', duration: '15m', maxInterval: '60s', maxRetries: 3 })
+  })
+})
+
+describe('isDefaultPolicyName', () => {
+  it('matches only DaprBuiltIn* names', () => {
+    expect(isDefaultPolicyName('DaprBuiltInServiceRetries')).toBe(true)
+    expect(isDefaultPolicyName('retry1')).toBe(false)
+  })
+})
+
+describe('presetToRetryPolicy', () => {
+  it('carries duration + maxInterval for exponential presets', () => {
+    const reminder = DEFAULT_DAPR_RETRY_POLICIES.find((p) => p.label === 'DaprBuiltInActorReminderRetries')!
+    expect(presetToRetryPolicy(reminder)).toEqual({ policy: 'exponential', duration: '15m', maxInterval: '60s', maxRetries: 3 })
+  })
+  it('drops empty maxInterval for constant presets', () => {
+    const service = DEFAULT_DAPR_RETRY_POLICIES.find((p) => p.label === 'DaprBuiltInServiceRetries')!
+    expect(presetToRetryPolicy(service)).toEqual({ policy: 'constant', duration: '1s', maxInterval: undefined, maxRetries: 3 })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/defaultPolicies.test.ts`
+Expected: FAIL — cannot find module `./defaultPolicies`.
+
+- [ ] **Step 3: Create the module**
+
+Create `web/src/pages/resiliency-builder/defaultPolicies.ts`:
+
+```ts
+import type { RetryPolicy } from '../../types/resiliency'
+
+export interface DefaultPolicyPreset {
+  label: string
+  policy: 'constant' | 'exponential'
+  duration: string
+  maxInterval: string
+  maxRetries: number
+}
+
+/** The four reserved Dapr built-in retry policies (mirrors cloudgrid DEFAULT_DAPR_RETRY_POLICIES). */
+export const DEFAULT_DAPR_RETRY_POLICIES: DefaultPolicyPreset[] = [
+  { label: 'DaprBuiltInServiceRetries', policy: 'constant', duration: '1s', maxInterval: '', maxRetries: 3 },
+  { label: 'DaprBuiltInActorRetries', policy: 'constant', duration: '1s', maxInterval: '', maxRetries: 3 },
+  { label: 'DaprBuiltInActorReminderRetries', policy: 'exponential', duration: '15m', maxInterval: '60s', maxRetries: 3 },
+  { label: 'DaprBuiltInInitializationRetries', policy: 'exponential', duration: '10s', maxInterval: '500ms', maxRetries: 3 },
+]
+
+/** True for the reserved built-in override keys (they live only in the overrides section). */
+export function isDefaultPolicyName(name: string): boolean {
+  return name.startsWith('DaprBuiltIn')
+}
+
+/** Convert a preset to a RetryPolicy; empty maxInterval becomes undefined so it isn't emitted for constant. */
+export function presetToRetryPolicy(p: DefaultPolicyPreset): RetryPolicy {
+  return {
+    policy: p.policy,
+    duration: p.duration,
+    maxInterval: p.maxInterval || undefined,
+    maxRetries: p.maxRetries,
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/defaultPolicies.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+cd web && npx tsc -b
+git add web/src/pages/resiliency-builder/defaultPolicies.ts web/src/pages/resiliency-builder/defaultPolicies.test.ts
+git commit -m "feat(web): add Dapr built-in retry policy presets module"
+```
+
+---
+
+## Task 3: Override-aware Targets-step gating
+
+**Files:**
+- Modify: `web/src/pages/resiliency-builder/reducer.ts` (`canContinue`, case 2)
+- Test: `web/src/pages/resiliency-builder/reducer.test.ts`
+
+**Interfaces:**
+- Consumes: `isDefaultPolicyName` from `./defaultPolicies` (Task 2).
+- Produces: `canContinue(state)` at step 2 returns true when there is ≥1 target OR ≥1 `DaprBuiltIn*` retry override.
+
+- [ ] **Step 1: Write the failing test**
+
+In `reducer.test.ts`, inside the `describe('canContinue', ...)` block, add:
+
+```ts
+  it('step 2 passes with a DaprBuiltIn override and no explicit target', () => {
+    let s = reducer(initialState(), { type: 'SET_NAME', name: 'r' })
+    s = reducer(s, { type: 'UPSERT_RETRY', name: 'DaprBuiltInServiceRetries', policy: { policy: 'constant', duration: '1s', maxRetries: 3 } })
+    s = reducer(s, { type: 'NEXT' }) // 0->1
+    s = reducer(s, { type: 'NEXT' }) // 1->2
+    expect(canContinue(s)).toBe(true)
+  })
+  it('step 2 fails with only a non-builtin retry and no target', () => {
+    let s = reducer(initialState(), { type: 'SET_NAME', name: 'r' })
+    s = reducer(s, { type: 'UPSERT_RETRY', name: 'retry1', policy: { policy: 'constant', duration: '5s' } })
+    s = reducer(s, { type: 'NEXT' })
+    s = reducer(s, { type: 'NEXT' })
+    expect(canContinue(s)).toBe(false)
+  })
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/reducer.test.ts`
+Expected: FAIL — the DaprBuiltIn-override case returns false (only targets counted).
+
+- [ ] **Step 3: Update the gating**
+
+In `web/src/pages/resiliency-builder/reducer.ts`, add the import near the top:
+
+```ts
+import { isDefaultPolicyName } from './defaultPolicies'
+```
+
+Replace the `case 2:` branch in `canContinue`:
+
+```ts
+    case 2:
+      return countAll(targets.apps) + countAll(targets.actors) + countAll(targets.components) > 0
+```
+
+with:
+
+```ts
+    case 2: {
+      const hasTarget = countAll(targets.apps) + countAll(targets.actors) + countAll(targets.components) > 0
+      const hasOverride = Object.keys(policies.retries).some(isDefaultPolicyName)
+      return hasTarget || hasOverride
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/reducer.test.ts`
+Expected: PASS (existing step-2 test that adds an app still passes).
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+cd web && npx tsc -b
+git add web/src/pages/resiliency-builder/reducer.ts web/src/pages/resiliency-builder/reducer.test.ts
+git commit -m "feat(web): allow finishing with a DaprBuiltIn override and no explicit target"
+```
+
+---
+
+## Task 4: Editable chips in NamedList
+
+**Files:**
+- Modify: `web/src/pages/resiliency-builder/NamedList.tsx`
+- Test: `web/src/pages/resiliency-builder/policyDialogs.test.tsx` (the `NamedList` describe block already lives here)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `NamedList({ title, names, onAdd, onRemove, onEdit? })` where `onEdit?: (name: string) => void`. When `onEdit` is provided, clicking the chip body (button labelled `Edit <name>`) fires `onEdit(name)`; the ✕ button still fires `onRemove(name)` and does not also trigger edit.
+
+- [ ] **Step 1: Write the failing test**
+
+In `policyDialogs.test.tsx`, replace the `NamedList` describe block with:
+
+```ts
+describe('NamedList', () => {
+  it('renders names, add, and remove', () => {
+    const onAdd = vi.fn(); const onRemove = vi.fn()
+    render(<NamedList title="Timeouts" names={['timeout1']} onAdd={onAdd} onRemove={onRemove} />)
+    expect(screen.getByText('timeout1')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /add timeouts/i }))
+    expect(onAdd).toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: /remove timeout1/i }))
+    expect(onRemove).toHaveBeenCalledWith('timeout1')
+  })
+  it('fires onEdit from the chip body and not on remove', () => {
+    const onEdit = vi.fn(); const onRemove = vi.fn()
+    render(<NamedList title="Timeouts" names={['timeout1']} onAdd={vi.fn()} onRemove={onRemove} onEdit={onEdit} />)
+    fireEvent.click(screen.getByRole('button', { name: /edit timeout1/i }))
+    expect(onEdit).toHaveBeenCalledWith('timeout1')
+    expect(onRemove).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: /remove timeout1/i }))
+    expect(onRemove).toHaveBeenCalledWith('timeout1')
+    expect(onEdit).toHaveBeenCalledTimes(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/policyDialogs.test.tsx`
+Expected: FAIL — no `Edit timeout1` button.
+
+- [ ] **Step 3: Implement the clickable chip body**
+
+Replace `web/src/pages/resiliency-builder/NamedList.tsx` with:
+
+```tsx
+interface NamedListProps {
+  title: string
+  names: string[]
+  onAdd: () => void
+  onRemove: (name: string) => void
+  onEdit?: (name: string) => void
+}
+
+export function NamedList({ title, names, onAdd, onRemove, onEdit }: NamedListProps) {
+  return (
+    <div className="sbsection">
+      <div className="sech">
+        {title}
+        <button type="button" className="btn ghost" style={{ marginLeft: 'auto' }} aria-label={`Add ${title}`} onClick={onAdd}>
+          + Add
+        </button>
+      </div>
+      {names.length === 0 ? (
+        <p className="none">None yet.</p>
+      ) : (
+        names.map((name) => (
+          <div key={name} className="chip k" style={{ marginRight: 6, marginBottom: 6 }}>
+            {onEdit ? (
+              <button
+                type="button"
+                className="chip-edit"
+                aria-label={`Edit ${name}`}
+                onClick={() => onEdit(name)}
+                style={{ background: 'none', border: 0, cursor: 'pointer', font: 'inherit', padding: 0 }}
+              >
+                <b>{name}</b>
+              </button>
+            ) : (
+              <b>{name}</b>
+            )}
+            <button
+              type="button"
+              className="copybtn"
+              aria-label={`Remove ${name}`}
+              onClick={(e) => { e.stopPropagation(); onRemove(name) }}
+            >
+              ✕
+            </button>
+          </div>
+        ))
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/policyDialogs.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+cd web && npx tsc -b
+git add web/src/pages/resiliency-builder/NamedList.tsx web/src/pages/resiliency-builder/policyDialogs.test.tsx
+git commit -m "feat(web): make resiliency NamedList chips editable via onEdit"
+```
+
+---
+
+## Task 5: Policy dialogs — real defaults, edit mode, locked name, keep-duration
+
+**Files:**
+- Modify: `web/src/pages/resiliency-builder/policyDialogs.tsx`
+- Test: `web/src/pages/resiliency-builder/policyDialogs.test.tsx`
+
+**Interfaces:**
+- Consumes: `RetryPolicy`, `CircuitBreakerPolicy` from `../../types/resiliency`.
+- Produces (new/changed dialog props):
+  - `TimeoutDialog({ open, initialName, initialDuration?, editing?, onClose, onSave })` — duration defaults to `initialDuration ?? '5s'`; title `Edit`/`Add timeout policy`.
+  - `RetryDialog({ open, initialName, initialPolicy?, editing?, lockName?, keepDurationForExponential?, onClose, onSave })` — fields default from `initialPolicy` (fallback `constant`/`5s`/`60s`/`-1`); when `lockName`, the name renders as static read-only text; when `keepDurationForExponential`, an exponential save also emits `duration`.
+  - `CircuitBreakerDialog({ open, initialName, initialPolicy?, editing?, onClose, onSave })` — defaults `maxRequests 1`, `timeout 45s`, `trip 'consecutiveFailures >= 5'`, `interval 8s`; title `Edit`/`Add circuit breaker policy`.
+  - `onSave` signatures unchanged: `(name, duration)` / `(name, policy)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `policyDialogs.test.tsx`, add `CircuitBreakerDialog` to the import line and add these describe blocks:
+
+```ts
+import { NamedList, TimeoutDialog, RetryDialog, CircuitBreakerDialog } from './policyDialogs'
+```
+
+```ts
+describe('TimeoutDialog defaults + edit', () => {
+  it('prefills 5s on add', () => {
+    render(<TimeoutDialog open initialName="timeout1" onClose={vi.fn()} onSave={vi.fn()} />)
+    expect((screen.getByLabelText(/duration/i) as HTMLInputElement).value).toBe('5s')
+  })
+  it('prefills the existing duration and title on edit', () => {
+    const onSave = vi.fn()
+    render(<TimeoutDialog open editing initialName="timeout1" initialDuration="42s" onClose={vi.fn()} onSave={onSave} />)
+    expect(screen.getByText(/edit timeout policy/i)).toBeInTheDocument()
+    expect((screen.getByLabelText(/duration/i) as HTMLInputElement).value).toBe('42s')
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(onSave).toHaveBeenCalledWith('timeout1', '42s')
+  })
+})
+
+describe('CircuitBreakerDialog defaults', () => {
+  it('prefills canonical defaults as real text', () => {
+    render(<CircuitBreakerDialog open initialName="circuitBreaker1" onClose={vi.fn()} onSave={vi.fn()} />)
+    expect((screen.getByLabelText(/max requests/i) as HTMLInputElement).value).toBe('1')
+    expect((screen.getByLabelText(/^timeout/i) as HTMLInputElement).value).toBe('45s')
+    expect((screen.getByLabelText(/trip/i) as HTMLInputElement).value).toBe('consecutiveFailures >= 5')
+    expect((screen.getByLabelText(/interval/i) as HTMLInputElement).value).toBe('8s')
+  })
+})
+
+describe('RetryDialog edit + lock + keep-duration', () => {
+  it('locks the name when lockName is set', () => {
+    render(<RetryDialog open initialName="DaprBuiltInServiceRetries" lockName onClose={vi.fn()} onSave={vi.fn()} />)
+    expect(screen.queryByLabelText(/retry name/i)).not.toBeInTheDocument()
+    expect(screen.getByText('DaprBuiltInServiceRetries')).toBeInTheDocument()
+  })
+  it('keeps duration for an exponential override on save', () => {
+    const onSave = vi.fn()
+    render(
+      <RetryDialog open editing lockName keepDurationForExponential
+        initialName="DaprBuiltInActorReminderRetries"
+        initialPolicy={{ policy: 'exponential', duration: '15m', maxInterval: '60s', maxRetries: 3 }}
+        onClose={vi.fn()} onSave={onSave} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(onSave).toHaveBeenCalledWith('DaprBuiltInActorReminderRetries', expect.objectContaining({ policy: 'exponential', duration: '15m', maxInterval: '60s', maxRetries: 3 }))
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/policyDialogs.test.tsx`
+Expected: FAIL — CB defaults empty, no `editing`/`lockName`/`keepDurationForExponential` support.
+
+- [ ] **Step 3: Update the three dialogs**
+
+Replace `TimeoutDialog`, `RetryDialog`, and `CircuitBreakerDialog` in `web/src/pages/resiliency-builder/policyDialogs.tsx` with:
+
+```tsx
+export function TimeoutDialog({ open, initialName, initialDuration, editing, onClose, onSave }: {
+  open: boolean; initialName: string; initialDuration?: string; editing?: boolean; onClose: () => void; onSave: (name: string, duration: string) => void
+}) {
+  const [name, setName] = useState(initialName)
+  const [duration, setDuration] = useState(initialDuration ?? '5s')
+  const nameErr = name === '' ? 'Name is required' : validateResourceName(name)
+  const durOk = duration !== '' && validateGoDuration(duration).valid
+  return (
+    <DialogShell open={open} title={editing ? 'Edit timeout policy' : 'Add timeout policy'} onClose={onClose} canSave={!nameErr && durOk}
+      onSave={() => onSave(name, duration)}>
+      <Field label="Name" required error={name === '' ? null : nameErr}>
+        <TextInput aria-label="Timeout name" value={name} onChange={setName} />
+      </Field>
+      <Field label="Duration" required error={duration === '' ? null : (durOk ? null : validateGoDuration(duration).error)}>
+        <TextInput aria-label="Duration" placeholder="30s" value={duration} onChange={setDuration} />
+      </Field>
+    </DialogShell>
+  )
+}
+
+export function RetryDialog({ open, initialName, initialPolicy, editing, lockName, keepDurationForExponential, onClose, onSave }: {
+  open: boolean; initialName: string; initialPolicy?: RetryPolicy; editing?: boolean; lockName?: boolean; keepDurationForExponential?: boolean
+  onClose: () => void; onSave: (name: string, policy: RetryPolicy) => void
+}) {
+  const [name, setName] = useState(initialName)
+  const [policy, setPolicy] = useState<'constant' | 'exponential'>(initialPolicy?.policy ?? 'constant')
+  const [duration, setDuration] = useState(initialPolicy?.duration ?? '5s')
+  const [maxInterval, setMaxInterval] = useState(initialPolicy?.maxInterval ?? '60s')
+  const [maxRetries, setMaxRetries] = useState(initialPolicy?.maxRetries?.toString() ?? '-1')
+  const [http, setHttp] = useState(initialPolicy?.matching?.httpStatusCodes ?? '')
+  const [grpc, setGrpc] = useState(initialPolicy?.matching?.grpcStatusCodes ?? '')
+  const nameErr = name === '' ? 'Name is required' : validateResourceName(name)
+  const durField = policy === 'constant' ? duration : maxInterval
+  const durOk = validateGoDuration(durField).valid
+  const numOk = integerError(maxRetries) === null
+  const codesOk = validateStatusCodes(http) === null && validateStatusCodes(grpc) === null
+  const canSave = !nameErr && durOk && numOk && codesOk
+  function save() {
+    const p: RetryPolicy = {
+      policy,
+      maxRetries: maxRetries === '' ? undefined : Number(maxRetries),
+      matching: { httpStatusCodes: http, grpcStatusCodes: grpc },
+    }
+    if (policy === 'constant') {
+      p.duration = duration
+    } else {
+      p.maxInterval = maxInterval
+      if (keepDurationForExponential && duration !== '') p.duration = duration
+    }
+    onSave(name, p)
+  }
+  return (
+    <DialogShell open={open} title={editing ? 'Edit retry policy' : 'Add retry policy'} onClose={onClose} canSave={canSave} onSave={save}>
+      {lockName ? (
+        <Field label="Name"><b>{name}</b></Field>
+      ) : (
+        <Field label="Name" required error={name === '' ? null : nameErr}>
+          <TextInput aria-label="Retry name" value={name} onChange={setName} />
+        </Field>
+      )}
+      <Field label="Policy" required>
+        <SelectInput aria-label="Retry policy type" value={policy}
+          options={[{ label: 'constant', value: 'constant' }, { label: 'exponential', value: 'exponential' }]}
+          onChange={(v) => setPolicy(v === 'exponential' ? 'exponential' : 'constant')} />
+      </Field>
+      {policy === 'constant' ? (
+        <Field label="Duration" required error={durOk ? null : validateGoDuration(duration).error}>
+          <TextInput aria-label="Duration" placeholder="5s" value={duration} onChange={setDuration} />
+        </Field>
+      ) : (
+        <Field label="Max interval" required error={durOk ? null : validateGoDuration(maxInterval).error}>
+          <TextInput aria-label="Max interval" placeholder="60s" value={maxInterval} onChange={setMaxInterval} />
+        </Field>
+      )}
+      <Field label="Max retries" error={numOk ? null : 'Must be an integer'}>
+        <NumberInput aria-label="Max retries" value={maxRetries} onChange={setMaxRetries} />
+      </Field>
+      <Field label="HTTP status codes" error={validateStatusCodes(http)}>
+        <TextInput aria-label="HTTP status codes" placeholder="429,500-504" value={http} onChange={setHttp} />
+      </Field>
+      <Field label="gRPC status codes" error={validateStatusCodes(grpc)}>
+        <TextInput aria-label="gRPC status codes" placeholder="4,8,14" value={grpc} onChange={setGrpc} />
+      </Field>
+    </DialogShell>
+  )
+}
+
+export function CircuitBreakerDialog({ open, initialName, initialPolicy, editing, onClose, onSave }: {
+  open: boolean; initialName: string; initialPolicy?: CircuitBreakerPolicy; editing?: boolean; onClose: () => void; onSave: (name: string, policy: CircuitBreakerPolicy) => void
+}) {
+  const [name, setName] = useState(initialName)
+  const [maxRequests, setMaxRequests] = useState(initialPolicy?.maxRequests?.toString() ?? '1')
+  const [timeoutDur, setTimeoutDur] = useState(initialPolicy?.timeout ?? '45s')
+  const [trip, setTrip] = useState(initialPolicy?.trip ?? 'consecutiveFailures >= 5')
+  const [intervalDur, setIntervalDur] = useState(initialPolicy?.interval ?? '8s')
+  const nameErr = name === '' ? 'Name is required' : validateResourceName(name)
+  const numOk = integerError(maxRequests) === null
+  const toOk = validateGoDuration(timeoutDur).valid
+  const ivOk = validateGoDuration(intervalDur).valid
+  const canSave = !nameErr && numOk && toOk && ivOk
+  function save() {
+    onSave(name, {
+      maxRequests: maxRequests === '' ? undefined : Number(maxRequests),
+      timeout: timeoutDur, trip, interval: intervalDur,
+    })
+  }
+  return (
+    <DialogShell open={open} title={editing ? 'Edit circuit breaker policy' : 'Add circuit breaker policy'} onClose={onClose} canSave={canSave} onSave={save}>
+      <Field label="Name" required error={name === '' ? null : nameErr}>
+        <TextInput aria-label="Circuit breaker name" value={name} onChange={setName} />
+      </Field>
+      <Field label="Max requests" error={numOk ? null : 'Must be an integer'}>
+        <NumberInput aria-label="Max requests" value={maxRequests} onChange={setMaxRequests} />
+      </Field>
+      <Field label="Timeout" error={timeoutDur === '' ? null : (toOk ? null : validateGoDuration(timeoutDur).error)}>
+        <TextInput aria-label="Timeout" placeholder="30s" value={timeoutDur} onChange={setTimeoutDur} />
+      </Field>
+      <Field label="Trip (CEL)">
+        <TextInput aria-label="Trip" placeholder="consecutiveFailures >= 5" value={trip} onChange={setTrip} />
+      </Field>
+      <Field label="Interval" error={intervalDur === '' ? null : (ivOk ? null : validateGoDuration(intervalDur).error)}>
+        <TextInput aria-label="Interval" placeholder="8s" value={intervalDur} onChange={setIntervalDur} />
+      </Field>
+    </DialogShell>
+  )
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/policyDialogs.test.tsx`
+Expected: PASS (existing `TimeoutDialog`/`RetryDialog` save tests still pass).
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+cd web && npx tsc -b
+git add web/src/pages/resiliency-builder/policyDialogs.tsx web/src/pages/resiliency-builder/policyDialogs.test.tsx
+git commit -m "feat(web): resiliency policy dialogs gain real defaults + edit/lock/keep-duration"
+```
+
+---
+
+## Task 6: Target dialogs — edit mode + component-direction derivation
+
+**Files:**
+- Modify: `web/src/pages/resiliency-builder/targetDialogs.tsx`
+- Test: `web/src/pages/resiliency-builder/targetDialogs.test.tsx`
+
+**Interfaces:**
+- Consumes: `AppTarget`, `ActorTarget`, `ComponentTarget` from `../../types/resiliency`; `PolicyNames` (existing).
+- Produces (changed props):
+  - `AppTargetDialog({ open, policies, initialName?, initialTarget?, editing?, onClose, onSave })`
+  - `ActorTargetDialog({ open, policies, initialName?, initialTarget?, editing?, onClose, onSave })`
+  - `ComponentTargetDialog({ open, policies, initialName?, initialTarget?, editing?, onClose, onSave })` — direction derived from `initialTarget` (both legs → `both`; else the present leg; default `outbound`); pickers prefill from `outbound` else `inbound`.
+  - Titles `Edit`/`Add … target`. `onSave` signatures unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `targetDialogs.test.tsx`, add:
+
+```ts
+describe('AppTargetDialog edit', () => {
+  it('prefills name + policy refs and title on edit', () => {
+    const onSave = vi.fn()
+    render(<AppTargetDialog open editing policies={policies} initialName="orders" initialTarget={{ timeout: 'timeout1', retry: 'retry1' }} onClose={vi.fn()} onSave={onSave} />)
+    expect(screen.getByText(/edit app target/i)).toBeInTheDocument()
+    expect((screen.getByLabelText(/app id/i) as HTMLInputElement).value).toBe('orders')
+    expect((screen.getByLabelText(/^timeout policy/i) as HTMLSelectElement).value).toBe('timeout1')
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(onSave).toHaveBeenCalledWith('orders', expect.objectContaining({ timeout: 'timeout1', retry: 'retry1' }))
+  })
+})
+
+describe('ComponentTargetDialog edit', () => {
+  it('derives both-direction and prefills from outbound leg', () => {
+    render(<ComponentTargetDialog open editing policies={policies} initialName="statestore" initialTarget={{ outbound: { retry: 'retry1' }, inbound: { retry: 'retry1' } }} onClose={vi.fn()} onSave={vi.fn()} />)
+    expect((screen.getByLabelText(/direction/i) as HTMLSelectElement).value).toBe('both')
+    expect((screen.getByLabelText(/^retry policy/i) as HTMLSelectElement).value).toBe('retry1')
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/targetDialogs.test.tsx`
+Expected: FAIL — dialogs ignore `initialName`/`initialTarget`/`editing`.
+
+- [ ] **Step 3: Update the three target dialogs**
+
+In `web/src/pages/resiliency-builder/targetDialogs.tsx`, replace the three exported dialog functions with:
+
+```tsx
+export function AppTargetDialog({ open, policies, initialName, initialTarget, editing, onClose, onSave }: {
+  open: boolean; policies: PolicyNames; initialName?: string; initialTarget?: AppTarget; editing?: boolean; onClose: () => void; onSave: (name: string, target: AppTarget) => void
+}) {
+  const [name, setName] = useState(initialName ?? '')
+  const [timeoutRef, setTimeoutRef] = useState(initialTarget?.timeout ?? '')
+  const [retry, setRetry] = useState(initialTarget?.retry ?? '')
+  const [cb, setCb] = useState(initialTarget?.circuitBreaker ?? '')
+  const nameOk = validateResourceName(name) === null
+  const anyPolicy = !!(timeoutRef || retry || cb)
+  function save() {
+    const t: AppTarget = {}
+    if (timeoutRef) t.timeout = timeoutRef
+    if (retry) t.retry = retry
+    if (cb) t.circuitBreaker = cb
+    onSave(name, t)
+  }
+  return (
+    <Shell open={open} title={editing ? 'Edit app target' : 'Add app target'} onClose={onClose} canSave={nameOk && anyPolicy} onSave={save}>
+      <Field label="App ID" required error={name === '' ? null : validateResourceName(name)}>
+        <TextInput aria-label="App ID" value={name} onChange={setName} />
+      </Field>
+      <PolicyPickers policies={policies} timeout={timeoutRef} retry={retry} cb={cb} setTimeout={setTimeoutRef} setRetry={setRetry} setCb={setCb} />
+    </Shell>
+  )
+}
+
+export function ActorTargetDialog({ open, policies, initialName, initialTarget, editing, onClose, onSave }: {
+  open: boolean; policies: PolicyNames; initialName?: string; initialTarget?: ActorTarget; editing?: boolean; onClose: () => void; onSave: (name: string, target: ActorTarget) => void
+}) {
+  const [name, setName] = useState(initialName ?? '')
+  const [timeoutRef, setTimeoutRef] = useState(initialTarget?.timeout ?? '')
+  const [retry, setRetry] = useState(initialTarget?.retry ?? '')
+  const [cb, setCb] = useState(initialTarget?.circuitBreaker ?? '')
+  const [scope, setScope] = useState<'' | 'type' | 'id' | 'both'>(initialTarget?.circuitBreakerScope ?? '')
+  const [cacheSize, setCacheSize] = useState(initialTarget?.circuitBreakerCacheSize?.toString() ?? '')
+  const nameOk = validateResourceName(name) === null
+  const anyPolicy = !!(timeoutRef || retry || cb)
+  const cacheOk = integerError(cacheSize) === null
+  function save() {
+    const t: ActorTarget = {}
+    if (timeoutRef) t.timeout = timeoutRef
+    if (retry) t.retry = retry
+    if (cb) {
+      t.circuitBreaker = cb
+      if (scope) t.circuitBreakerScope = scope
+      if (cacheSize) t.circuitBreakerCacheSize = Number(cacheSize)
+    }
+    onSave(name, t)
+  }
+  return (
+    <Shell open={open} title={editing ? 'Edit actor target' : 'Add actor target'} onClose={onClose} canSave={nameOk && anyPolicy && cacheOk} onSave={save}>
+      <Field label="Actor type" required error={name === '' ? null : validateResourceName(name)}>
+        <TextInput aria-label="Actor type" value={name} onChange={setName} />
+      </Field>
+      <PolicyPickers policies={policies} timeout={timeoutRef} retry={retry} cb={cb} setTimeout={setTimeoutRef} setRetry={setRetry} setCb={setCb} />
+      {cb && (
+        <>
+          <Field label="Circuit breaker scope">
+            <SelectInput aria-label="Circuit breaker scope" value={scope}
+              options={[{ label: 'type', value: 'type' }, { label: 'id', value: 'id' }, { label: 'both', value: 'both' }]}
+              onChange={(v) => setScope((v as '' | 'type' | 'id' | 'both'))} />
+          </Field>
+          <Field label="Circuit breaker cache size" error={cacheOk ? null : 'Must be an integer'}>
+            <NumberInput aria-label="Circuit breaker cache size" value={cacheSize} onChange={setCacheSize} />
+          </Field>
+        </>
+      )}
+    </Shell>
+  )
+}
+
+export function ComponentTargetDialog({ open, policies, initialName, initialTarget, editing, onClose, onSave }: {
+  open: boolean; policies: PolicyNames; initialName?: string; initialTarget?: ComponentTarget; editing?: boolean; onClose: () => void; onSave: (name: string, target: ComponentTarget) => void
+}) {
+  const hasOut = !!initialTarget?.outbound
+  const hasIn = !!initialTarget?.inbound
+  const initialDirection: 'outbound' | 'inbound' | 'both' = hasOut && hasIn ? 'both' : hasIn ? 'inbound' : 'outbound'
+  const initialLeg = initialTarget?.outbound ?? initialTarget?.inbound
+  const [name, setName] = useState(initialName ?? '')
+  const [direction, setDirection] = useState<'outbound' | 'inbound' | 'both'>(initialDirection)
+  const [timeoutRef, setTimeoutRef] = useState(initialLeg?.timeout ?? '')
+  const [retry, setRetry] = useState(initialLeg?.retry ?? '')
+  const [cb, setCb] = useState(initialLeg?.circuitBreaker ?? '')
+  const nameOk = validateResourceName(name) === null
+  const anyPolicy = !!(timeoutRef || retry || cb)
+  function leg() {
+    const l: { timeout?: string; retry?: string; circuitBreaker?: string } = {}
+    if (timeoutRef) l.timeout = timeoutRef
+    if (retry) l.retry = retry
+    if (cb) l.circuitBreaker = cb
+    return l
+  }
+  function save() {
+    const t: ComponentTarget = {}
+    if (direction === 'outbound' || direction === 'both') t.outbound = leg()
+    if (direction === 'inbound' || direction === 'both') t.inbound = leg()
+    onSave(name, t)
+  }
+  return (
+    <Shell open={open} title={editing ? 'Edit component target' : 'Add component target'} onClose={onClose} canSave={nameOk && anyPolicy} onSave={save}>
+      <Field label="Component name" required error={name === '' ? null : validateResourceName(name)}>
+        <TextInput aria-label="Component name" value={name} onChange={setName} />
+      </Field>
+      <Field label="Direction" required>
+        <SelectInput aria-label="Direction" value={direction}
+          options={[{ label: 'outbound', value: 'outbound' }, { label: 'inbound', value: 'inbound' }, { label: 'both', value: 'both' }]}
+          onChange={(v) => setDirection(v === 'inbound' ? 'inbound' : v === 'both' ? 'both' : 'outbound')} />
+      </Field>
+      <PolicyPickers policies={policies} timeout={timeoutRef} retry={retry} cb={cb} setTimeout={setTimeoutRef} setRetry={setRetry} setCb={setCb} />
+    </Shell>
+  )
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/targetDialogs.test.tsx`
+Expected: PASS (existing add-mode tests still pass).
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+cd web && npx tsc -b
+git add web/src/pages/resiliency-builder/targetDialogs.tsx web/src/pages/resiliency-builder/targetDialogs.test.tsx
+git commit -m "feat(web): resiliency target dialogs gain edit mode + direction derivation"
+```
+
+---
+
+## Task 7: StepPolicies — edit wiring, retries filter, overrides section
+
+**Files:**
+- Modify: `web/src/pages/resiliency-builder/StepPolicies.tsx`
+- Test: `web/src/pages/resiliency-builder/steps.test.tsx`
+
+**Interfaces:**
+- Consumes: `NamedList` (Task 4), `TimeoutDialog`/`RetryDialog`/`CircuitBreakerDialog` (Task 5), `DEFAULT_DAPR_RETRY_POLICIES`/`isDefaultPolicyName`/`presetToRetryPolicy` (Task 2), `nextName`/`Action`/`ResiliencyState` (existing).
+- Produces: `StepPolicies({ state, dispatch })` renders three editable lists (Retries list filters out `DaprBuiltIn*` keys) plus a "Default policy overrides" section with one row per built-in (Add or editable chip). Rename dispatches `REMOVE_*` + `UPSERT_*`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `steps.test.tsx`, add these tests inside the `describe('StepPolicies', ...)` block:
+
+```ts
+  it('edits an existing timeout via chip click (rename dispatches remove + upsert)', () => {
+    const dispatch = vi.fn()
+    const s = reducer(initialState(), { type: 'UPSERT_TIMEOUT', name: 'timeout1', duration: '30s' })
+    render(<StepPolicies state={s} dispatch={dispatch} />)
+    fireEvent.click(screen.getByRole('button', { name: /edit timeout1/i }))
+    fireEvent.change(screen.getByLabelText(/timeout name/i), { target: { value: 'renamed' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(dispatch).toHaveBeenCalledWith({ type: 'REMOVE_TIMEOUT', name: 'timeout1' })
+    expect(dispatch).toHaveBeenCalledWith({ type: 'UPSERT_TIMEOUT', name: 'renamed', duration: '30s' })
+  })
+  it('adds a DaprBuiltIn override with prefilled defaults', () => {
+    const dispatch = vi.fn()
+    render(<StepPolicies state={initialState()} dispatch={dispatch} />)
+    fireEvent.click(screen.getByRole('button', { name: /add DaprBuiltInServiceRetries/i }))
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'UPSERT_RETRY',
+      name: 'DaprBuiltInServiceRetries',
+      policy: expect.objectContaining({ policy: 'constant', duration: '1s', maxRetries: 3 }),
+    })
+  })
+  it('does not list a DaprBuiltIn override in the regular Retries list', () => {
+    const dispatch = vi.fn()
+    const s = reducer(initialState(), { type: 'UPSERT_RETRY', name: 'DaprBuiltInServiceRetries', policy: { policy: 'constant', duration: '1s', maxRetries: 3 } })
+    render(<StepPolicies state={s} dispatch={dispatch} />)
+    // present as an editable override chip, but not offered as an "Add" row anymore
+    expect(screen.getByRole('button', { name: /edit DaprBuiltInServiceRetries/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /add DaprBuiltInServiceRetries/i })).not.toBeInTheDocument()
+  })
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/steps.test.tsx`
+Expected: FAIL — no edit wiring, no overrides section.
+
+- [ ] **Step 3: Rewrite StepPolicies**
+
+Replace `web/src/pages/resiliency-builder/StepPolicies.tsx` with:
+
+```tsx
+import { useState } from 'react'
+import { NamedList } from './NamedList'
+import { TimeoutDialog, RetryDialog, CircuitBreakerDialog } from './policyDialogs'
+import { DEFAULT_DAPR_RETRY_POLICIES, isDefaultPolicyName, presetToRetryPolicy } from './defaultPolicies'
+import { nextName, type Action, type ResiliencyState } from './reducer'
+
+type Dialog =
+  | null
+  | { kind: 'timeout' | 'retry' | 'cb'; editName?: string }
+  | { kind: 'override'; label: string; editing: boolean }
+
+export function StepPolicies({ state, dispatch }: { state: ResiliencyState; dispatch: (a: Action) => void }) {
+  const [open, setOpen] = useState<Dialog>(null)
+  const pol = state.config.spec.policies
+  const customRetryNames = Object.keys(pol.retries).filter((n) => !isDefaultPolicyName(n))
+
+  function renameThenUpsert<A extends Action>(editName: string | undefined, name: string, removeType: Action['type'], upsert: A) {
+    if (editName && editName !== name) dispatch({ type: removeType, name: editName } as Action)
+    dispatch(upsert)
+  }
+
+  return (
+    <div>
+      <NamedList title="Timeouts" names={Object.keys(pol.timeouts)}
+        onAdd={() => setOpen({ kind: 'timeout' })}
+        onEdit={(name) => setOpen({ kind: 'timeout', editName: name })}
+        onRemove={(name) => dispatch({ type: 'REMOVE_TIMEOUT', name })} />
+      <NamedList title="Retries" names={customRetryNames}
+        onAdd={() => setOpen({ kind: 'retry' })}
+        onEdit={(name) => setOpen({ kind: 'retry', editName: name })}
+        onRemove={(name) => dispatch({ type: 'REMOVE_RETRY', name })} />
+      <NamedList title="Circuit breakers" names={Object.keys(pol.circuitBreakers)}
+        onAdd={() => setOpen({ kind: 'cb' })}
+        onEdit={(name) => setOpen({ kind: 'cb', editName: name })}
+        onRemove={(name) => dispatch({ type: 'REMOVE_CB', name })} />
+
+      <div className="sbsection">
+        <div className="sech">Default policy overrides</div>
+        <p className="none" style={{ marginTop: 0 }}>⚠ These override Dapr's built-in retry behavior globally.</p>
+        {DEFAULT_DAPR_RETRY_POLICIES.map((preset) => {
+          const exists = pol.retries[preset.label] !== undefined
+          return exists ? (
+            <div key={preset.label} className="chip k" style={{ marginRight: 6, marginBottom: 6 }}>
+              <button type="button" aria-label={`Edit ${preset.label}`}
+                onClick={() => setOpen({ kind: 'override', label: preset.label, editing: true })}
+                style={{ background: 'none', border: 0, cursor: 'pointer', font: 'inherit', padding: 0 }}>
+                <b>{preset.label}</b>
+              </button>
+              <button type="button" className="copybtn" aria-label={`Remove ${preset.label}`}
+                onClick={(e) => { e.stopPropagation(); dispatch({ type: 'REMOVE_RETRY', name: preset.label }) }}>✕</button>
+            </div>
+          ) : (
+            <div key={preset.label} className="sech" style={{ fontWeight: 'normal' }}>
+              {preset.label}
+              <button type="button" className="btn ghost" style={{ marginLeft: 'auto' }}
+                aria-label={`Add ${preset.label}`} onClick={() => setOpen({ kind: 'override', label: preset.label, editing: false })}>
+                + Add
+              </button>
+            </div>
+          )
+        })}
+      </div>
+
+      {open?.kind === 'timeout' && (
+        <TimeoutDialog open editing={!!open.editName}
+          initialName={open.editName ?? nextName('timeout', pol.timeouts)}
+          initialDuration={open.editName ? pol.timeouts[open.editName] : undefined}
+          onClose={() => setOpen(null)}
+          onSave={(name, duration) => { renameThenUpsert(open.editName, name, 'REMOVE_TIMEOUT', { type: 'UPSERT_TIMEOUT', name, duration }); setOpen(null) }} />
+      )}
+      {open?.kind === 'retry' && (
+        <RetryDialog open editing={!!open.editName}
+          initialName={open.editName ?? nextName('retry', pol.retries)}
+          initialPolicy={open.editName ? pol.retries[open.editName] : undefined}
+          onClose={() => setOpen(null)}
+          onSave={(name, policy) => { renameThenUpsert(open.editName, name, 'REMOVE_RETRY', { type: 'UPSERT_RETRY', name, policy }); setOpen(null) }} />
+      )}
+      {open?.kind === 'cb' && (
+        <CircuitBreakerDialog open editing={!!open.editName}
+          initialName={open.editName ?? nextName('circuitBreaker', pol.circuitBreakers)}
+          initialPolicy={open.editName ? pol.circuitBreakers[open.editName] : undefined}
+          onClose={() => setOpen(null)}
+          onSave={(name, policy) => { renameThenUpsert(open.editName, name, 'REMOVE_CB', { type: 'UPSERT_CB', name, policy }); setOpen(null) }} />
+      )}
+      {open?.kind === 'override' && (
+        <RetryDialog open lockName keepDurationForExponential editing={open.editing}
+          initialName={open.label}
+          initialPolicy={open.editing ? pol.retries[open.label] : presetToRetryPolicy(DEFAULT_DAPR_RETRY_POLICIES.find((p) => p.label === open.label)!)}
+          onClose={() => setOpen(null)}
+          onSave={(_name, policy) => { dispatch({ type: 'UPSERT_RETRY', name: open.label, policy }); setOpen(null) }} />
+      )}
+    </div>
+  )
+}
+```
+
+Note: `renameThenUpsert`'s `upsert` argument is the fully-typed action; the `removeType` cast is confined to the helper. If `npx tsc -b` rejects the generic cast, inline the rename check per dialog instead (three `if (editName && editName !== name) dispatch({ type: 'REMOVE_*', name: editName })` lines).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/steps.test.tsx`
+Expected: PASS (existing add/second-add/remove tests still pass).
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+cd web && npx tsc -b
+git add web/src/pages/resiliency-builder/StepPolicies.tsx web/src/pages/resiliency-builder/steps.test.tsx
+git commit -m "feat(web): StepPolicies editable chips, retries filter, DaprBuiltIn overrides section"
+```
+
+---
+
+## Task 8: StepTargets — edit wiring
+
+**Files:**
+- Modify: `web/src/pages/resiliency-builder/StepTargets.tsx`
+- Test: `web/src/pages/resiliency-builder/steps.test.tsx`
+
+**Interfaces:**
+- Consumes: `NamedList` (Task 4), target dialogs (Task 6), `Action`/`ResiliencyState`/`PolicyNames` (existing).
+- Produces: `StepTargets({ state, dispatch })` with editable app/actor/component chips; rename dispatches `REMOVE_*` + `UPSERT_*`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `steps.test.tsx`, add a new describe block (and add `StepTargets` to the imports at the top):
+
+```ts
+import { StepTargets } from './StepTargets'
+```
+
+```ts
+describe('StepTargets', () => {
+  it('edits an existing app target via chip click', () => {
+    const dispatch = vi.fn()
+    let s = reducer(initialState(), { type: 'UPSERT_TIMEOUT', name: 'timeout1', duration: '30s' })
+    s = reducer(s, { type: 'UPSERT_APP', name: 'orders', target: { timeout: 'timeout1' } })
+    render(<StepTargets state={s} dispatch={dispatch} />)
+    fireEvent.click(screen.getByRole('button', { name: /edit orders/i }))
+    expect((screen.getByLabelText(/app id/i) as HTMLInputElement).value).toBe('orders')
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(dispatch).toHaveBeenCalledWith({ type: 'UPSERT_APP', name: 'orders', target: expect.objectContaining({ timeout: 'timeout1' }) })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/steps.test.tsx`
+Expected: FAIL — no `Edit orders` button.
+
+- [ ] **Step 3: Rewrite StepTargets**
+
+Replace `web/src/pages/resiliency-builder/StepTargets.tsx` with:
+
+```tsx
+import { useState } from 'react'
+import { NamedList } from './NamedList'
+import { AppTargetDialog, ActorTargetDialog, ComponentTargetDialog, type PolicyNames } from './targetDialogs'
+import { type Action, type ResiliencyState } from './reducer'
+
+type Dialog = null | { kind: 'app' | 'actor' | 'component'; editName?: string }
+
+export function StepTargets({ state, dispatch }: { state: ResiliencyState; dispatch: (a: Action) => void }) {
+  const [open, setOpen] = useState<Dialog>(null)
+  const { policies, targets } = state.config.spec
+  const names: PolicyNames = {
+    timeouts: Object.keys(policies.timeouts),
+    retries: Object.keys(policies.retries),
+    circuitBreakers: Object.keys(policies.circuitBreakers),
+  }
+  const apps = targets.apps ?? {}
+  const actors = targets.actors ?? {}
+  const components = targets.components ?? {}
+
+  return (
+    <div>
+      <NamedList title="Apps" names={Object.keys(apps)}
+        onAdd={() => setOpen({ kind: 'app' })}
+        onEdit={(name) => setOpen({ kind: 'app', editName: name })}
+        onRemove={(name) => dispatch({ type: 'REMOVE_APP', name })} />
+      <NamedList title="Actors" names={Object.keys(actors)}
+        onAdd={() => setOpen({ kind: 'actor' })}
+        onEdit={(name) => setOpen({ kind: 'actor', editName: name })}
+        onRemove={(name) => dispatch({ type: 'REMOVE_ACTOR', name })} />
+      <NamedList title="Components" names={Object.keys(components)}
+        onAdd={() => setOpen({ kind: 'component' })}
+        onEdit={(name) => setOpen({ kind: 'component', editName: name })}
+        onRemove={(name) => dispatch({ type: 'REMOVE_COMPONENT', name })} />
+
+      {open?.kind === 'app' && (
+        <AppTargetDialog open policies={names} editing={!!open.editName}
+          initialName={open.editName} initialTarget={open.editName ? apps[open.editName] : undefined}
+          onClose={() => setOpen(null)}
+          onSave={(name, target) => { if (open.editName && open.editName !== name) dispatch({ type: 'REMOVE_APP', name: open.editName }); dispatch({ type: 'UPSERT_APP', name, target }); setOpen(null) }} />
+      )}
+      {open?.kind === 'actor' && (
+        <ActorTargetDialog open policies={names} editing={!!open.editName}
+          initialName={open.editName} initialTarget={open.editName ? actors[open.editName] : undefined}
+          onClose={() => setOpen(null)}
+          onSave={(name, target) => { if (open.editName && open.editName !== name) dispatch({ type: 'REMOVE_ACTOR', name: open.editName }); dispatch({ type: 'UPSERT_ACTOR', name, target }); setOpen(null) }} />
+      )}
+      {open?.kind === 'component' && (
+        <ComponentTargetDialog open policies={names} editing={!!open.editName}
+          initialName={open.editName} initialTarget={open.editName ? components[open.editName] : undefined}
+          onClose={() => setOpen(null)}
+          onSave={(name, target) => { if (open.editName && open.editName !== name) dispatch({ type: 'REMOVE_COMPONENT', name: open.editName }); dispatch({ type: 'UPSERT_COMPONENT', name, target }); setOpen(null) }} />
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/steps.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+cd web && npx tsc -b
+git add web/src/pages/resiliency-builder/StepTargets.tsx web/src/pages/resiliency-builder/steps.test.tsx
+git commit -m "feat(web): StepTargets editable target chips"
+```
+
+---
+
+## Task 9: End-to-end — overrides-only config reaches preview
+
+**Files:**
+- Test: `web/src/pages/resiliency-builder/ResiliencyBuilder.test.tsx`
+
+**Interfaces:**
+- Consumes: `ResiliencyBuilder` page (existing), full wizard flow.
+- Produces: no source change — this task guards the integrated behaviour (override-only path + default namespace).
+
+- [ ] **Step 1: Write the failing test**
+
+In `ResiliencyBuilder.test.tsx`, add this test inside the `describe('ResiliencyBuilder', ...)` block:
+
+```ts
+  it('finishes with only a DaprBuiltIn override (no explicit target) and emits default namespace', async () => {
+    renderBuilder()
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'my-res' } })
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // 0->1
+    fireEvent.click(screen.getByRole('button', { name: /add DaprBuiltInServiceRetries/i }))
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // 1->2 (policy present)
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // 2->3 (override satisfies gating)
+    await waitFor(() => expect(document.querySelector('pre.code')?.textContent).toContain('kind: Resiliency'))
+    const yaml = document.querySelector('pre.code')?.textContent ?? ''
+    expect(yaml).toContain('namespace: default')
+    expect(yaml).toContain('DaprBuiltInServiceRetries')
+  })
+```
+
+- [ ] **Step 2: Run the test to verify it passes (behaviour already built in Tasks 1-8)**
+
+Run: `cd web && npx vitest run src/pages/resiliency-builder/ResiliencyBuilder.test.tsx`
+Expected: PASS. If it fails on the second `continue` being disabled, confirm Task 3 gating landed; if it fails on `namespace: default`, confirm Task 1 landed.
+
+- [ ] **Step 3: Full resiliency-builder test sweep + typecheck**
+
+Run:
+```bash
+cd web && npx tsc -b && npx vitest run src/pages/resiliency-builder
+```
+Expected: all resiliency-builder tests PASS, no type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/pages/resiliency-builder/ResiliencyBuilder.test.tsx
+git commit -m "test(web): e2e override-only resiliency config with default namespace"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 namespace `default` → Task 1 (type default + emit tests). ✓
+- §2 real defaults (timeout `5s`; CB `maxRequests 1`/`timeout 45s`/`trip`/`interval 8s`) → Task 5. ✓
+- §3 editable chips (NamedList `onEdit`; all six dialogs edit mode; rename; component direction) → Tasks 4, 5, 6, 7, 8. ✓
+- §4 overrides (presets module; overrides section; retries filter; exponential `duration` preservation; override-aware gating) → Tasks 2, 3, 5 (`keepDurationForExponential`), 7. ✓
+- Testing section → each task is TDD; Task 9 integrates. ✓
+- Non-goals (no read-only Targets table, no ResiliencyAccess) → not built. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code; every command has an expected result. ✓
+
+**Type consistency:**
+- `onEdit?: (name: string) => void` — defined Task 4, consumed Tasks 7, 8. ✓
+- Dialog prop names (`initialDuration`, `initialPolicy`, `initialTarget`, `editing`, `lockName`, `keepDurationForExponential`) — defined Tasks 5, 6; consumed Tasks 7, 8. ✓
+- `DEFAULT_DAPR_RETRY_POLICIES`, `isDefaultPolicyName`, `presetToRetryPolicy`, `DefaultPolicyPreset` — defined Task 2; consumed Tasks 3, 7. ✓
+- `UPSERT_*`/`REMOVE_*` action names match the existing reducer (unchanged). ✓
+- `canContinue` case 2 signature unchanged; only body edited (Task 3). ✓

--- a/docs/superpowers/specs/2026-06-28-component-resiliency-builders-design.md
+++ b/docs/superpowers/specs/2026-06-28-component-resiliency-builders-design.md
@@ -1,13 +1,21 @@
 # Design: Component Builder & Resiliency Builder
 
-**Date:** 2026-06-28
-**Status:** Approved design. Implementation plan not yet started.
+**Date:** 2026-06-28 (reconciled 2026-07-01)
+**Status:** Approved design. Backend catalog endpoint already shipped (see "Backend"). Frontend wizards not yet started; implementation plan in progress.
 
 Port cloudgrid's **Component Builder** and **Resiliency Builder** into `dev-dashboard` as two
 multi-step wizards that generate Dapr YAML you can copy or download.
 
 - **Source:** `cloudgrid/services/admingrid/web/packages/cloud-ui-shared/components/{component-configurator,resiliency-builder}/` (React 19 + MUI + react-hook-form + Yup + js-yaml + Ace).
-- **Target:** `dev-dashboard` (Go backend + React 18 frontend in `web/`).
+- **Target:** `dev-dashboard` (Go backend + **React 19** frontend in `web/`; upgraded from React 18 on 2026-06-30).
+
+## Reconciliation notes (2026-07-01)
+
+Verified against `main` before planning:
+- **Frontend is React 19** (not 18 as originally written).
+- **Backend catalog endpoint is already implemented and merged** — the "Backend" section below is now a reuse note, not work to do.
+- **Reusable frontend pieces already exist** (see "Already in the repo") — the plan reuses `Modal.tsx` rather than creating a new `Dialog.tsx`, and generalizes the existing `useComponentCatalog.ts`.
+- The existing `MetadataField.type` union is `'string' | 'number' | 'bool' | 'duration'` (not `boolean|json`), and `ComponentMetadataSchema` currently omits `authenticationProfiles`; the builder must extend these (see "Types").
 
 ## Locked decisions
 
@@ -28,7 +36,7 @@ React Router v6.
 
 ## Target repo conventions (must match)
 
-- React 18 + TS + Vite, React Router v6 (routes in `web/src/router.tsx`).
+- React 19 + TS + Vite, React Router v6 (routes in `web/src/router.tsx`).
 - Styling: vanilla CSS, semantic tokens in `theme.css` (`.card`, `.btn`/`.btn.primary`/`.btn.ghost`/
   `.btn.danger`, `.select`, `.pill`, `.code`, `.md` master-detail, `.kv`, `.ph`). Light/dark via
   `data-theme`.
@@ -41,17 +49,40 @@ React Router v6.
 - Tests: Vitest + Testing Library, colocated `*.test.tsx`. Go: golden tests via `internal/golden`.
 - Directory layout: `pages/`, `components/`, `hooks/`, `lib/`, `types/`.
 
-## Backend — catalog endpoint
+## Backend — catalog endpoint (ALREADY SHIPPED — reuse, do NOT re-port)
 
-- New `pkg/metadata/metadata.go`: `go:embed component-metadata-bundle.json` (754 KB bundle copied
-  from cloudgrid `tools/diagrid-dashboard/pkg/metadata/`). Serve raw JSON with ETag + `Cache-Control`
-  headers (mirror cloudgrid's `HandleGetComponents`).
-- Wire into `apiRouter` in `pkg/server/api.go` (chi router) → reachable at
-  `GET /api/metadata/components`.
-- Port `update-component-metadata-bundle.sh` → `scripts/update-component-metadata-bundle.sh`
-  (refreshes bundle from `diagridio/dapr-components-contrib` release assets; current tag
-  `v1.18.0-catalyst.1`).
-- Handler test + golden following `internal/golden`.
+Verified present on `main` as of 2026-07-01:
+- `pkg/metadata/metadata.go` — `go:embed component-metadata-bundle.json`, serves raw JSON with
+  ETag/304 + `Cache-Control` via `HandleGetComponents`. `metadata.Init()` is wired in `cmd/root.go`.
+- Route registered in `pkg/server/api.go` (chi): `r.Get("/metadata/components", metadata.HandleGetComponents)`,
+  reachable at `GET /api/metadata/components`.
+- `scripts/update-component-metadata-bundle.sh` present (refreshes bundle from
+  `diagridio/dapr-components-contrib` release assets).
+- Unit test (`pkg/metadata/metadata_test.go`) + golden (`golden_test.go`, `testdata/`) present.
+
+The frontend builders reuse this endpoint as-is. **No backend work is required** unless the
+`authenticationProfiles` gap below needs the bundle re-generated to include that field.
+
+## Already in the repo (reuse, don't rebuild)
+
+- `web/src/types/metadata.ts` — `MetadataField { name; type?: 'string'|'number'|'bool'|'duration';
+  description?; required?; sensitive?; default?; example?; allowedValues?; url?: {title,url} }`,
+  `ComponentMetadataSchema { type; name; version; title; status; description?; metadata? }`,
+  `MetadataBundle { schemaVersion; date; components[] }`. **Gap:** no `authenticationProfiles` field —
+  the builder must extend `ComponentMetadataSchema` (and likely the bundle) to carry auth profiles.
+- `web/src/hooks/useComponentCatalog.ts` — fetches `/metadata/components` (TanStack Query, 1h
+  staleTime). **Currently narrowed** to `type === 'state'` + supported store names, and injects a
+  synthetic `connectionString` field for pg/sqlite (because auth profiles are absent). The full
+  builder must **generalize** it: expose all component types, drop the state-only filter (or make it
+  optional), and replace the synthetic-field hack with real `authenticationProfiles` handling once
+  the schema carries them.
+- `web/src/components/Modal.tsx` — backdrop + `role="dialog"` + `aria-modal` + Escape-to-close +
+  initial focus. **Reuse this** for add/edit forms instead of creating a new `Dialog.tsx`.
+  Caveats to address when reused for multi-instance forms: it hardcodes `id="modal-title"` /
+  `aria-labelledby="modal-title"` (fine for one-at-a-time), and it focuses the container but is not a
+  full focus-trap — add a trap if a builder form needs it.
+- `web/src/components/MetadataFieldInput.tsx` — per-field control (reuse for the Configure step's
+  metadata editor).
 
 ## Routing & entry points (frontend)
 
@@ -69,8 +100,10 @@ React Router v6.
 - `components/form/`: thin controlled wrappers over native elements styled via theme.css — `Field`
   (label + control + inline error), `TextInput`, `NumberInput`, `SelectInput`, `Toggle`. No form
   library.
-- `components/Dialog.tsx`: small modal (focus trap + Escape) generalized from `ConfirmRemoveDialog`,
-  used for add/edit forms (policies, targets).
+- **Reuse `components/Modal.tsx`** (already exists — backdrop + `role="dialog"` + `aria-modal` +
+  Escape + initial focus) for add/edit forms (policies, targets). Do NOT create a new `Dialog.tsx`.
+  Add a focus-trap only if a form needs it, and give the title a unique id if two modals can ever
+  co-exist.
 - `components/YamlPreview.tsx`: editable finalizer. `<textarea>` styled as `.code`, initialized with
   generated YAML; tracks local edits; "Reset to generated" restores; **Back disabled once manually
   edited** (matches cloudgrid); Copy (`copyText` + `useToast`) + Download act on the current buffer.
@@ -84,9 +117,13 @@ React Router v6.
 
 ## Types (ported from cloudgrid TS types)
 
-- `types/metadata.ts`: `ComponentMetadataSchema`, `MetadataSchemaMetadataItem` (name, description,
-  type `string|number|boolean|json`, required, default, allowedValues, sensitive, url),
-  `AuthenticationProfile`, bundle response shape.
+- `types/metadata.ts`: **already exists** — `MetadataField` (name, `type?: 'string'|'number'|'bool'|'duration'`,
+  description, required, sensitive, default, example, allowedValues, `url?: {title,url}`),
+  `ComponentMetadataSchema`, `MetadataBundle`. **Extend it** to add `authenticationProfiles?:
+  AuthenticationProfile[]` on `ComponentMetadataSchema` and an `AuthenticationProfile` type. The
+  field controls map off the existing union (`bool` → boolean select, `duration` → text +
+  `validateGoDuration`, `allowedValues` → enum select); if the bundle ever emits `json`-typed
+  fields, add a JSON/textarea control then (YAGNI until observed).
 - `types/component.ts`: `ComponentSpec` (apiVersion `dapr.io/v1alpha1`, kind `Component`,
   metadata{name, namespace}, scopes[], spec{type, version, metadata[]{name, value? |
   secretKeyRef{name, key}}}).

--- a/docs/superpowers/specs/2026-06-28-component-resiliency-builders-design.md
+++ b/docs/superpowers/specs/2026-06-28-component-resiliency-builders-design.md
@@ -84,13 +84,37 @@ The frontend builders reuse this endpoint as-is. **No backend work is required**
 - `web/src/components/MetadataFieldInput.tsx` — per-field control (reuse for the Configure step's
   metadata editor).
 
-## Routing & entry points (frontend)
+## Routing & entry points (frontend) — decided 2026-07-01
 
-- `router.tsx`: `/components/new` → `<ComponentBuilder />`; `/resiliency/new` →
-  `<ResiliencyBuilder />`. Static `new` outranks dynamic `:name`, so no conflict with
-  `components/:name`.
-- "New component" button on the components `ResourceList` page; Resiliency nav/sidebar entry →
-  builder.
+**Placement: contextual button for the Component Builder + a new top-level "Resiliency" nav for the
+Resiliency Builder** (chosen over a unified "Create" hub because it mirrors Dapr's per-kind resource
+model — Resiliency is a first-class CRD sibling of Component/Configuration — and is forward-compatible
+with listing discovered resiliency policies later).
+
+**Component Builder**
+- Route in `router.tsx`: `{ path: 'components/new', element: <ComponentBuilder /> }`, added **before**
+  the existing `components/:name` route. Static `new` outranks the dynamic `:name` param in React
+  Router v6, so `/components/new` resolves to the builder, not the detail view.
+- Entry point: a **`+ New component`** button (`.btn.primary`) in the Components `ResourceList`
+  `.phead` header, present in all three render states (loading, empty, populated). `.phead` is already
+  `display:flex; justify-content:space-between`, so the button sits top-right of the title block.
+  Clicking navigates to `/components/new`.
+
+**Resiliency Builder**
+- New top-nav item: add `{ label: 'Resiliency', to: '/resiliency' }` to `NAV_ITEMS` in
+  `components/TopNav.tsx`, positioned **between `Configurations` and `Logs`**.
+- Routes in `router.tsx`:
+  - `{ path: 'resiliency', element: <Resiliency /> }` — a new **create-only landing page** that
+    reuses the `.page`/`.phead` + `.md` master-detail empty-state pattern from `ResourceList`: shows
+    a `+ New resiliency policy` button in the header and a "No resiliency policies" hint in the body.
+    (v1 lists nothing; the page exists as the discoverable home and a forward-compatible seam for
+    listing discovered policies later.)
+  - `{ path: 'resiliency/new', element: <ResiliencyBuilder /> }` — the wizard.
+- Entry point: the `Resiliency` nav item → `/resiliency` → `+ New resiliency policy` button →
+  `/resiliency/new`.
+
+**On finish/cancel:** both wizards return to their origin list (`/components` and `/resiliency`
+respectively).
 
 ## Shared frontend infrastructure (built once, used by both)
 

--- a/docs/superpowers/specs/2026-06-28-component-resiliency-builders-design.md
+++ b/docs/superpowers/specs/2026-06-28-component-resiliency-builders-design.md
@@ -161,7 +161,9 @@ respectively).
   secretKeyRef{name, key}}}).
 - `types/resiliency.ts`: `DaprResiliency` (kind `Resiliency`, spec{policies{timeouts, retries,
   circuitBreakers}, targets{apps, actors, components}}). RetryPolicy{policy `constant|exponential`,
-  duration, maxRetries, maxInterval, matching{httpStatusCodes, grcpStatusCodes}}.
+  duration, maxRetries, maxInterval, matching{httpStatusCodes, grpcStatusCodes}}.
+  (NOTE: cloudgrid's source type has the typo `grcpStatusCodes`; the port standardizes on the
+  correct `grpcStatusCodes` — implemented in `types/resiliency.ts`. Do not "correct" it back.)
   CircuitBreakerPolicy{maxRequests, timeout, trip (CEL), interval}.
   AppTarget / ActorTarget (+circuitBreakerScope `type|id|both`, circuitBreakerCacheSize) /
   ComponentTarget (inbound/outbound).
@@ -181,6 +183,13 @@ respectively).
 4. **Preview** — editable YAML, Copy + Download `<name>.yaml`.
 
 Dropped: cloudgrid's connected-mode "Access & Scopes" step.
+
+**Plan 2 implementation note (from Plan 1 foundation review):** `lib/yaml-emit.ts`
+`recursivelyRemoveEmptyValues` treats arrays as leaves — it does NOT prune empty keys *inside*
+objects held in an array. `ComponentSpec.spec.metadata` is an array of `{name, value? | secretKeyRef}`
+items, so the Component Builder must assemble each metadata item with only its populated key
+(`value` XOR `secretKeyRef`) and drop empty items itself, rather than relying on the stripper to
+clean item interiors. (Component emission does not run the stripper anyway; resiliency does.)
 
 ## Resiliency Builder flow (4 steps)
 

--- a/docs/superpowers/specs/2026-06-28-component-resiliency-builders-design.md
+++ b/docs/superpowers/specs/2026-06-28-component-resiliency-builders-design.md
@@ -119,8 +119,16 @@ respectively).
 ## Shared frontend infrastructure (built once, used by both)
 
 - `components/wizard/`: `Wizard` + `Stepper` (step labels styled with pill/tab classes) + `StepNav`
-  (Back/Continue/Finish using `.btn` variants). Per-builder typed `useReducer` for wizard state
-  (mirrors cloudgrid reducer shape: activeStep, steps, config object, etc.).
+  (Back/Continue/Finish). Per-builder typed `useReducer` for wizard state (mirrors cloudgrid reducer
+  shape: activeStep, steps, config object, etc.).
+- **Wizard button styling — monochrome, NOT green (decided 2026-07-01):** the wizard buttons must not
+  use the green brand `.btn.primary` (`background: var(--accent2)`). Do NOT change the global
+  `.btn.primary` (used elsewhere, e.g. the state-store dialog). Instead add a **wizard-scoped**
+  monochrome treatment: primary action (Continue/Finish) = filled neutral
+  (`background: var(--text); color: var(--bg)`, no accent color); secondary (Back/Cancel) = the
+  existing `.btn.ghost` (transparent, `--line` border, `--text`). Copy/Download in the finalizer also
+  use the neutral/ghost styles — no green. Keep focus-visible outlines as-is. This applies to both
+  builders and any dialog buttons inside them.
 - `components/form/`: thin controlled wrappers over native elements styled via theme.css — `Field`
   (label + control + inline error), `TextInput`, `NumberInput`, `SelectInput`, `Toggle`. No form
   library.

--- a/docs/superpowers/specs/2026-07-02-component-builder-type-filter-and-preview-design.md
+++ b/docs/superpowers/specs/2026-07-02-component-builder-type-filter-and-preview-design.md
@@ -5,10 +5,11 @@
 **Branch:** `feat/component-resiliency-builders`
 **Builds on:** the Component Builder shipped in `docs/superpowers/plans/2026-07-01-builders-02-component.md`.
 
-Two changes to the existing Component Builder wizard:
+Three changes to the existing Component Builder wizard:
 
 1. **Category filter on step 1 (Type).** Add single-select category filter buttons (one per Dapr component `type`: bindings, configuration, conversation, crypto, lock, middleware, nameresolution, pubsub, secretstores, state). Selecting a category filters the component list to that category and scopes the search box to it. The selected category + component remain visible across all wizard steps.
 2. **Highlighted, read-only Preview.** Replace the editable `<textarea>` preview with the same syntax-highlighted rendering the Components detail view uses (`highlightYaml` in `<pre className="code">`), reusing that proven look. Copy + Download still act on the generated YAML.
+3. **Removable optional fields on step 3 (Configure).** Added optional metadata fields must be removable again, reusing the add/remove UI the "Add state store connection" dialog already uses on the Components page (`StateStoreConnectionDialog.tsx`): each added optional field shows its control alongside a ghost **✕** remove button; a `+ add optional field…` select adds from the not-yet-added pool. The builder currently has the add-select but no remove control (the reducer already exposes an unused `REMOVE_OPTIONAL`).
 
 ## Decisions (from brainstorming, 2026-07-02)
 
@@ -20,7 +21,8 @@ Two changes to the existing Component Builder wizard:
 ## Current state (what changes)
 
 - `web/src/pages/component-builder/StepType.tsx` — currently a search box over ALL components grouped by type. Becomes category-chip-gated.
-- `web/src/pages/component-builder/reducer.ts` — gains a `category` field + `SELECT_CATEGORY` action.
+- `web/src/pages/component-builder/reducer.ts` — gains a `category` field + `SELECT_CATEGORY` action; `REMOVE_OPTIONAL` also clears the field's value/secret state.
+- `web/src/pages/component-builder/StepConfigure.tsx` — added optional fields gain a ✕ remove button (reusing the state-connection dialog pattern).
 - `web/src/pages/component-builder/ComponentBuilder.tsx` — gains the persistent selection bar; drops the `previewEdited` gate.
 - `web/src/components/YamlPreview.tsx` — becomes read-only + highlighted; loses `edited`/`onEditedChange`/Reset and the mount-emit effect.
 - Tests for all four, plus `ComponentBuilder.test.tsx` (reads a `<pre>` instead of a textbox; drops the back-then-forward Finish probe which no longer applies).
@@ -43,6 +45,8 @@ Add action:
 
 Update `SELECT_SCHEMA`: also set `category = action.schema.type` (keep the chip in sync with the picked component). All other behavior (advance to step 1) unchanged.
 
+Update `REMOVE_OPTIONAL`: in addition to removing the field from `optionalAdded`, clear that field's entries from `values`, `secretRefs`, and `useSecret` (so a re-added field starts clean and no stale value lingers) — mirrors the state-connection dialog, which deletes the value on remove.
+
 `canContinue`, `assembleComponentSpec`, and every other action are unchanged.
 
 ### Step 1 (`StepType.tsx`)
@@ -56,6 +60,14 @@ Update `SELECT_SCHEMA`: also set `category = action.schema.type` (keep the chip 
 
 - A bar rendered above the `Wizard` (so it shows on all four steps). When `state.category` is set, show a category chip (`.typechip`); when `state.schema` is set, also show the component: `{schema.title} · {version}` (e.g. `[ state ]  Redis · v1`). When nothing is selected yet, the bar is empty/omitted.
 - Purely presentational, derived from `state`.
+
+### Step 3 Configure (`StepConfigure.tsx`) — removable optional fields
+
+Reuse the add/remove pattern from `StateStoreConnectionDialog.tsx` (lines ~110–150):
+- Keep the "Required fields" rows as-is.
+- Render each added optional field (`state.optionalAdded`) in its own row where the value control (the "use secret" toggle + secret inputs OR `MetadataFieldInput`) sits next to a ghost remove button: `<button className="btn ghost" aria-label={`remove ${field.name}`}>✕</button>` that dispatches `{ type: 'REMOVE_OPTIONAL', field: field.name }`. Use the existing `.field`/`.field-row` layout so the control and ✕ align, matching the dialog.
+- Keep the `+ add optional field…` select (dispatches `ADD_OPTIONAL`), sourced from the not-yet-added optional pool (`activeFields(schema, authProfile).optional` minus `optionalAdded`). It renders only when the pool is non-empty.
+- Required fields have no remove button (they are not optional).
 
 ### Step 4 Preview (`YamlPreview.tsx` → read-only)
 
@@ -73,7 +85,8 @@ Edit `docs/superpowers/plans/2026-07-01-builders-03-resiliency.md`: its Task 5 u
 
 ## Testing
 
-- `reducer.test.ts`: `SELECT_CATEGORY` sets category; switching category clears schema + config; `SELECT_SCHEMA` sets category = schema.type.
+- `reducer.test.ts`: `SELECT_CATEGORY` sets category; switching category clears schema + config; `SELECT_SCHEMA` sets category = schema.type; `REMOVE_OPTIONAL` removes the field from `optionalAdded` AND clears its `values`/`secretRefs`/`useSecret` entries.
+- `StepConfigure.test.tsx`: adding an optional field then clicking its ✕ (`remove <field>`) dispatches `REMOVE_OPTIONAL` and the field's row disappears; the removed field reappears in the add-select pool.
 - `StepType.test.tsx`: chips render; no-category shows the hint and no list; selecting a category shows the scoped list + search; search filters within the category; clicking a component dispatches `SELECT_SCHEMA`.
 - `YamlPreview.test.tsx`: renders highlighted YAML read-only (a `<pre>`, no textbox); Copy calls copyText with the yaml; Download (`.btn.mono`) triggers a download; no Reset/edited behavior.
 - `ComponentBuilder.test.tsx`: full walk Type (pick category → pick component) → Auth → Configure → Preview; assert the Preview `<pre>`/container text contains `type: state.redis` and `name: order-store`; Finish enabled on preview. Remove the back-then-forward Finish probe (no longer applicable).
@@ -90,4 +103,5 @@ Edit `docs/superpowers/plans/2026-07-01-builders-03-resiliency.md`: its Task 5 u
 2. The selected category + component stay visible on every wizard step.
 3. Preview renders syntax-highlighted, read-only YAML matching the Components detail view; Copy + Download work.
 4. Switching category resets the stale component/config.
-5. All touched tests pass; `tsc -b` clean; `main` untouched.
+5. Added optional fields can be removed again via a ✕ button (matching the state-connection dialog); removing clears the field's value/secret state and returns it to the add pool.
+6. All touched tests pass; `tsc -b` clean; `main` untouched.

--- a/docs/superpowers/specs/2026-07-02-component-builder-type-filter-and-preview-design.md
+++ b/docs/superpowers/specs/2026-07-02-component-builder-type-filter-and-preview-design.md
@@ -1,0 +1,93 @@
+# Design: Component Builder — category filter + highlighted preview
+
+**Date:** 2026-07-02
+**Status:** Approved design. Implementation plan not yet started.
+**Branch:** `feat/component-resiliency-builders`
+**Builds on:** the Component Builder shipped in `docs/superpowers/plans/2026-07-01-builders-02-component.md`.
+
+Two changes to the existing Component Builder wizard:
+
+1. **Category filter on step 1 (Type).** Add single-select category filter buttons (one per Dapr component `type`: bindings, configuration, conversation, crypto, lock, middleware, nameresolution, pubsub, secretstores, state). Selecting a category filters the component list to that category and scopes the search box to it. The selected category + component remain visible across all wizard steps.
+2. **Highlighted, read-only Preview.** Replace the editable `<textarea>` preview with the same syntax-highlighted rendering the Components detail view uses (`highlightYaml` in `<pre className="code">`), reusing that proven look. Copy + Download still act on the generated YAML.
+
+## Decisions (from brainstorming, 2026-07-02)
+
+- **Design A** (top category chips + read-only highlighted preview) over the master-detail/editable alternative.
+- **Initial state:** before a category is chosen, show only the category chips + a hint ("Choose a category to browse components"); the search box and list appear once a category is selected. (Avoids rendering all 141 components; matches "only show components for the selected type".)
+- **Switching category** after a component was chosen **clears** the selected schema and its downstream config (auth profile, field values, secret refs, added-optional) — they no longer apply.
+- **Shared preview:** simplify the shared `components/YamlPreview.tsx` to read-only and **update Plan 3's plan doc** (`2026-07-01-builders-03-resiliency.md`) so the Resiliency Builder also uses the read-only preview. One component, consistent everywhere. (Plan 3 is not yet implemented, so this is a doc edit.)
+
+## Current state (what changes)
+
+- `web/src/pages/component-builder/StepType.tsx` — currently a search box over ALL components grouped by type. Becomes category-chip-gated.
+- `web/src/pages/component-builder/reducer.ts` — gains a `category` field + `SELECT_CATEGORY` action.
+- `web/src/pages/component-builder/ComponentBuilder.tsx` — gains the persistent selection bar; drops the `previewEdited` gate.
+- `web/src/components/YamlPreview.tsx` — becomes read-only + highlighted; loses `edited`/`onEditedChange`/Reset and the mount-emit effect.
+- Tests for all four, plus `ComponentBuilder.test.tsx` (reads a `<pre>` instead of a textbox; drops the back-then-forward Finish probe which no longer applies).
+
+## Reuse (must match)
+
+- YAML rendering: `lib/yaml-highlight.tsx` `highlightYaml(text)` inside `<pre className="code">…</pre>` (exactly as `ResourceDetail.tsx:87`). Read-only.
+- Existing theme.css tokens: category chips use the segmented/chip styles already present (`.segs`/`.segs button[aria-pressed]`, or `.lvchips`/`.lvchip[aria-pressed]`); selection bar uses `.chip`/`.typechip`; list uses `.complist`/`.ci`/`.ci.sel`; search uses `.search`.
+- `lib/clipboard.ts` `copyText`, `lib/toast.tsx` `useToast`, `lib/download.ts` `downloadText`.
+
+## Detailed design
+
+### Reducer (`reducer.ts`)
+
+Add to `ComponentBuilderState`:
+- `category?: string` — the active category filter on step 1 (persists across step navigation).
+
+Add action:
+- `{ type: 'SELECT_CATEGORY'; category: string }` — sets `category`. If `category !== state.schema?.type`, also clears schema-dependent state: `schema = undefined`, `version = ''`, `authProfile = undefined`, `hasAuthProfiles = false`, `values = {}`, `secretRefs = {}`, `useSecret = {}`, `optionalAdded = []`. `activeStep` stays 0.
+
+Update `SELECT_SCHEMA`: also set `category = action.schema.type` (keep the chip in sync with the picked component). All other behavior (advance to step 1) unchanged.
+
+`canContinue`, `assembleComponentSpec`, and every other action are unchanged.
+
+### Step 1 (`StepType.tsx`)
+
+- Render a single-select row of category chips from `Object.keys(byType).sort()`. The active chip = `state.category`. Clicking a chip dispatches `SELECT_CATEGORY`. Chips use `aria-pressed` for the active state and are keyboard-operable (they are `<button>`s).
+- If `state.category` is undefined: render only the chips + a `.muted` hint "Choose a category to browse components." No search box, no list.
+- If a category is selected: render the scoped search input (`aria-label="Search components"`, placeholder `Search {category} components…`) and the flat list (`.complist`) of `byType[category]` filtered by title/name against the query. Each row (`.ci`, `.ci.sel` when selected) dispatches `SELECT_SCHEMA` on click/Enter/Space (unchanged payload).
+- Search state stays local (`useState`); it may reset when the category changes (acceptable).
+
+### Persistent selection bar (`ComponentBuilder.tsx`)
+
+- A bar rendered above the `Wizard` (so it shows on all four steps). When `state.category` is set, show a category chip (`.typechip`); when `state.schema` is set, also show the component: `{schema.title} · {version}` (e.g. `[ state ]  Redis · v1`). When nothing is selected yet, the bar is empty/omitted.
+- Purely presentational, derived from `state`.
+
+### Step 4 Preview (`YamlPreview.tsx` → read-only)
+
+New props/behavior:
+- `YamlPreview({ yaml, filename })` — no `onEditedChange`.
+- Renders `<pre className="code">{highlightYaml(yaml)}</pre>` (read-only, syntax-highlighted).
+- Buttons: Copy (`.btn.ghost`/`copybtn`, `copyText(yaml)` + `useToast().toast.show('Copied')`) and Download (`.btn.mono`, `downloadText(filename, yaml)`), acting on the generated `yaml` prop directly.
+- Removes: `edited` state, `onEditedChange`, the mount-emit effect, the re-seed effect, "Reset to generated", and the internal buffer.
+
+`ComponentBuilder.tsx`: drop `previewEdited` state and the `!previewEdited` clause; `canContinue` on step 3 is simply `true` (Finish always enabled). `YamlPreview` is passed `yaml` + `filename` only.
+
+### Plan 3 doc update
+
+Edit `docs/superpowers/plans/2026-07-01-builders-03-resiliency.md`: its Task 5 uses `YamlPreview` with `onEditedChange`/preview-edited gating. Update it to the read-only `YamlPreview({ yaml, filename })` API (drop `previewEdited` in `ResiliencyBuilder`, Finish always enabled on the preview step). No Plan 3 code exists yet, so this is a plan-text change only.
+
+## Testing
+
+- `reducer.test.ts`: `SELECT_CATEGORY` sets category; switching category clears schema + config; `SELECT_SCHEMA` sets category = schema.type.
+- `StepType.test.tsx`: chips render; no-category shows the hint and no list; selecting a category shows the scoped list + search; search filters within the category; clicking a component dispatches `SELECT_SCHEMA`.
+- `YamlPreview.test.tsx`: renders highlighted YAML read-only (a `<pre>`, no textbox); Copy calls copyText with the yaml; Download (`.btn.mono`) triggers a download; no Reset/edited behavior.
+- `ComponentBuilder.test.tsx`: full walk Type (pick category → pick component) → Auth → Configure → Preview; assert the Preview `<pre>`/container text contains `type: state.redis` and `name: order-store`; Finish enabled on preview. Remove the back-then-forward Finish probe (no longer applicable).
+
+## Out of scope (YAGNI)
+
+- Inline YAML editing in the builder (removed by this change; Copy/Download + regenerate cover the need).
+- Multi-select categories or an "All" category (single-select only).
+- Changes to Auth/Configure steps beyond what the category-clear requires.
+
+## Success criteria
+
+1. Step 1 shows category filter buttons; picking one filters the list + scopes search; a hint shows before any pick.
+2. The selected category + component stay visible on every wizard step.
+3. Preview renders syntax-highlighted, read-only YAML matching the Components detail view; Copy + Download work.
+4. Switching category resets the stale component/config.
+5. All touched tests pass; `tsc -b` clean; `main` untouched.

--- a/docs/superpowers/specs/2026-07-02-resiliency-builder-enhancements-design.md
+++ b/docs/superpowers/specs/2026-07-02-resiliency-builder-enhancements-design.md
@@ -1,0 +1,136 @@
+# Resiliency Builder Enhancements — Design
+
+**Date:** 2026-07-02
+**Branch:** `feat/component-resiliency-builders`
+**Builds on:** `docs/superpowers/specs/2026-06-28-component-resiliency-builders-design.md` and the shipped Resiliency Builder (`web/src/pages/resiliency-builder/*`).
+
+## Goal
+
+Four enhancements to the existing 3-step Resiliency Builder (General → Policies → Targets → YAML preview):
+
+1. Default the namespace to `default`.
+2. Show default values as real, editable text in the dialogs (not just placeholders).
+3. Make policy **and** target chips editable by clicking the chip.
+4. Bring back cloudgrid's "override default Dapr policies" feature (the reserved `DaprBuiltIn*` retry policies).
+
+These are additive; the data model (`types/resiliency.ts`) and reducer actions are sufficient as-is except where noted.
+
+## Non-goals (YAGNI)
+
+- The read-only "default policy overrides" **table** on the Targets step (cloudgrid's `DefaultPolicyOverridesContainer`). Redundant — overrides live on the Policies step here.
+- The connected-mode cluster/namespace/scope pickers (`ResiliencyAccess`). Still dropped, as in v1.
+
+---
+
+## 1. Namespace defaults to `default`
+
+- `defaultResiliencyConfig()` in `web/src/types/resiliency.ts` initializes `metadata.namespace = 'default'` (was `''`).
+- `StepGeneral` already binds the Namespace input to `state.config.metadata.namespace`, so the field renders `default` as real text with no component change.
+- **Emission:** `assembleResiliency` keeps its existing rule — emit `metadata.namespace` only when the trimmed value is non-empty. With the new default, YAML includes `namespace: default`; if the user clears the field, `namespace` is omitted.
+- **Tests:** update any reducer/assemble test that assumed an empty default namespace.
+
+---
+
+## 2. Real default values instead of placeholders
+
+Initial field values sourced from cloudgrid's canonical `ResiliencyDefaults`. Placeholders remain (they now echo the default). Validation is unchanged.
+
+| Dialog | Field | Default |
+|---|---|---|
+| Timeout | Duration | `5s` |
+| Retry (custom) | Duration / Max interval / Max retries | `5s` / `60s` / `-1` *(already real — no change)* |
+| Circuit breaker | Max requests | `1` |
+| Circuit breaker | Timeout | `45s` |
+| Circuit breaker | Trip (CEL) | `consecutiveFailures >= 5` |
+| Circuit breaker | Interval | `8s` |
+
+Affected file: `web/src/pages/resiliency-builder/policyDialogs.tsx` (change the `useState` initializers for `TimeoutDialog` duration and `CircuitBreakerDialog` maxRequests/timeout/trip/interval).
+
+---
+
+## 3. Editable chips — policies and targets
+
+### NamedList
+
+`web/src/pages/resiliency-builder/NamedList.tsx` gains an optional `onEdit(name)` callback:
+
+- The chip **body** (currently `<b>{name}</b>`) becomes a clickable `<button>` that fires `onEdit(name)`.
+- The ✕ remove button stays; its click handler calls `stopPropagation` so removing does not also trigger edit.
+- When `onEdit` is not provided, the chip renders non-interactive (backward-compatible), though every caller in this change provides it.
+
+### Dialogs gain edit mode
+
+All six dialogs gain optional initial-value props and a mode-aware title:
+
+- **Policy dialogs** (`policyDialogs.tsx`): `TimeoutDialog` → `initialName`, `initialDuration`; `RetryDialog` → `initialName`, `initialPolicy?: RetryPolicy`; `CircuitBreakerDialog` → `initialName`, `initialPolicy?: CircuitBreakerPolicy`.
+- **Target dialogs** (`targetDialogs.tsx`): `AppTargetDialog`/`ActorTargetDialog`/`ComponentTargetDialog` → `initialName`, `initialTarget?`.
+- Title reads **"Add …"** when there is no initial value, **"Edit …"** when editing.
+- `ComponentTargetDialog` derives its **direction** from the initial target: both legs present → `both`; only `outbound` → `outbound`; only `inbound` → `inbound`.
+- Dialogs continue to be remounted per open (existing pattern) so each open starts from the correct initial state.
+
+### Steps wire onEdit
+
+- `StepPolicies` and `StepTargets` track an "editing" name alongside the existing open-dialog state, and pass the existing policy/target as the dialog's initial value.
+- **Rename during edit** is allowed for all custom policies and all targets. If the saved name differs from the name being edited, the step dispatches `REMOVE_<old>` followed by `UPSERT_<new>`; otherwise a single `UPSERT_<name>`. This reuses the existing reducer actions — no reducer or type changes.
+- `DaprBuiltIn*` override names are **locked** in edit mode (see §4).
+
+---
+
+## 4. Default policy overrides (`DaprBuiltIn*` retries)
+
+### Preset data
+
+New `web/src/pages/resiliency-builder/defaultPolicies.ts` exporting `DEFAULT_DAPR_RETRY_POLICIES`, mirroring cloudgrid's `DEFAULT_DAPR_RETRY_POLICIES`:
+
+| Label | policy | duration | maxInterval | maxRetries |
+|---|---|---|---|---|
+| `DaprBuiltInServiceRetries` | constant | `1s` | — | `3` |
+| `DaprBuiltInActorRetries` | constant | `1s` | — | `3` |
+| `DaprBuiltInActorReminderRetries` | exponential | `15m` | `60s` | `3` |
+| `DaprBuiltInInitializationRetries` | exponential | `10s` | `500ms` | `3` |
+
+Also export a helper `isDefaultPolicyName(name): boolean` (`name.startsWith('DaprBuiltIn')`).
+
+### Policies step — new "Default policy overrides" section
+
+Rendered below the three existing policy lists in `StepPolicies`:
+
+- A section header "Default policy overrides" with a collapsible info note and a warning line ("These override Dapr's built-in retry behavior globally").
+- One row per built-in policy. If not yet added, a **+ Add** action; if already added, the chip (editable/removable via §3).
+- **Adding** opens `RetryDialog` with the name **locked** to the built-in label and all fields **prefilled** from the preset. Editing opens it prefilled from the current stored value, name still locked.
+- Stored under their reserved keys in `spec.policies.retries` via the existing `UPSERT_RETRY` action.
+
+### Retries list filters out built-ins
+
+The regular "Retries" `NamedList` in `StepPolicies` filters keys with `isDefaultPolicyName`, so a built-in override appears only in the overrides section, never in both.
+
+### Exponential preset nuance
+
+Dapr exponential retries use both `duration` (initial interval) and `maxInterval` (cap). The standard `RetryDialog` only edits `maxInterval` for exponential and drops `duration` on save. For the override flow, the preset's `duration` must be **preserved** through save so the emitted override matches Dapr's real defaults (`ActorReminder` = `duration 15m` + `maxInterval 60s`; `Initialization` = `duration 10s` + `maxInterval 500ms`). Implementation preserves the carried `duration` when the policy type is unchanged; this is scoped to the override save path so the regular custom-retry flow is unaffected.
+
+### Targets gating
+
+`canContinue` for the Targets step (case 2 in `reducer.ts`) passes when there is **≥1 target of any type OR ≥1 `DaprBuiltIn*` retry override** present. This enables the common overrides-only resiliency config (overrides apply globally with no target reference).
+
+---
+
+## Files touched
+
+- `web/src/types/resiliency.ts` — namespace default `'default'`.
+- `web/src/pages/resiliency-builder/policyDialogs.tsx` — real defaults; edit-mode props + titles.
+- `web/src/pages/resiliency-builder/targetDialogs.tsx` — edit-mode props + titles; component-direction derivation.
+- `web/src/pages/resiliency-builder/NamedList.tsx` — `onEdit` + clickable chip body.
+- `web/src/pages/resiliency-builder/StepPolicies.tsx` — edit wiring; overrides section; retries filter.
+- `web/src/pages/resiliency-builder/StepTargets.tsx` — edit wiring.
+- `web/src/pages/resiliency-builder/reducer.ts` — override-aware Targets gating.
+- `web/src/pages/resiliency-builder/defaultPolicies.ts` — **new** preset data + helper.
+
+## Testing (TDD)
+
+- `reducer.test.ts` — namespace default; override-aware gating (overrides-only passes; empty fails).
+- `policyDialogs.test.tsx` — real defaults present; edit mode prefills + rename; locked built-in name.
+- `targetDialogs.test.tsx` — edit mode prefills + rename; component direction derivation.
+- `steps.test.tsx` — overrides section rows/add/edit; retries list excludes built-ins; chip-click opens edit for policies and targets.
+- `defaultPolicies.test.ts` — **new**; preset values and `isDefaultPolicyName`.
+- `ResiliencyBuilder.test.tsx` — end-to-end override-only config reaches preview with `namespace: default` and the built-in key under `spec.policies.retries`.
+- Run `npx tsc -b` before every commit (all `npm`/`npx` from `web/`).

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,6 +7,7 @@
       "name": "dev-dashboard-web",
       "dependencies": {
         "@tanstack/react-query": "^5.59.0",
+        "js-yaml": "^5.2.0",
         "react": "^19",
         "react-dom": "^19",
         "react-router-dom": "^6.26.0"
@@ -15,6 +16,7 @@
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.1",
         "@testing-library/user-event": "^14.5.2",
+        "@types/js-yaml": "^4.0.9",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^6.0.3",
@@ -852,6 +854,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "26.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
@@ -1071,6 +1080,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -1742,6 +1757,28 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/js-yaml": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.0.tgz",
+      "integrity": "sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
     },
     "node_modules/jsdom": {
       "version": "25.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.59.0",
+    "js-yaml": "^5.2.0",
     "react": "^19",
     "react-dom": "^19",
     "react-router-dom": "^6.26.0"
@@ -18,6 +19,7 @@
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.5.2",
+    "@types/js-yaml": "^4.0.9",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.3",

--- a/web/src/components/StateStoreConnectionDialog.tsx
+++ b/web/src/components/StateStoreConnectionDialog.tsx
@@ -163,7 +163,7 @@ export function StateStoreConnectionDialog({ open, onClose }: Props) {
 
       <div className="modal-actions">
         <button className="btn ghost" onClick={onClose}>Cancel</button>
-        <button className="btn primary" disabled={!canSave} onClick={handleSave}>Save connection</button>
+        <button className="btn ghost" disabled={!canSave} onClick={handleSave}>Save connection</button>
       </div>
     </Modal>
   )

--- a/web/src/components/StateStoreConnectionsPanel.tsx
+++ b/web/src/components/StateStoreConnectionsPanel.tsx
@@ -17,7 +17,7 @@ export function StateStoreConnectionsPanel() {
     <div className="card" style={{ padding: '14px 16px', marginBottom: 16 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
         <b style={{ fontSize: 13 }}>State store connections</b>
-        <button className="btn primary" onClick={() => setAddOpen(true)}>+ Add connection</button>
+        <button className="btn ghost" onClick={() => setAddOpen(true)}>+ Add connection</button>
       </div>
 
       {(stores ?? []).length === 0 && <p className="hint">No state store connections yet.</p>}

--- a/web/src/components/TopNav.test.tsx
+++ b/web/src/components/TopNav.test.tsx
@@ -7,7 +7,7 @@ import { RefreshProvider } from '../lib/refresh'
 const noop = () => {}
 
 describe('NAV_ITEMS', () => {
-  it('has exactly 7 items in the correct order', () => {
+  it('has exactly 8 items in the correct order', () => {
     const labels = NAV_ITEMS.map((i) => i.label)
     expect(labels).toEqual([
       'Applications',
@@ -16,6 +16,7 @@ describe('NAV_ITEMS', () => {
       'Subscriptions',
       'Components',
       'Configurations',
+      'Resiliency',
       'Logs',
     ])
   })
@@ -29,6 +30,7 @@ describe('NAV_ITEMS', () => {
       '/subscriptions',
       '/components',
       '/configurations',
+      '/resiliency',
       '/logs',
     ])
   })
@@ -50,7 +52,7 @@ describe('TopNav', () => {
     expect(screen.getByRole('img', { name: /diagrid/i })).toBeInTheDocument()
   })
 
-  it('renders all 7 nav links', () => {
+  it('renders all 8 nav links', () => {
     renderNav()
     for (const item of NAV_ITEMS) {
       expect(screen.getByRole('link', { name: item.label })).toBeInTheDocument()

--- a/web/src/components/TopNav.tsx
+++ b/web/src/components/TopNav.tsx
@@ -16,6 +16,7 @@ export const NAV_ITEMS: NavItem[] = [
   { label: 'Subscriptions', to: '/subscriptions' },
   { label: 'Components', to: '/components' },
   { label: 'Configurations', to: '/configurations' },
+  { label: 'Resiliency', to: '/resiliency' },
   { label: 'Logs', to: '/logs' },
 ]
 

--- a/web/src/components/YamlPreview.test.tsx
+++ b/web/src/components/YamlPreview.test.tsx
@@ -24,6 +24,12 @@ describe('YamlPreview', () => {
     expect(onEditedChange).toHaveBeenLastCalledWith(false)
   })
 
+  it('calls onEditedChange(false) on mount so parent stale state is cleared', () => {
+    const onEditedChange = vi.fn()
+    render(<YamlPreview yaml={'a: 1\n'} filename="c.yaml" onEditedChange={onEditedChange} />)
+    expect(onEditedChange).toHaveBeenCalledWith(false)
+  })
+
   it('download button uses the current buffer and the monochrome class', () => {
     render(<YamlPreview yaml={'a: 1\n'} filename="order.yaml" />)
     const dl = screen.getByRole('button', { name: /download/i })

--- a/web/src/components/YamlPreview.test.tsx
+++ b/web/src/components/YamlPreview.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { YamlPreview } from './YamlPreview'
+
+describe('YamlPreview', () => {
+  beforeEach(() => {
+    ;(URL as unknown as { createObjectURL: unknown }).createObjectURL = vi.fn(() => 'blob:mock')
+    ;(URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = vi.fn()
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('seeds the textarea with the generated yaml', () => {
+    render(<YamlPreview yaml={'a: 1\n'} filename="c.yaml" />)
+    expect(screen.getByRole('textbox')).toHaveValue('a: 1\n')
+  })
+
+  it('reports edited=true on manual edit and edited=false on reset', () => {
+    const onEditedChange = vi.fn()
+    render(<YamlPreview yaml={'a: 1\n'} filename="c.yaml" onEditedChange={onEditedChange} />)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'a: 2\n' } })
+    expect(onEditedChange).toHaveBeenLastCalledWith(true)
+    fireEvent.click(screen.getByRole('button', { name: /reset to generated/i }))
+    expect(screen.getByRole('textbox')).toHaveValue('a: 1\n')
+    expect(onEditedChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('download button uses the current buffer and the monochrome class', () => {
+    render(<YamlPreview yaml={'a: 1\n'} filename="order.yaml" />)
+    const dl = screen.getByRole('button', { name: /download/i })
+    expect(dl).toHaveClass('btn', 'mono')
+    fireEvent.click(dl)
+    expect(URL.createObjectURL).toHaveBeenCalled()
+  })
+})

--- a/web/src/components/YamlPreview.test.tsx
+++ b/web/src/components/YamlPreview.test.tsx
@@ -26,10 +26,10 @@ describe('YamlPreview (read-only)', () => {
     expect(copyText).toHaveBeenCalledWith('a: 1\n')
   })
 
-  it('Download uses the monochrome class and triggers a download', () => {
+  it('Download uses the ghost class and triggers a download', () => {
     render(<YamlPreview yaml={'a: 1\n'} filename="order.yaml" />)
     const dl = screen.getByRole('button', { name: /download/i })
-    expect(dl).toHaveClass('btn', 'mono')
+    expect(dl).toHaveClass('btn', 'ghost')
     fireEvent.click(dl)
     expect(URL.createObjectURL).toHaveBeenCalled()
   })

--- a/web/src/components/YamlPreview.test.tsx
+++ b/web/src/components/YamlPreview.test.tsx
@@ -1,36 +1,32 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { YamlPreview } from './YamlPreview'
+import { copyText } from '../lib/clipboard'
 
-describe('YamlPreview', () => {
+vi.mock('../lib/clipboard', () => ({ copyText: vi.fn() }))
+
+describe('YamlPreview (read-only)', () => {
   beforeEach(() => {
     ;(URL as unknown as { createObjectURL: unknown }).createObjectURL = vi.fn(() => 'blob:mock')
     ;(URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = vi.fn()
   })
   afterEach(() => vi.restoreAllMocks())
 
-  it('seeds the textarea with the generated yaml', () => {
+  it('renders the yaml read-only in a <pre> (no textbox)', () => {
+    const { container } = render(<YamlPreview yaml={'a: 1\nb: x\n'} filename="c.yaml" />)
+    const pre = container.querySelector('pre.code')
+    expect(pre).not.toBeNull()
+    expect(pre?.textContent).toContain('a: 1')
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+  })
+
+  it('Copy copies the yaml', () => {
     render(<YamlPreview yaml={'a: 1\n'} filename="c.yaml" />)
-    expect(screen.getByRole('textbox')).toHaveValue('a: 1\n')
+    fireEvent.click(screen.getByRole('button', { name: /^copy$/i }))
+    expect(copyText).toHaveBeenCalledWith('a: 1\n')
   })
 
-  it('reports edited=true on manual edit and edited=false on reset', () => {
-    const onEditedChange = vi.fn()
-    render(<YamlPreview yaml={'a: 1\n'} filename="c.yaml" onEditedChange={onEditedChange} />)
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'a: 2\n' } })
-    expect(onEditedChange).toHaveBeenLastCalledWith(true)
-    fireEvent.click(screen.getByRole('button', { name: /reset to generated/i }))
-    expect(screen.getByRole('textbox')).toHaveValue('a: 1\n')
-    expect(onEditedChange).toHaveBeenLastCalledWith(false)
-  })
-
-  it('calls onEditedChange(false) on mount so parent stale state is cleared', () => {
-    const onEditedChange = vi.fn()
-    render(<YamlPreview yaml={'a: 1\n'} filename="c.yaml" onEditedChange={onEditedChange} />)
-    expect(onEditedChange).toHaveBeenCalledWith(false)
-  })
-
-  it('download button uses the current buffer and the monochrome class', () => {
+  it('Download uses the monochrome class and triggers a download', () => {
     render(<YamlPreview yaml={'a: 1\n'} filename="order.yaml" />)
     const dl = screen.getByRole('button', { name: /download/i })
     expect(dl).toHaveClass('btn', 'mono')

--- a/web/src/components/YamlPreview.tsx
+++ b/web/src/components/YamlPreview.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react'
+import { copyText } from '../lib/clipboard'
+import { useToast } from '../lib/toast'
+import { downloadText } from '../lib/download'
+
+interface YamlPreviewProps {
+  yaml: string
+  filename: string
+  onEditedChange?: (edited: boolean) => void
+}
+
+export function YamlPreview({ yaml, filename, onEditedChange }: YamlPreviewProps) {
+  const [buffer, setBuffer] = useState(yaml)
+  const [edited, setEdited] = useState(false)
+  const { toast, toastNode } = useToast()
+
+  // Re-seed when the generated yaml changes AND the user hasn't manually edited.
+  useEffect(() => {
+    if (!edited) setBuffer(yaml)
+  }, [yaml, edited])
+
+  function onInput(value: string) {
+    setBuffer(value)
+    if (!edited) {
+      setEdited(true)
+      onEditedChange?.(true)
+    }
+  }
+
+  function reset() {
+    setBuffer(yaml)
+    setEdited(false)
+    onEditedChange?.(false)
+  }
+
+  return (
+    <div>
+      <textarea
+        className="inp code"
+        aria-label="Generated YAML"
+        rows={16}
+        value={buffer}
+        onChange={(e) => onInput(e.target.value)}
+      />
+      <div className="stepnav" style={{ marginTop: 10 }}>
+        <button type="button" className="btn ghost" onClick={reset}>Reset to generated</button>
+        <div className="spacer" />
+        <button
+          type="button"
+          className="btn ghost"
+          onClick={() => { copyText(buffer); toast.show('Copied') }}
+        >
+          Copy
+        </button>
+        <button
+          type="button"
+          className="btn mono"
+          onClick={() => downloadText(filename, buffer)}
+        >
+          Download
+        </button>
+      </div>
+      {toastNode}
+    </div>
+  )
+}

--- a/web/src/components/YamlPreview.tsx
+++ b/web/src/components/YamlPreview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { highlightYaml } from '../lib/yaml-highlight'
 import { copyText } from '../lib/clipboard'
 import { useToast } from '../lib/toast'
 import { downloadText } from '../lib/download'
@@ -6,63 +6,19 @@ import { downloadText } from '../lib/download'
 interface YamlPreviewProps {
   yaml: string
   filename: string
-  onEditedChange?: (edited: boolean) => void
 }
 
-export function YamlPreview({ yaml, filename, onEditedChange }: YamlPreviewProps) {
-  const [buffer, setBuffer] = useState(yaml)
-  const [edited, setEdited] = useState(false)
+export function YamlPreview({ yaml, filename }: YamlPreviewProps) {
   const { toast, toastNode } = useToast()
-
-  // Notify parent of initial (false) edited state on mount so stale parent state is cleared.
-  useEffect(() => {
-    onEditedChange?.(false)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  // Re-seed when the generated yaml changes AND the user hasn't manually edited.
-  useEffect(() => {
-    if (!edited) setBuffer(yaml)
-  }, [yaml, edited])
-
-  function onInput(value: string) {
-    setBuffer(value)
-    if (!edited) {
-      setEdited(true)
-      onEditedChange?.(true)
-    }
-  }
-
-  function reset() {
-    setBuffer(yaml)
-    setEdited(false)
-    onEditedChange?.(false)
-  }
-
   return (
     <div>
-      <textarea
-        className="inp code"
-        aria-label="Generated YAML"
-        rows={16}
-        value={buffer}
-        onChange={(e) => onInput(e.target.value)}
-      />
+      <pre className="code">{highlightYaml(yaml)}</pre>
       <div className="stepnav" style={{ marginTop: 10 }}>
-        <button type="button" className="btn ghost" onClick={reset}>Reset to generated</button>
         <div className="spacer" />
-        <button
-          type="button"
-          className="btn ghost"
-          onClick={() => { copyText(buffer); toast.show('Copied') }}
-        >
+        <button type="button" className="btn ghost" onClick={() => { copyText(yaml); toast.show('Copied') }}>
           Copy
         </button>
-        <button
-          type="button"
-          className="btn mono"
-          onClick={() => downloadText(filename, buffer)}
-        >
+        <button type="button" className="btn mono" onClick={() => downloadText(filename, yaml)}>
           Download
         </button>
       </div>

--- a/web/src/components/YamlPreview.tsx
+++ b/web/src/components/YamlPreview.tsx
@@ -18,7 +18,7 @@ export function YamlPreview({ yaml, filename }: YamlPreviewProps) {
         <button type="button" className="btn ghost" onClick={() => { copyText(yaml); toast.show('Copied') }}>
           Copy
         </button>
-        <button type="button" className="btn mono" onClick={() => downloadText(filename, yaml)}>
+        <button type="button" className="btn ghost" onClick={() => downloadText(filename, yaml)}>
           Download
         </button>
       </div>

--- a/web/src/components/YamlPreview.tsx
+++ b/web/src/components/YamlPreview.tsx
@@ -14,6 +14,12 @@ export function YamlPreview({ yaml, filename, onEditedChange }: YamlPreviewProps
   const [edited, setEdited] = useState(false)
   const { toast, toastNode } = useToast()
 
+  // Notify parent of initial (false) edited state on mount so stale parent state is cleared.
+  useEffect(() => {
+    onEditedChange?.(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   // Re-seed when the generated yaml changes AND the user hasn't manually edited.
   useEffect(() => {
     if (!edited) setBuffer(yaml)

--- a/web/src/components/form/Field.tsx
+++ b/web/src/components/form/Field.tsx
@@ -1,0 +1,20 @@
+interface FieldProps {
+  label: string
+  htmlFor?: string
+  required?: boolean
+  error?: string | null
+  children: React.ReactNode
+}
+
+export function Field({ label, htmlFor, required, error, children }: FieldProps) {
+  return (
+    <div className="field">
+      <label htmlFor={htmlFor}>
+        {label}
+        {required && <span className="req"> *</span>}
+      </label>
+      {children}
+      {error && <div className="field-err">{error}</div>}
+    </div>
+  )
+}

--- a/web/src/components/form/NumberInput.tsx
+++ b/web/src/components/form/NumberInput.tsx
@@ -1,0 +1,22 @@
+interface NumberInputProps {
+  id?: string
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  'aria-label'?: string
+}
+
+// value is kept as a string so the field can be empty; callers coerce on emit.
+export function NumberInput({ id, value, onChange, placeholder, ...rest }: NumberInputProps) {
+  return (
+    <input
+      id={id}
+      className="inp"
+      type="number"
+      value={value}
+      placeholder={placeholder}
+      aria-label={rest['aria-label']}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  )
+}

--- a/web/src/components/form/SelectInput.tsx
+++ b/web/src/components/form/SelectInput.tsx
@@ -1,0 +1,29 @@
+interface SelectOption {
+  label: string
+  value: string
+}
+
+interface SelectInputProps {
+  id?: string
+  value: string
+  onChange: (value: string) => void
+  options: SelectOption[]
+  'aria-label'?: string
+}
+
+export function SelectInput({ id, value, onChange, options, ...rest }: SelectInputProps) {
+  return (
+    <select
+      id={id}
+      className="select"
+      value={value}
+      aria-label={rest['aria-label']}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="">—</option>
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>{o.label}</option>
+      ))}
+    </select>
+  )
+}

--- a/web/src/components/form/TextInput.tsx
+++ b/web/src/components/form/TextInput.tsx
@@ -1,0 +1,22 @@
+interface TextInputProps {
+  id?: string
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  type?: 'text' | 'password'
+  'aria-label'?: string
+}
+
+export function TextInput({ id, value, onChange, placeholder, type = 'text', ...rest }: TextInputProps) {
+  return (
+    <input
+      id={id}
+      className="inp"
+      type={type}
+      value={value}
+      placeholder={placeholder}
+      aria-label={rest['aria-label']}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  )
+}

--- a/web/src/components/form/Toggle.tsx
+++ b/web/src/components/form/Toggle.tsx
@@ -1,0 +1,21 @@
+interface ToggleProps {
+  id?: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+  label: string
+}
+
+export function Toggle({ id, checked, onChange, label }: ToggleProps) {
+  return (
+    <label className="childtoggle">
+      <input
+        id={id}
+        type="checkbox"
+        aria-label={label}
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      {label}
+    </label>
+  )
+}

--- a/web/src/components/form/form.test.tsx
+++ b/web/src/components/form/form.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { Field, TextInput, NumberInput, SelectInput, Toggle } from './index'
+
+describe('Field', () => {
+  it('renders label, required marker, and error', () => {
+    render(<Field label="Name" required error="bad"><input aria-label="Name" /></Field>)
+    expect(screen.getByText('Name')).toBeInTheDocument()
+    expect(screen.getByText('*')).toBeInTheDocument()
+    expect(screen.getByText('bad')).toBeInTheDocument()
+  })
+})
+
+describe('TextInput', () => {
+  it('is controlled and reports string values', () => {
+    const onChange = vi.fn()
+    render(<TextInput value="a" onChange={onChange} aria-label="f" />)
+    fireEvent.change(screen.getByLabelText('f'), { target: { value: 'ab' } })
+    expect(onChange).toHaveBeenCalledWith('ab')
+  })
+})
+
+describe('SelectInput', () => {
+  it('renders options and reports the chosen value', () => {
+    const onChange = vi.fn()
+    render(
+      <SelectInput value="" onChange={onChange} aria-label="pick"
+        options={[{ label: 'One', value: '1' }, { label: 'Two', value: '2' }]} />,
+    )
+    fireEvent.change(screen.getByLabelText('pick'), { target: { value: '2' } })
+    expect(onChange).toHaveBeenCalledWith('2')
+  })
+})
+
+describe('Toggle', () => {
+  it('reports boolean changes', () => {
+    const onChange = vi.fn()
+    render(<Toggle checked={false} onChange={onChange} label="on" />)
+    fireEvent.click(screen.getByLabelText('on'))
+    expect(onChange).toHaveBeenCalledWith(true)
+  })
+})
+
+describe('NumberInput', () => {
+  it('reports raw string value (allowing empty)', () => {
+    const onChange = vi.fn()
+    render(<NumberInput value="" onChange={onChange} aria-label="n" />)
+    fireEvent.change(screen.getByLabelText('n'), { target: { value: '5' } })
+    expect(onChange).toHaveBeenCalledWith('5')
+  })
+})

--- a/web/src/components/form/index.ts
+++ b/web/src/components/form/index.ts
@@ -1,0 +1,5 @@
+export { Field } from './Field'
+export { TextInput } from './TextInput'
+export { NumberInput } from './NumberInput'
+export { SelectInput } from './SelectInput'
+export { Toggle } from './Toggle'

--- a/web/src/components/wizard/StepNav.tsx
+++ b/web/src/components/wizard/StepNav.tsx
@@ -1,0 +1,26 @@
+interface StepNavProps {
+  activeStep: number
+  stepCount: number
+  canContinue: boolean
+  onBack: () => void
+  onContinue: () => void
+  onFinish: () => void
+}
+
+export function StepNav({ activeStep, stepCount, canContinue, onBack, onContinue, onFinish }: StepNavProps) {
+  const isLast = activeStep === stepCount - 1
+  return (
+    <div className="stepnav">
+      {activeStep > 0 ? (
+        <button type="button" className="btn ghost" onClick={onBack}>Back</button>
+      ) : (
+        <span className="spacer" />
+      )}
+      {isLast ? (
+        <button type="button" className="btn mono" disabled={!canContinue} onClick={onFinish}>Finish</button>
+      ) : (
+        <button type="button" className="btn mono" disabled={!canContinue} onClick={onContinue}>Continue</button>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/wizard/StepNav.tsx
+++ b/web/src/components/wizard/StepNav.tsx
@@ -17,9 +17,9 @@ export function StepNav({ activeStep, stepCount, canContinue, onBack, onContinue
         <span className="spacer" />
       )}
       {isLast ? (
-        <button type="button" className="btn mono" disabled={!canContinue} onClick={onFinish}>Finish</button>
+        <button type="button" className="btn ghost" disabled={!canContinue} onClick={onFinish}>Finish</button>
       ) : (
-        <button type="button" className="btn mono" disabled={!canContinue} onClick={onContinue}>Continue</button>
+        <button type="button" className="btn ghost" disabled={!canContinue} onClick={onContinue}>Continue</button>
       )}
     </div>
   )

--- a/web/src/components/wizard/Stepper.tsx
+++ b/web/src/components/wizard/Stepper.tsx
@@ -1,0 +1,21 @@
+interface StepperProps {
+  steps: { label: string }[]
+  activeStep: number
+}
+
+export function Stepper({ steps, activeStep }: StepperProps) {
+  return (
+    <div className="stepper" role="list" aria-label="Wizard steps">
+      {steps.map((s, i) => (
+        <span
+          key={s.label}
+          role="listitem"
+          aria-current={i === activeStep ? 'step' : undefined}
+          className={`step${i === activeStep ? ' active' : ''}${i < activeStep ? ' done' : ''}`}
+        >
+          {s.label}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/web/src/components/wizard/Wizard.tsx
+++ b/web/src/components/wizard/Wizard.tsx
@@ -1,0 +1,33 @@
+import { Stepper } from './Stepper'
+import { StepNav } from './StepNav'
+
+export interface WizardStep {
+  label: string
+  content: React.ReactNode
+}
+
+interface WizardProps {
+  steps: WizardStep[]
+  activeStep: number
+  canContinue: boolean
+  onBack: () => void
+  onContinue: () => void
+  onFinish: () => void
+}
+
+export function Wizard({ steps, activeStep, canContinue, onBack, onContinue, onFinish }: WizardProps) {
+  return (
+    <div className="wizard">
+      <Stepper steps={steps.map((s) => ({ label: s.label }))} activeStep={activeStep} />
+      <div className="wizard-body">{steps[activeStep]?.content}</div>
+      <StepNav
+        activeStep={activeStep}
+        stepCount={steps.length}
+        canContinue={canContinue}
+        onBack={onBack}
+        onContinue={onContinue}
+        onFinish={onFinish}
+      />
+    </div>
+  )
+}

--- a/web/src/components/wizard/index.ts
+++ b/web/src/components/wizard/index.ts
@@ -1,0 +1,3 @@
+export { Wizard, type WizardStep } from './Wizard'
+export { Stepper } from './Stepper'
+export { StepNav } from './StepNav'

--- a/web/src/components/wizard/wizard.test.tsx
+++ b/web/src/components/wizard/wizard.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { Wizard, StepNav } from './index'
+
+const steps = [
+  { label: 'One', content: <div>content-one</div> },
+  { label: 'Two', content: <div>content-two</div> },
+]
+
+describe('Wizard', () => {
+  it('renders step labels and only the active step content', () => {
+    render(<Wizard steps={steps} activeStep={0} canContinue onBack={() => {}} onContinue={() => {}} onFinish={() => {}} />)
+    expect(screen.getByText('One')).toBeInTheDocument()
+    expect(screen.getByText('Two')).toBeInTheDocument()
+    expect(screen.getByText('content-one')).toBeInTheDocument()
+    expect(screen.queryByText('content-two')).not.toBeInTheDocument()
+  })
+})
+
+describe('StepNav', () => {
+  it('hides Back on the first step and shows Continue', () => {
+    render(<StepNav activeStep={0} stepCount={2} canContinue onBack={() => {}} onContinue={() => {}} onFinish={() => {}} />)
+    expect(screen.queryByRole('button', { name: /back/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /continue/i })).toBeEnabled()
+  })
+  it('shows Finish (not Continue) on the last step', () => {
+    render(<StepNav activeStep={1} stepCount={2} canContinue onBack={() => {}} onContinue={() => {}} onFinish={() => {}} />)
+    expect(screen.getByRole('button', { name: /finish/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /continue/i })).not.toBeInTheDocument()
+  })
+  it('disables the primary action when canContinue is false', () => {
+    render(<StepNav activeStep={0} stepCount={2} canContinue={false} onBack={() => {}} onContinue={() => {}} onFinish={() => {}} />)
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled()
+  })
+  it('primary button uses the monochrome class, never the green .btn.primary', () => {
+    render(<StepNav activeStep={0} stepCount={2} canContinue onBack={() => {}} onContinue={() => {}} onFinish={() => {}} />)
+    const cont = screen.getByRole('button', { name: /continue/i })
+    expect(cont).toHaveClass('btn', 'mono')
+    expect(cont).not.toHaveClass('primary')
+  })
+  it('fires onContinue / onFinish / onBack', () => {
+    const onContinue = vi.fn(); const onFinish = vi.fn(); const onBack = vi.fn()
+    const { rerender } = render(<StepNav activeStep={0} stepCount={2} canContinue onBack={onBack} onContinue={onContinue} onFinish={onFinish} />)
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }))
+    expect(onContinue).toHaveBeenCalledOnce()
+    rerender(<StepNav activeStep={1} stepCount={2} canContinue onBack={onBack} onContinue={onContinue} onFinish={onFinish} />)
+    fireEvent.click(screen.getByRole('button', { name: /back/i }))
+    fireEvent.click(screen.getByRole('button', { name: /finish/i }))
+    expect(onBack).toHaveBeenCalledOnce()
+    expect(onFinish).toHaveBeenCalledOnce()
+  })
+})

--- a/web/src/components/wizard/wizard.test.tsx
+++ b/web/src/components/wizard/wizard.test.tsx
@@ -32,11 +32,12 @@ describe('StepNav', () => {
     render(<StepNav activeStep={0} stepCount={2} canContinue={false} onBack={() => {}} onContinue={() => {}} onFinish={() => {}} />)
     expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled()
   })
-  it('primary button uses the monochrome class, never the green .btn.primary', () => {
+  it('primary button uses ghost styling, never the green .btn.primary', () => {
     render(<StepNav activeStep={0} stepCount={2} canContinue onBack={() => {}} onContinue={() => {}} onFinish={() => {}} />)
     const cont = screen.getByRole('button', { name: /continue/i })
-    expect(cont).toHaveClass('btn', 'mono')
+    expect(cont).toHaveClass('btn', 'ghost')
     expect(cont).not.toHaveClass('primary')
+    expect(cont).not.toHaveClass('mono')
   })
   it('fires onContinue / onFinish / onBack', () => {
     const onContinue = vi.fn(); const onFinish = vi.fn(); const onBack = vi.fn()

--- a/web/src/hooks/useComponentSchemas.test.tsx
+++ b/web/src/hooks/useComponentSchemas.test.tsx
@@ -1,0 +1,50 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { server } from '../test/setup'
+import { QueryProvider, makeQueryClient } from '../lib/query'
+import { useComponentSchemas, activeFields } from './useComponentSchemas'
+import type { ComponentMetadataSchema } from '../types/metadata'
+
+const bundle = {
+  schemaVersion: '1', date: '2026-01-01',
+  components: [
+    { type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable',
+      metadata: [{ name: 'redisHost', required: true }, { name: 'enableTLS', type: 'bool' }] },
+    { type: 'pubsub', name: 'redis', version: 'v1', title: 'Redis PubSub', status: 'stable', metadata: [] },
+  ],
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <QueryProvider client={makeQueryClient()}>{children}</QueryProvider>
+}
+
+describe('useComponentSchemas', () => {
+  it('returns all schemas grouped by type (no state-only filter)', async () => {
+    server.use(http.get('/api/metadata/components', () => HttpResponse.json(bundle)))
+    const { result } = renderHook(() => useComponentSchemas(), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.schemas).toHaveLength(2)
+    expect(Object.keys(result.current.byType).sort()).toEqual(['pubsub', 'state'])
+    expect(result.current.byType.state[0].name).toBe('redis')
+  })
+})
+
+describe('activeFields', () => {
+  const schema: ComponentMetadataSchema = {
+    type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable',
+    metadata: [{ name: 'redisHost', required: true }, { name: 'enableTLS', type: 'bool' }],
+  }
+  it('splits required vs optional and merges auth-profile fields', () => {
+    const { required, optional } = activeFields(schema, {
+      title: 'AWS IAM', metadata: [{ name: 'accessKey', required: true, sensitive: true }],
+    })
+    expect(required.map((f) => f.name).sort()).toEqual(['accessKey', 'redisHost'])
+    expect(optional.map((f) => f.name)).toEqual(['enableTLS'])
+  })
+  it('works with no auth profile', () => {
+    const { required, optional } = activeFields(schema)
+    expect(required.map((f) => f.name)).toEqual(['redisHost'])
+    expect(optional.map((f) => f.name)).toEqual(['enableTLS'])
+  })
+})

--- a/web/src/hooks/useComponentSchemas.ts
+++ b/web/src/hooks/useComponentSchemas.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchJSON } from '../lib/api'
+import type { MetadataBundle, ComponentMetadataSchema, MetadataField, AuthenticationProfile } from '../types/metadata'
+
+export function useComponentSchemas() {
+  const query = useQuery<MetadataBundle>({
+    queryKey: ['metadata', 'components'],
+    queryFn: () => fetchJSON<MetadataBundle>('/metadata/components'),
+    staleTime: 60 * 60 * 1000,
+  })
+  const schemas = query.data?.components ?? []
+  const byType: Record<string, ComponentMetadataSchema[]> = {}
+  for (const s of schemas) {
+    ;(byType[s.type] ??= []).push(s)
+  }
+  return { schemas, byType, isLoading: query.isLoading, isError: query.isError }
+}
+
+/** Merge schema metadata with the chosen auth-profile metadata, split by required. */
+export function activeFields(
+  schema: ComponentMetadataSchema,
+  authProfile?: AuthenticationProfile,
+): { required: MetadataField[]; optional: MetadataField[] } {
+  const all: MetadataField[] = [...(schema.metadata ?? []), ...(authProfile?.metadata ?? [])]
+  const required = all.filter((f) => f.required)
+  const optional = all.filter((f) => !f.required)
+  return { required, optional }
+}

--- a/web/src/lib/download.test.ts
+++ b/web/src/lib/download.test.ts
@@ -17,10 +17,12 @@ describe('downloadText', () => {
       if (tag === 'a') (el as HTMLAnchorElement).click = click
       return el
     })
+    const appendSpy = vi.spyOn(document.body, 'appendChild')
     downloadText('order.yaml', 'a: 1\n')
     const anchor = spy.mock.results.map((r) => r.value as HTMLElement).find((e) => e.tagName === 'A') as HTMLAnchorElement
     expect(anchor.download).toBe('order.yaml')
     expect(anchor.href).toContain('blob:mock')
+    expect(appendSpy).toHaveBeenCalledWith(anchor)
     expect(click).toHaveBeenCalledOnce()
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock')
   })

--- a/web/src/lib/download.test.ts
+++ b/web/src/lib/download.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { downloadText } from './download'
+
+describe('downloadText', () => {
+  beforeEach(() => {
+    // jsdom lacks these; stub them.
+    ;(URL as unknown as { createObjectURL: unknown }).createObjectURL = vi.fn(() => 'blob:mock')
+    ;(URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = vi.fn()
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('creates an anchor with the given filename and clicks it', () => {
+    const click = vi.fn()
+    const orig = document.createElement.bind(document)
+    const spy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = orig(tag) as HTMLElement
+      if (tag === 'a') (el as HTMLAnchorElement).click = click
+      return el
+    })
+    downloadText('order.yaml', 'a: 1\n')
+    const anchor = spy.mock.results.map((r) => r.value as HTMLElement).find((e) => e.tagName === 'A') as HTMLAnchorElement
+    expect(anchor.download).toBe('order.yaml')
+    expect(anchor.href).toContain('blob:mock')
+    expect(click).toHaveBeenCalledOnce()
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock')
+  })
+})

--- a/web/src/lib/download.ts
+++ b/web/src/lib/download.ts
@@ -1,0 +1,12 @@
+/** Trigger a client-side download of `text` as a file named `filename`. */
+export function downloadText(filename: string, text: string): void {
+  const blob = new Blob([text], { type: 'text/yaml;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+}

--- a/web/src/lib/validation.test.ts
+++ b/web/src/lib/validation.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateGoDuration,
+  validateResourceName,
+  validateStatusCodes,
+  requiredError,
+  integerError,
+} from './validation'
+
+describe('validateGoDuration', () => {
+  it('accepts ordered unit combinations', () => {
+    for (const d of ['30s', '1h', '1h30m', '500ms', '1m30s', '10s', '15m']) {
+      expect(validateGoDuration(d).valid, d).toBe(true)
+    }
+  })
+  it('accepts empty string (required-ness gated separately)', () => {
+    expect(validateGoDuration('').valid).toBe(true)
+  })
+  it('rejects out-of-order and repeated units', () => {
+    expect(validateGoDuration('1s1h').valid).toBe(false)
+    expect(validateGoDuration('1m1m').valid).toBe(false)
+  })
+  it('rejects arbitrary text', () => {
+    const r = validateGoDuration('nope')
+    expect(r.valid).toBe(false)
+    expect(r.error).toBeTruthy()
+  })
+})
+
+describe('validateResourceName', () => {
+  it('accepts lowercase dns-ish names', () => {
+    expect(validateResourceName('order-store')).toBeNull()
+  })
+  it('rejects empty, spaces, bad chars, and non-letter starts', () => {
+    expect(validateResourceName('')).toMatch(/required/i)
+    expect(validateResourceName('a b')).toMatch(/space/i)
+    expect(validateResourceName('a_b')).toMatch(/alphanumeric/i)
+    expect(validateResourceName('1abc')).toMatch(/start/i)
+  })
+})
+
+describe('validateStatusCodes', () => {
+  it('accepts CSV of codes and ranges', () => {
+    expect(validateStatusCodes('200,404,500-503')).toBeNull()
+    expect(validateStatusCodes('')).toBeNull() // optional
+  })
+  it('rejects malformed input', () => {
+    expect(validateStatusCodes('200,abc')).toBeTruthy()
+    expect(validateStatusCodes('200-')).toBeTruthy()
+  })
+})
+
+describe('requiredError / integerError', () => {
+  it('requiredError flags empty', () => {
+    expect(requiredError('')).toMatch(/required/i)
+    expect(requiredError('x')).toBeNull()
+  })
+  it('integerError flags non-integers, allows empty', () => {
+    expect(integerError('')).toBeNull()
+    expect(integerError('3')).toBeNull()
+    expect(integerError('-1')).toBeNull()
+    expect(integerError('1.5')).toMatch(/integer/i)
+    expect(integerError('x')).toMatch(/integer/i)
+  })
+})

--- a/web/src/lib/validation.ts
+++ b/web/src/lib/validation.ts
@@ -1,0 +1,53 @@
+// Go duration: optional units in strict descending order, no repetition.
+// Ported from cloudgrid utils/validateGoDuration.ts. Empty string is valid
+// (required-ness is enforced separately by requiredError).
+const DURATION_RE = /^(\d+h)?(\d+m)?(\d+s)?(\d+ms)?(\d+[uµ]s)?(\d+ns)?$/
+const UNIT_ORDER = ['h', 'm', 's', 'ms', 'us', 'µs', 'ns']
+
+export function validateGoDuration(value: string): { valid: boolean; error?: string } {
+  const err = 'Enter a Go duration like 30s, 5m, 1h30m (units in order h→m→s→ms→us→ns, no repeats)'
+  const matches = value.match(DURATION_RE)
+  if (!matches) return { valid: false, error: err }
+  let lastIndex = -1
+  for (let i = 1; i < matches.length; i++) {
+    const m = matches[i]
+    if (!m) continue
+    let unit: string
+    if (m.endsWith('ms')) unit = 'ms'
+    else if (m.endsWith('us')) unit = 'us'
+    else if (m.endsWith('µs')) unit = 'µs'
+    else if (m.endsWith('ns')) unit = 'ns'
+    else unit = UNIT_ORDER.find((u) => m.endsWith(u)) as string
+    const idx = UNIT_ORDER.indexOf(unit)
+    if (idx <= lastIndex) return { valid: false, error: err }
+    lastIndex = idx
+  }
+  return { valid: true }
+}
+
+// Ported from cloudgrid ConductorResourceMetadataSchema name rules.
+export function validateResourceName(value: string): string | null {
+  if (!value) return 'Name is required'
+  if (value.includes(' ')) return 'Name cannot contain spaces'
+  if (/[^a-zA-Z0-9-]/.test(value)) return 'Only alphanumeric characters and hyphens are allowed'
+  if (/^[^a-zA-Z]/.test(value)) return 'Name must start with a letter'
+  return null
+}
+
+// CSV of HTTP/gRPC status codes or ranges, e.g. "200,404,500-503". Optional.
+export function validateStatusCodes(value: string): string | null {
+  if (value.trim() === '') return null
+  const parts = value.split(',').map((p) => p.trim())
+  const seg = /^\d{1,3}(-\d{1,3})?$/
+  if (!parts.every((p) => seg.test(p))) return 'Use comma-separated codes or ranges, e.g. 200,404,500-503'
+  return null
+}
+
+export function requiredError(value: string): string | null {
+  return value.trim() === '' ? 'This field is required' : null
+}
+
+export function integerError(value: string): string | null {
+  if (value.trim() === '') return null
+  return /^-?\d+$/.test(value.trim()) ? null : 'Must be an integer'
+}

--- a/web/src/lib/yaml-emit.test.ts
+++ b/web/src/lib/yaml-emit.test.ts
@@ -26,4 +26,7 @@ describe('recursivelyRemoveEmptyValues', () => {
     expect(out).toEqual({ spec: { timeout: '30s' } })
     expect(input.spec.extra).toBe('') // original untouched
   })
+  it('preserves non-empty array values without creating holes', () => {
+    expect(recursivelyRemoveEmptyValues({ scopes: ['a', 'b'] })).toEqual({ scopes: ['a', 'b'] })
+  })
 })

--- a/web/src/lib/yaml-emit.test.ts
+++ b/web/src/lib/yaml-emit.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { dumpYaml, recursivelyRemoveEmptyValues } from './yaml-emit'
+
+describe('dumpYaml', () => {
+  it('serializes a plain object to YAML', () => {
+    expect(dumpYaml({ a: 1, b: 'x' })).toBe('a: 1\nb: x\n')
+  })
+})
+
+describe('recursivelyRemoveEmptyValues', () => {
+  it('removes null, undefined, empty string, whitespace string', () => {
+    expect(recursivelyRemoveEmptyValues({ a: null, b: undefined, c: '', d: '  ', e: 'keep' })).toEqual({ e: 'keep' })
+  })
+  it('preserves 0 and false', () => {
+    expect(recursivelyRemoveEmptyValues({ n: 0, b: false })).toEqual({ n: 0, b: false })
+  })
+  it('removes empty objects and empty arrays', () => {
+    expect(recursivelyRemoveEmptyValues({ o: {}, a: [], keep: { x: 1 } })).toEqual({ keep: { x: 1 } })
+  })
+  it('prunes branches that become empty after recursion', () => {
+    expect(recursivelyRemoveEmptyValues({ policies: { retries: { r1: { duration: '' } } } })).toEqual({})
+  })
+  it('keeps non-empty nested values and does not mutate the input', () => {
+    const input = { spec: { timeout: '30s', extra: '' } }
+    const out = recursivelyRemoveEmptyValues(input)
+    expect(out).toEqual({ spec: { timeout: '30s' } })
+    expect(input.spec.extra).toBe('') // original untouched
+  })
+})

--- a/web/src/lib/yaml-emit.ts
+++ b/web/src/lib/yaml-emit.ts
@@ -1,0 +1,42 @@
+import { dump } from 'js-yaml'
+
+/** Serialize an object to YAML using js-yaml defaults (matches cloudgrid: no options). */
+export function dumpYaml(obj: unknown): string {
+  return dump(obj)
+}
+
+// lodash-isEmpty equivalent for the only cases used here: plain objects and arrays.
+function isEmptyContainer(v: unknown): boolean {
+  if (Array.isArray(v)) return v.length === 0
+  if (v && typeof v === 'object') return Object.keys(v as Record<string, unknown>).length === 0
+  return false
+}
+
+/**
+ * Deep-clone `input`, then delete keys whose value is null/undefined, an
+ * empty/whitespace string, or an empty object/array — recursing into nested
+ * objects and pruning branches that become empty. Numbers (incl. 0) and
+ * booleans (incl. false) are preserved. Ported from cloudgrid
+ * resiliency-builder/utils.ts `recursivelyRemoveEmptyValues`.
+ */
+export function recursivelyRemoveEmptyValues<T>(input: T): T {
+  const obj = structuredClone(input)
+  if (typeof obj === 'object' && obj !== null) {
+    const rec = obj as Record<string, unknown>
+    for (const key of Object.keys(rec)) {
+      const v = rec[key]
+      if (
+        v === null ||
+        v === undefined ||
+        (typeof v === 'string' && v.trim() === '') ||
+        (typeof v === 'object' && isEmptyContainer(v))
+      ) {
+        delete rec[key]
+      } else if (typeof v === 'object') {
+        rec[key] = recursivelyRemoveEmptyValues(v)
+        if (isEmptyContainer(rec[key])) delete rec[key]
+      }
+    }
+  }
+  return obj
+}

--- a/web/src/lib/yaml-emit.ts
+++ b/web/src/lib/yaml-emit.ts
@@ -5,7 +5,7 @@ export function dumpYaml(obj: unknown): string {
   return dump(obj)
 }
 
-// lodash-isEmpty equivalent for the only cases used here: plain objects and arrays.
+// Check if the value is an empty array or empty plain object.
 function isEmptyContainer(v: unknown): boolean {
   if (Array.isArray(v)) return v.length === 0
   if (v && typeof v === 'object') return Object.keys(v as Record<string, unknown>).length === 0
@@ -21,7 +21,7 @@ function isEmptyContainer(v: unknown): boolean {
  */
 export function recursivelyRemoveEmptyValues<T>(input: T): T {
   const obj = structuredClone(input)
-  if (typeof obj === 'object' && obj !== null) {
+  if (typeof obj === 'object' && obj !== null && !Array.isArray(obj)) {
     const rec = obj as Record<string, unknown>
     for (const key of Object.keys(rec)) {
       const v = rec[key]
@@ -32,7 +32,7 @@ export function recursivelyRemoveEmptyValues<T>(input: T): T {
         (typeof v === 'object' && isEmptyContainer(v))
       ) {
         delete rec[key]
-      } else if (typeof v === 'object') {
+      } else if (typeof v === 'object' && !Array.isArray(v)) {
         rec[key] = recursivelyRemoveEmptyValues(v)
         if (isEmptyContainer(rec[key])) delete rec[key]
       }

--- a/web/src/pages/Resiliency.test.tsx
+++ b/web/src/pages/Resiliency.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import { Resiliency } from './Resiliency'
+
+describe('Resiliency landing', () => {
+  it('shows the empty state and a New resiliency policy link', () => {
+    render(<MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}><Resiliency /></MemoryRouter>)
+    expect(screen.getByText(/no resiliency policies/i)).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: /new resiliency policy/i })
+    expect(link).toHaveAttribute('href', '/resiliency/new')
+  })
+})

--- a/web/src/pages/Resiliency.tsx
+++ b/web/src/pages/Resiliency.tsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router-dom'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
+
+export function Resiliency() {
+  useDocumentTitle('Resiliency')
+  return (
+    <div className="page">
+      <div className="phead">
+        <div>
+          <h1>Resiliency</h1>
+          <div className="sub">Dapr resiliency policies</div>
+        </div>
+        <Link className="btn ghost" to="/resiliency/new">+ New resiliency policy</Link>
+      </div>
+      <div className="md">
+        <div className="card complist" />
+        <div className="card">
+          <p className="hint" style={{ padding: '14px' }}>
+            No resiliency policies. Use &ldquo;New resiliency policy&rdquo; to build one.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/ResourceList.tsx
+++ b/web/src/pages/ResourceList.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useResources } from '../hooks/useResources'
 import type { ResourceKind } from '../types/resources'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
@@ -58,6 +58,9 @@ export function ResourceList({ kind }: ResourceListProps) {
             <h1>{title}</h1>
             <div className="sub">{sub}</div>
           </div>
+          {kind === 'component' && (
+            <Link className="btn mono" to="/components/new">+ New component</Link>
+          )}
         </div>
         {kind === 'component' && <StateStoreConnectionsPanel />}
         <p className="muted">Loading…</p>
@@ -74,6 +77,9 @@ export function ResourceList({ kind }: ResourceListProps) {
             <h1>{title}</h1>
             <div className="sub">{sub}</div>
           </div>
+          {kind === 'component' && (
+            <Link className="btn mono" to="/components/new">+ New component</Link>
+          )}
         </div>
         {kind === 'component' && <StateStoreConnectionsPanel />}
         <div className="md">
@@ -99,6 +105,9 @@ export function ResourceList({ kind }: ResourceListProps) {
           <h1>{title}</h1>
           <div className="sub">{sub}</div>
         </div>
+        {kind === 'component' && (
+          <Link className="btn mono" to="/components/new">+ New component</Link>
+        )}
       </div>
       {kind === 'component' && <StateStoreConnectionsPanel />}
       <div className="md">

--- a/web/src/pages/ResourceList.tsx
+++ b/web/src/pages/ResourceList.tsx
@@ -59,7 +59,7 @@ export function ResourceList({ kind }: ResourceListProps) {
             <div className="sub">{sub}</div>
           </div>
           {kind === 'component' && (
-            <Link className="btn mono" to="/components/new">+ New component</Link>
+            <Link className="btn ghost" to="/components/new">+ New component</Link>
           )}
         </div>
         {kind === 'component' && <StateStoreConnectionsPanel />}
@@ -78,7 +78,7 @@ export function ResourceList({ kind }: ResourceListProps) {
             <div className="sub">{sub}</div>
           </div>
           {kind === 'component' && (
-            <Link className="btn mono" to="/components/new">+ New component</Link>
+            <Link className="btn ghost" to="/components/new">+ New component</Link>
           )}
         </div>
         {kind === 'component' && <StateStoreConnectionsPanel />}
@@ -106,7 +106,7 @@ export function ResourceList({ kind }: ResourceListProps) {
           <div className="sub">{sub}</div>
         </div>
         {kind === 'component' && (
-          <Link className="btn mono" to="/components/new">+ New component</Link>
+          <Link className="btn ghost" to="/components/new">+ New component</Link>
         )}
       </div>
       {kind === 'component' && <StateStoreConnectionsPanel />}

--- a/web/src/pages/component-builder/ComponentBuilder.test.tsx
+++ b/web/src/pages/component-builder/ComponentBuilder.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
+import { describe, it, expect } from 'vitest'
+import { server } from '../../test/setup'
+import { QueryProvider, makeQueryClient } from '../../lib/query'
+import { ComponentBuilder } from './ComponentBuilder'
+
+const bundle = {
+  schemaVersion: '1', date: '2026-01-01',
+  components: [{ type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable',
+    metadata: [{ name: 'redisHost', required: true }] }],
+}
+
+function renderBuilder() {
+  server.use(http.get('/api/metadata/components', () => HttpResponse.json(bundle)))
+  const router = createMemoryRouter(
+    [{ path: '/components/new', element: <ComponentBuilder /> }, { path: '/components', element: <div>components list</div> }],
+    { initialEntries: ['/components/new'], future: { v7_relativeSplatPath: true } },
+  )
+  return render(<QueryProvider client={makeQueryClient()}><RouterProvider router={router} future={{ v7_startTransition: true }} /></QueryProvider>)
+}
+
+describe('ComponentBuilder', () => {
+  it('walks type → (auth) → configure → preview and shows generated YAML', async () => {
+    renderBuilder()
+    fireEvent.click(await screen.findByText('Redis')) // step 0 -> 1
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // step 1 -> 2 (no profiles)
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'order-store' } })
+    fireEvent.change(screen.getByLabelText('redisHost'), { target: { value: 'localhost:6379' } })
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // step 2 -> 3
+    const ta = await screen.findByRole('textbox', { name: /generated yaml/i })
+    await waitFor(() => expect((ta as HTMLTextAreaElement).value).toContain('type: state.redis'))
+    expect((ta as HTMLTextAreaElement).value).toContain('name: order-store')
+  })
+})

--- a/web/src/pages/component-builder/ComponentBuilder.test.tsx
+++ b/web/src/pages/component-builder/ComponentBuilder.test.tsx
@@ -22,29 +22,6 @@ function renderBuilder() {
 }
 
 describe('ComponentBuilder', () => {
-  it('Finish is re-enabled after Back-from-preview when user had edited YAML', async () => {
-    renderBuilder()
-    fireEvent.click(await screen.findByRole('button', { name: 'state' })) // pick category
-    fireEvent.click(await screen.findByText('Redis')) // step 0 -> 1
-    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // step 1 -> 2
-    fireEvent.change(screen.getByLabelText(/^Name\s/i), { target: { value: 'order-store' } })
-    fireEvent.change(screen.getByLabelText('redisHost'), { target: { value: 'localhost:6379' } })
-    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // step 2 -> 3 (Preview)
-    const ta = await screen.findByRole('textbox', { name: /generated yaml/i })
-    await waitFor(() => expect((ta as HTMLTextAreaElement).value).toContain('type: state.redis'))
-    // Edit the YAML — this sets previewEdited=true in the parent
-    fireEvent.change(ta, { target: { value: 'edited: true\n' } })
-    // Go Back (YamlPreview unmounts)
-    fireEvent.click(screen.getByRole('button', { name: /back/i }))
-    // Return to Preview (YamlPreview remounts, mount effect fires onEditedChange(false))
-    fireEvent.click(screen.getByRole('button', { name: /continue/i }))
-    await screen.findByRole('textbox', { name: /generated yaml/i })
-    // Finish should now be enabled (not disabled)
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /finish/i })).not.toBeDisabled()
-    })
-  })
-
   it('walks type → (auth) → configure → preview and shows generated YAML', async () => {
     renderBuilder()
     fireEvent.click(await screen.findByRole('button', { name: 'state' })) // pick category
@@ -53,8 +30,12 @@ describe('ComponentBuilder', () => {
     fireEvent.change(screen.getByLabelText(/^Name\s/i), { target: { value: 'order-store' } })
     fireEvent.change(screen.getByLabelText('redisHost'), { target: { value: 'localhost:6379' } })
     fireEvent.click(screen.getByRole('button', { name: /continue/i })) // step 2 -> 3
-    const ta = await screen.findByRole('textbox', { name: /generated yaml/i })
-    await waitFor(() => expect((ta as HTMLTextAreaElement).value).toContain('type: state.redis'))
-    expect((ta as HTMLTextAreaElement).value).toContain('name: order-store')
+    // after Continue into Preview:
+    // highlighted YAML may be split across spans, so use waitFor on textContent
+    await waitFor(() => expect(document.querySelector('pre.code')?.textContent).toContain('kind: Component'))
+    const pre = document.querySelector('pre.code') as HTMLPreElement
+    expect(pre.textContent).toContain('type: state.redis')
+    expect(pre.textContent).toContain('name: order-store')
+    expect(screen.getByRole('button', { name: /finish/i })).toBeEnabled()
   })
 })

--- a/web/src/pages/component-builder/ComponentBuilder.test.tsx
+++ b/web/src/pages/component-builder/ComponentBuilder.test.tsx
@@ -22,6 +22,28 @@ function renderBuilder() {
 }
 
 describe('ComponentBuilder', () => {
+  it('Finish is re-enabled after Back-from-preview when user had edited YAML', async () => {
+    renderBuilder()
+    fireEvent.click(await screen.findByText('Redis')) // step 0 -> 1
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // step 1 -> 2
+    fireEvent.change(screen.getByLabelText(/^Name\s/i), { target: { value: 'order-store' } })
+    fireEvent.change(screen.getByLabelText('redisHost'), { target: { value: 'localhost:6379' } })
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // step 2 -> 3 (Preview)
+    const ta = await screen.findByRole('textbox', { name: /generated yaml/i })
+    await waitFor(() => expect((ta as HTMLTextAreaElement).value).toContain('type: state.redis'))
+    // Edit the YAML — this sets previewEdited=true in the parent
+    fireEvent.change(ta, { target: { value: 'edited: true\n' } })
+    // Go Back (YamlPreview unmounts)
+    fireEvent.click(screen.getByRole('button', { name: /back/i }))
+    // Return to Preview (YamlPreview remounts, mount effect fires onEditedChange(false))
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }))
+    await screen.findByRole('textbox', { name: /generated yaml/i })
+    // Finish should now be enabled (not disabled)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /finish/i })).not.toBeDisabled()
+    })
+  })
+
   it('walks type → (auth) → configure → preview and shows generated YAML', async () => {
     renderBuilder()
     fireEvent.click(await screen.findByText('Redis')) // step 0 -> 1

--- a/web/src/pages/component-builder/ComponentBuilder.test.tsx
+++ b/web/src/pages/component-builder/ComponentBuilder.test.tsx
@@ -24,6 +24,7 @@ function renderBuilder() {
 describe('ComponentBuilder', () => {
   it('Finish is re-enabled after Back-from-preview when user had edited YAML', async () => {
     renderBuilder()
+    fireEvent.click(await screen.findByRole('button', { name: 'state' })) // pick category
     fireEvent.click(await screen.findByText('Redis')) // step 0 -> 1
     fireEvent.click(screen.getByRole('button', { name: /continue/i })) // step 1 -> 2
     fireEvent.change(screen.getByLabelText(/^Name\s/i), { target: { value: 'order-store' } })
@@ -46,6 +47,7 @@ describe('ComponentBuilder', () => {
 
   it('walks type → (auth) → configure → preview and shows generated YAML', async () => {
     renderBuilder()
+    fireEvent.click(await screen.findByRole('button', { name: 'state' })) // pick category
     fireEvent.click(await screen.findByText('Redis')) // step 0 -> 1
     fireEvent.click(screen.getByRole('button', { name: /continue/i })) // step 1 -> 2 (no profiles)
     fireEvent.change(screen.getByLabelText(/^Name\s/i), { target: { value: 'order-store' } })

--- a/web/src/pages/component-builder/ComponentBuilder.test.tsx
+++ b/web/src/pages/component-builder/ComponentBuilder.test.tsx
@@ -26,7 +26,7 @@ describe('ComponentBuilder', () => {
     renderBuilder()
     fireEvent.click(await screen.findByText('Redis')) // step 0 -> 1
     fireEvent.click(screen.getByRole('button', { name: /continue/i })) // step 1 -> 2 (no profiles)
-    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'order-store' } })
+    fireEvent.change(screen.getByLabelText(/^Name\s/i), { target: { value: 'order-store' } })
     fireEvent.change(screen.getByLabelText('redisHost'), { target: { value: 'localhost:6379' } })
     fireEvent.click(screen.getByRole('button', { name: /continue/i })) // step 2 -> 3
     const ta = await screen.findByRole('textbox', { name: /generated yaml/i })

--- a/web/src/pages/component-builder/ComponentBuilder.tsx
+++ b/web/src/pages/component-builder/ComponentBuilder.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useReducer, useState } from 'react'
+import { useMemo, useReducer } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Wizard, type WizardStep } from '../../components/wizard'
 import { YamlPreview } from '../../components/YamlPreview'
@@ -11,7 +11,6 @@ import { StepConfigure } from './StepConfigure'
 export function ComponentBuilder() {
   const navigate = useNavigate()
   const [state, dispatch] = useReducer(reducer, undefined, initialState)
-  const [previewEdited, setPreviewEdited] = useState(false)
 
   const yaml = useMemo(
     () => (state.activeStep === 3 ? dumpYaml(assembleComponentSpec(state)) : ''),
@@ -22,12 +21,7 @@ export function ComponentBuilder() {
     { label: 'Type', content: <StepType state={state} dispatch={dispatch} /> },
     { label: 'Auth', content: <StepAuth state={state} dispatch={dispatch} /> },
     { label: 'Configure', content: <StepConfigure state={state} dispatch={dispatch} /> },
-    {
-      label: 'Preview',
-      content: (
-        <YamlPreview yaml={yaml} filename={`${state.name || 'component'}.yaml`} onEditedChange={setPreviewEdited} />
-      ),
-    },
+    { label: 'Preview', content: <YamlPreview yaml={yaml} filename={`${state.name || 'component'}.yaml`} /> },
   ]
 
   return (
@@ -39,11 +33,17 @@ export function ComponentBuilder() {
         </div>
         <button type="button" className="btn ghost" onClick={() => navigate('/components')}>Cancel</button>
       </div>
+      {(state.category || state.schema) && (
+        <div className="crumbs" aria-label="Selected component" style={{ marginBottom: 12 }}>
+          {state.category && <span className="typechip">{state.category}</span>}
+          {state.schema && <span className="b">{state.schema.title} · {state.version}</span>}
+        </div>
+      )}
       <div className="card" style={{ padding: 18 }}>
         <Wizard
           steps={steps}
           activeStep={state.activeStep}
-          canContinue={state.activeStep === 3 ? !previewEdited : canContinue(state)}
+          canContinue={canContinue(state)}
           onBack={() => dispatch({ type: 'BACK' })}
           onContinue={() => dispatch({ type: 'NEXT' })}
           onFinish={() => navigate('/components')}

--- a/web/src/pages/component-builder/ComponentBuilder.tsx
+++ b/web/src/pages/component-builder/ComponentBuilder.tsx
@@ -1,0 +1,54 @@
+import { useMemo, useReducer, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Wizard, type WizardStep } from '../../components/wizard'
+import { YamlPreview } from '../../components/YamlPreview'
+import { dumpYaml } from '../../lib/yaml-emit'
+import { initialState, reducer, canContinue, assembleComponentSpec } from './reducer'
+import { StepType } from './StepType'
+import { StepAuth } from './StepAuth'
+import { StepConfigure } from './StepConfigure'
+
+export function ComponentBuilder() {
+  const navigate = useNavigate()
+  const [state, dispatch] = useReducer(reducer, undefined, initialState)
+  const [previewEdited, setPreviewEdited] = useState(false)
+
+  const yaml = useMemo(
+    () => (state.activeStep === 3 ? dumpYaml(assembleComponentSpec(state)) : ''),
+    [state],
+  )
+
+  const steps: WizardStep[] = [
+    { label: 'Type', content: <StepType state={state} dispatch={dispatch} /> },
+    { label: 'Auth', content: <StepAuth state={state} dispatch={dispatch} /> },
+    { label: 'Configure', content: <StepConfigure state={state} dispatch={dispatch} /> },
+    {
+      label: 'Preview',
+      content: (
+        <YamlPreview yaml={yaml} filename={`${state.name || 'component'}.yaml`} onEditedChange={setPreviewEdited} />
+      ),
+    },
+  ]
+
+  return (
+    <div className="page">
+      <div className="phead">
+        <div>
+          <h1>New component</h1>
+          <div className="sub">Build a Dapr component YAML to copy or download</div>
+        </div>
+        <button type="button" className="btn ghost" onClick={() => navigate('/components')}>Cancel</button>
+      </div>
+      <div className="card" style={{ padding: 18 }}>
+        <Wizard
+          steps={steps}
+          activeStep={state.activeStep}
+          canContinue={state.activeStep === 3 ? !previewEdited : canContinue(state)}
+          onBack={() => dispatch({ type: 'BACK' })}
+          onContinue={() => dispatch({ type: 'NEXT' })}
+          onFinish={() => navigate('/components')}
+        />
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/component-builder/StepAuth.test.tsx
+++ b/web/src/pages/component-builder/StepAuth.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { StepAuth } from './StepAuth'
+import { initialState, reducer } from './reducer'
+import type { ComponentMetadataSchema } from '../../types/metadata'
+
+const withProfiles: ComponentMetadataSchema = {
+  type: 'bindings', name: 'aws.s3', version: 'v1', title: 'AWS S3', status: 'stable', metadata: [],
+  authenticationProfiles: [
+    { title: 'AWS IAM', metadata: [{ name: 'accessKey', required: true }] },
+    { title: 'AWS STS', metadata: [{ name: 'sessionToken', required: true }] },
+  ],
+}
+
+function stateWith(schema: ComponentMetadataSchema) {
+  return reducer(initialState(), { type: 'SELECT_SCHEMA', schema, version: 'v1' })
+}
+
+describe('StepAuth', () => {
+  it('shows a no-profiles message when the schema has none', () => {
+    const schema: ComponentMetadataSchema = { type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable', metadata: [] }
+    render(<StepAuth state={stateWith(schema)} dispatch={vi.fn()} />)
+    expect(screen.getByText(/no authentication profiles/i)).toBeInTheDocument()
+  })
+
+  it('dispatches SET_AUTH_PROFILE with the chosen profile', () => {
+    const dispatch = vi.fn()
+    render(<StepAuth state={stateWith(withProfiles)} dispatch={dispatch} />)
+    fireEvent.change(screen.getByLabelText(/authentication profile/i), { target: { value: 'AWS STS' } })
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SET_AUTH_PROFILE', profile: expect.objectContaining({ title: 'AWS STS' }) }),
+    )
+  })
+})

--- a/web/src/pages/component-builder/StepAuth.tsx
+++ b/web/src/pages/component-builder/StepAuth.tsx
@@ -1,0 +1,27 @@
+import { Field, SelectInput } from '../../components/form'
+import type { Action, ComponentBuilderState } from './reducer'
+
+interface Props {
+  state: ComponentBuilderState
+  dispatch: (a: Action) => void
+}
+
+export function StepAuth({ state, dispatch }: Props) {
+  const profiles = state.schema?.authenticationProfiles ?? []
+  if (profiles.length === 0) {
+    return <p className="muted">This component has no authentication profiles — continue.</p>
+  }
+  return (
+    <Field label="Authentication profile" htmlFor="auth-profile">
+      <SelectInput
+        id="auth-profile"
+        aria-label="Authentication profile"
+        value={state.authProfile?.title ?? ''}
+        options={profiles.map((p) => ({ label: p.title, value: p.title }))}
+        onChange={(title) =>
+          dispatch({ type: 'SET_AUTH_PROFILE', profile: profiles.find((p) => p.title === title) })
+        }
+      />
+    </Field>
+  )
+}

--- a/web/src/pages/component-builder/StepConfigure.test.tsx
+++ b/web/src/pages/component-builder/StepConfigure.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { StepConfigure } from './StepConfigure'
+import { initialState, reducer } from './reducer'
+import type { ComponentMetadataSchema } from '../../types/metadata'
+
+const redis: ComponentMetadataSchema = {
+  type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable',
+  metadata: [{ name: 'redisHost', required: true }, { name: 'enableTLS', type: 'bool' }],
+}
+function configureState() {
+  let s = reducer(initialState(), { type: 'SELECT_SCHEMA', schema: redis, version: 'v1' })
+  s = reducer(s, { type: 'NEXT' }) // -> step 2
+  return s
+}
+
+describe('StepConfigure', () => {
+  it('dispatches SET_NAME and shows a validation error for a bad name', () => {
+    const dispatch = vi.fn()
+    render(<StepConfigure state={configureState()} dispatch={dispatch} />)
+    const name = screen.getByLabelText(/^name/i)
+    fireEvent.change(name, { target: { value: 'Bad Name' } })
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NAME', name: 'Bad Name' })
+  })
+
+  it('renders the required field and dispatches SET_VALUE', () => {
+    const dispatch = vi.fn()
+    render(<StepConfigure state={configureState()} dispatch={dispatch} />)
+    fireEvent.change(screen.getByLabelText('redisHost'), { target: { value: 'localhost:6379' } })
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_VALUE', field: 'redisHost', value: 'localhost:6379' })
+  })
+
+  it('toggling "use secret" for a field dispatches TOGGLE_SECRET', () => {
+    const dispatch = vi.fn()
+    render(<StepConfigure state={configureState()} dispatch={dispatch} />)
+    fireEvent.click(screen.getByLabelText(/use secret for redisHost/i))
+    expect(dispatch).toHaveBeenCalledWith({ type: 'TOGGLE_SECRET', field: 'redisHost', on: true })
+  })
+})

--- a/web/src/pages/component-builder/StepConfigure.test.tsx
+++ b/web/src/pages/component-builder/StepConfigure.test.tsx
@@ -18,7 +18,7 @@ describe('StepConfigure', () => {
   it('dispatches SET_NAME and shows a validation error for a bad name', () => {
     const dispatch = vi.fn()
     render(<StepConfigure state={configureState()} dispatch={dispatch} />)
-    const name = screen.getByLabelText(/^name/i)
+    const name = screen.getByLabelText(/^Name\s*\*?$/)
     fireEvent.change(name, { target: { value: 'Bad Name' } })
     expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NAME', name: 'Bad Name' })
   })

--- a/web/src/pages/component-builder/StepConfigure.test.tsx
+++ b/web/src/pages/component-builder/StepConfigure.test.tsx
@@ -37,3 +37,20 @@ describe('StepConfigure', () => {
     expect(dispatch).toHaveBeenCalledWith({ type: 'TOGGLE_SECRET', field: 'redisHost', on: true })
   })
 })
+
+describe('StepConfigure optional field removal', () => {
+  it('shows a remove button for an added optional field and dispatches REMOVE_OPTIONAL', () => {
+    const dispatch = vi.fn()
+    let s = configureState()
+    s = reducer(s, { type: 'ADD_OPTIONAL', field: 'enableTLS' })
+    render(<StepConfigure state={s} dispatch={dispatch} />)
+    const removeBtn = screen.getByRole('button', { name: /remove enableTLS/i })
+    fireEvent.click(removeBtn)
+    expect(dispatch).toHaveBeenCalledWith({ type: 'REMOVE_OPTIONAL', field: 'enableTLS' })
+  })
+
+  it('does not show a remove button for required fields', () => {
+    render(<StepConfigure state={configureState()} dispatch={vi.fn()} />)
+    expect(screen.queryByRole('button', { name: /remove redisHost/i })).not.toBeInTheDocument()
+  })
+})

--- a/web/src/pages/component-builder/StepConfigure.tsx
+++ b/web/src/pages/component-builder/StepConfigure.tsx
@@ -23,7 +23,7 @@ export function StepConfigure({ state, dispatch }: Props) {
       <Field label="Name" htmlFor="c-name" required error={nameError}>
         <TextInput id="c-name" value={state.name} onChange={(v) => dispatch({ type: 'SET_NAME', name: v })} />
       </Field>
-      <Field label="Dapr namespace" htmlFor="c-ns">
+      <Field label="Namespace" htmlFor="c-ns">
         <TextInput id="c-ns" value={state.namespace} onChange={(v) => dispatch({ type: 'SET_NAMESPACE', namespace: v })} />
       </Field>
 
@@ -32,7 +32,7 @@ export function StepConfigure({ state, dispatch }: Props) {
         const useSecret = !!state.useSecret[f.name]
         const ref = state.secretRefs[f.name] ?? { name: '', key: '' }
         return (
-          <Field key={f.name} label={f.name} required={f.required} error={undefined}>
+          <Field key={f.name} label={f.name} required={f.required}>
             {f.description && <div className="muted" style={{ fontSize: 12, marginBottom: 4 }}>{f.description}</div>}
             <Toggle
               label={`Use secret for ${f.name}`}
@@ -57,7 +57,6 @@ export function StepConfigure({ state, dispatch }: Props) {
         <Field label="Add optional field" htmlFor="add-opt">
           <SelectInput
             id="add-opt"
-            aria-label="Add optional field"
             value=""
             options={notAdded.map((f) => ({ label: f.name, value: f.name }))}
             onChange={(field) => field && dispatch({ type: 'ADD_OPTIONAL', field })}

--- a/web/src/pages/component-builder/StepConfigure.tsx
+++ b/web/src/pages/component-builder/StepConfigure.tsx
@@ -31,6 +31,7 @@ export function StepConfigure({ state, dispatch }: Props) {
       {shown.map((f) => {
         const useSecret = !!state.useSecret[f.name]
         const ref = state.secretRefs[f.name] ?? { name: '', key: '' }
+        const removable = !f.required
         return (
           <Field key={f.name} label={f.name} required={f.required}>
             {f.description && <div className="muted" style={{ fontSize: 12, marginBottom: 4 }}>{f.description}</div>}
@@ -39,16 +40,22 @@ export function StepConfigure({ state, dispatch }: Props) {
               checked={useSecret}
               onChange={(on) => dispatch({ type: 'TOGGLE_SECRET', field: f.name, on })}
             />
-            {useSecret ? (
-              <div className="field-row">
-                <TextInput aria-label={`${f.name} secret name`} placeholder="secret name" value={ref.name}
-                  onChange={(v) => dispatch({ type: 'SET_SECRET', field: f.name, ref: { ...ref, name: v } })} />
-                <TextInput aria-label={`${f.name} secret key`} placeholder="secret key" value={ref.key}
-                  onChange={(v) => dispatch({ type: 'SET_SECRET', field: f.name, ref: { ...ref, key: v } })} />
-              </div>
-            ) : (
-              <MetadataFieldInput field={f} value={state.values[f.name] ?? ''} onChange={(v) => dispatch({ type: 'SET_VALUE', field: f.name, value: v })} />
-            )}
+            <div className="field-row">
+              {useSecret ? (
+                <>
+                  <TextInput aria-label={`${f.name} secret name`} placeholder="secret name" value={ref.name}
+                    onChange={(v) => dispatch({ type: 'SET_SECRET', field: f.name, ref: { ...ref, name: v } })} />
+                  <TextInput aria-label={`${f.name} secret key`} placeholder="secret key" value={ref.key}
+                    onChange={(v) => dispatch({ type: 'SET_SECRET', field: f.name, ref: { ...ref, key: v } })} />
+                </>
+              ) : (
+                <MetadataFieldInput field={f} value={state.values[f.name] ?? ''} onChange={(v) => dispatch({ type: 'SET_VALUE', field: f.name, value: v })} />
+              )}
+              {removable && (
+                <button type="button" className="btn ghost" aria-label={`remove ${f.name}`}
+                  onClick={() => dispatch({ type: 'REMOVE_OPTIONAL', field: f.name })}>✕</button>
+              )}
+            </div>
           </Field>
         )
       })}

--- a/web/src/pages/component-builder/StepConfigure.tsx
+++ b/web/src/pages/component-builder/StepConfigure.tsx
@@ -23,7 +23,7 @@ export function StepConfigure({ state, dispatch }: Props) {
       <Field label="Name" htmlFor="c-name" required error={nameError}>
         <TextInput id="c-name" value={state.name} onChange={(v) => dispatch({ type: 'SET_NAME', name: v })} />
       </Field>
-      <Field label="Namespace" htmlFor="c-ns">
+      <Field label="Resource namespace" htmlFor="c-ns">
         <TextInput id="c-ns" value={state.namespace} onChange={(v) => dispatch({ type: 'SET_NAMESPACE', namespace: v })} />
       </Field>
 

--- a/web/src/pages/component-builder/StepConfigure.tsx
+++ b/web/src/pages/component-builder/StepConfigure.tsx
@@ -23,7 +23,7 @@ export function StepConfigure({ state, dispatch }: Props) {
       <Field label="Name" htmlFor="c-name" required error={nameError}>
         <TextInput id="c-name" value={state.name} onChange={(v) => dispatch({ type: 'SET_NAME', name: v })} />
       </Field>
-      <Field label="Resource namespace" htmlFor="c-ns">
+      <Field label="Namespace" htmlFor="c-ns">
         <TextInput id="c-ns" value={state.namespace} onChange={(v) => dispatch({ type: 'SET_NAMESPACE', namespace: v })} />
       </Field>
 

--- a/web/src/pages/component-builder/StepConfigure.tsx
+++ b/web/src/pages/component-builder/StepConfigure.tsx
@@ -1,0 +1,69 @@
+import { Field, TextInput, Toggle, SelectInput } from '../../components/form'
+import { MetadataFieldInput } from '../../components/MetadataFieldInput'
+import { validateResourceName } from '../../lib/validation'
+import { activeFields } from '../../hooks/useComponentSchemas'
+import type { Action, ComponentBuilderState } from './reducer'
+import type { MetadataField } from '../../types/metadata'
+
+interface Props {
+  state: ComponentBuilderState
+  dispatch: (a: Action) => void
+}
+
+export function StepConfigure({ state, dispatch }: Props) {
+  if (!state.schema) return null
+  const { required, optional } = activeFields(state.schema, state.authProfile)
+  const addedOptional = optional.filter((f) => state.optionalAdded.includes(f.name))
+  const shown: MetadataField[] = [...required, ...addedOptional]
+  const notAdded = optional.filter((f) => !state.optionalAdded.includes(f.name))
+  const nameError = state.name === '' ? null : validateResourceName(state.name)
+
+  return (
+    <div>
+      <Field label="Name" htmlFor="c-name" required error={nameError}>
+        <TextInput id="c-name" value={state.name} onChange={(v) => dispatch({ type: 'SET_NAME', name: v })} />
+      </Field>
+      <Field label="Dapr namespace" htmlFor="c-ns">
+        <TextInput id="c-ns" value={state.namespace} onChange={(v) => dispatch({ type: 'SET_NAMESPACE', namespace: v })} />
+      </Field>
+
+      <div className="sec-title">Metadata</div>
+      {shown.map((f) => {
+        const useSecret = !!state.useSecret[f.name]
+        const ref = state.secretRefs[f.name] ?? { name: '', key: '' }
+        return (
+          <Field key={f.name} label={f.name} required={f.required} error={undefined}>
+            {f.description && <div className="muted" style={{ fontSize: 12, marginBottom: 4 }}>{f.description}</div>}
+            <Toggle
+              label={`Use secret for ${f.name}`}
+              checked={useSecret}
+              onChange={(on) => dispatch({ type: 'TOGGLE_SECRET', field: f.name, on })}
+            />
+            {useSecret ? (
+              <div className="field-row">
+                <TextInput aria-label={`${f.name} secret name`} placeholder="secret name" value={ref.name}
+                  onChange={(v) => dispatch({ type: 'SET_SECRET', field: f.name, ref: { ...ref, name: v } })} />
+                <TextInput aria-label={`${f.name} secret key`} placeholder="secret key" value={ref.key}
+                  onChange={(v) => dispatch({ type: 'SET_SECRET', field: f.name, ref: { ...ref, key: v } })} />
+              </div>
+            ) : (
+              <MetadataFieldInput field={f} value={state.values[f.name] ?? ''} onChange={(v) => dispatch({ type: 'SET_VALUE', field: f.name, value: v })} />
+            )}
+          </Field>
+        )
+      })}
+
+      {notAdded.length > 0 && (
+        <Field label="Add optional field" htmlFor="add-opt">
+          <SelectInput
+            id="add-opt"
+            aria-label="Add optional field"
+            value=""
+            options={notAdded.map((f) => ({ label: f.name, value: f.name }))}
+            onChange={(field) => field && dispatch({ type: 'ADD_OPTIONAL', field })}
+          />
+        </Field>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/component-builder/StepType.test.tsx
+++ b/web/src/pages/component-builder/StepType.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../test/setup'
+import { QueryProvider, makeQueryClient } from '../../lib/query'
+import { StepType } from './StepType'
+import { initialState } from './reducer'
+
+const bundle = {
+  schemaVersion: '1', date: '2026-01-01',
+  components: [
+    { type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable', metadata: [] },
+    { type: 'pubsub', name: 'kafka', version: 'v1', title: 'Apache Kafka', status: 'stable', metadata: [] },
+  ],
+}
+
+function renderStep(dispatch = vi.fn()) {
+  server.use(http.get('/api/metadata/components', () => HttpResponse.json(bundle)))
+  return render(
+    <QueryProvider client={makeQueryClient()}>
+      <StepType state={initialState()} dispatch={dispatch} />
+    </QueryProvider>,
+  )
+}
+
+describe('StepType', () => {
+  it('lists schemas and filters by search text', async () => {
+    renderStep()
+    await screen.findByText('Redis')
+    expect(screen.getByText('Apache Kafka')).toBeInTheDocument()
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'kafka' } })
+    expect(screen.queryByText('Redis')).not.toBeInTheDocument()
+    expect(screen.getByText('Apache Kafka')).toBeInTheDocument()
+  })
+
+  it('dispatches SELECT_SCHEMA with schema + version on click', async () => {
+    const dispatch = vi.fn()
+    renderStep(dispatch)
+    fireEvent.click(await screen.findByText('Redis'))
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SELECT_SCHEMA', version: 'v1' }),
+    )
+    expect(dispatch.mock.calls[0][0].schema.name).toBe('redis')
+  })
+})

--- a/web/src/pages/component-builder/StepType.test.tsx
+++ b/web/src/pages/component-builder/StepType.test.tsx
@@ -60,4 +60,18 @@ describe('StepType category filter', () => {
     expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'SELECT_SCHEMA', version: 'v1' }))
     expect(dispatch.mock.calls[dispatch.mock.calls.length - 1]?.[0].schema.name).toBe('redis')
   })
+
+  it('clears the search query when the category changes', async () => {
+    const { rerender } = renderStep(reducer(initialState(), { type: 'SELECT_CATEGORY', category: 'state' }))
+    const box = await screen.findByRole('searchbox')
+    fireEvent.change(box, { target: { value: 'redis' } })
+    expect((box as HTMLInputElement).value).toBe('redis')
+    // switch category via a fresh state prop
+    rerender(
+      <QueryProvider client={makeQueryClient()}>
+        <StepType state={reducer(initialState(), { type: 'SELECT_CATEGORY', category: 'pubsub' })} dispatch={vi.fn()} />
+      </QueryProvider>,
+    )
+    expect((screen.getByRole('searchbox') as HTMLInputElement).value).toBe('')
+  })
 })

--- a/web/src/pages/component-builder/StepType.test.tsx
+++ b/web/src/pages/component-builder/StepType.test.tsx
@@ -4,42 +4,60 @@ import { http, HttpResponse } from 'msw'
 import { server } from '../../test/setup'
 import { QueryProvider, makeQueryClient } from '../../lib/query'
 import { StepType } from './StepType'
-import { initialState } from './reducer'
+import { initialState, reducer } from './reducer'
+import type { ComponentBuilderState } from './reducer'
 
 const bundle = {
   schemaVersion: '1', date: '2026-01-01',
   components: [
     { type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable', metadata: [] },
+    { type: 'state', name: 'postgresql', version: 'v1', title: 'PostgreSQL', status: 'stable', metadata: [] },
     { type: 'pubsub', name: 'kafka', version: 'v1', title: 'Apache Kafka', status: 'stable', metadata: [] },
   ],
 }
 
-function renderStep(dispatch = vi.fn()) {
+function renderStep(state: ComponentBuilderState, dispatch = vi.fn()) {
   server.use(http.get('/api/metadata/components', () => HttpResponse.json(bundle)))
   return render(
     <QueryProvider client={makeQueryClient()}>
-      <StepType state={initialState()} dispatch={dispatch} />
+      <StepType state={state} dispatch={dispatch} />
     </QueryProvider>,
   )
 }
 
-describe('StepType', () => {
-  it('lists schemas and filters by search text', async () => {
-    renderStep()
-    await screen.findByText('Redis')
-    expect(screen.getByText('Apache Kafka')).toBeInTheDocument()
-    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'kafka' } })
+describe('StepType category filter', () => {
+  it('shows category chips and a hint before any category is chosen', async () => {
+    renderStep(initialState())
+    expect(await screen.findByRole('button', { name: 'state' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'pubsub' })).toBeInTheDocument()
+    expect(screen.getByText(/choose a category/i)).toBeInTheDocument()
     expect(screen.queryByText('Redis')).not.toBeInTheDocument()
-    expect(screen.getByText('Apache Kafka')).toBeInTheDocument()
   })
 
-  it('dispatches SELECT_SCHEMA with schema + version on click', async () => {
+  it('clicking a category chip dispatches SELECT_CATEGORY', async () => {
     const dispatch = vi.fn()
-    renderStep(dispatch)
+    renderStep(initialState(), dispatch)
+    fireEvent.click(await screen.findByRole('button', { name: 'state' }))
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SELECT_CATEGORY', category: 'state' })
+  })
+
+  it('with a category selected, lists only that category and scopes search', async () => {
+    const state = reducer(initialState(), { type: 'SELECT_CATEGORY', category: 'state' })
+    renderStep(state)
+    expect(await screen.findByText('Redis')).toBeInTheDocument()
+    expect(screen.getByText('PostgreSQL')).toBeInTheDocument()
+    expect(screen.queryByText('Apache Kafka')).not.toBeInTheDocument()
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'postgres' } })
+    expect(screen.queryByText('Redis')).not.toBeInTheDocument()
+    expect(screen.getByText('PostgreSQL')).toBeInTheDocument()
+  })
+
+  it('clicking a component dispatches SELECT_SCHEMA with its version', async () => {
+    const dispatch = vi.fn()
+    const state = reducer(initialState(), { type: 'SELECT_CATEGORY', category: 'state' })
+    renderStep(state, dispatch)
     fireEvent.click(await screen.findByText('Redis'))
-    expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'SELECT_SCHEMA', version: 'v1' }),
-    )
-    expect(dispatch.mock.calls[0][0].schema.name).toBe('redis')
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'SELECT_SCHEMA', version: 'v1' }))
+    expect(dispatch.mock.calls[dispatch.mock.calls.length - 1]?.[0].schema.name).toBe('redis')
   })
 })

--- a/web/src/pages/component-builder/StepType.tsx
+++ b/web/src/pages/component-builder/StepType.tsx
@@ -13,30 +13,43 @@ export function StepType({ state, dispatch }: Props) {
 
   if (isLoading) return <p className="muted">Loading catalog…</p>
 
+  const categories = Object.keys(byType).sort()
+  const category = state.category
   const query = q.trim().toLowerCase()
-  const types = Object.keys(byType).sort()
 
   return (
     <div>
-      <div className="search" style={{ marginBottom: 12 }}>
-        <input
-          type="search"
-          aria-label="Search components"
-          placeholder="Search components…"
-          value={q}
-          onChange={(e) => setQ(e.target.value)}
-        />
+      <div className="filters" style={{ marginBottom: 12 }}>
+        {categories.map((c) => (
+          <button
+            key={c}
+            type="button"
+            className="lvchip"
+            aria-pressed={category === c}
+            onClick={() => dispatch({ type: 'SELECT_CATEGORY', category: c })}
+          >
+            {c}
+          </button>
+        ))}
       </div>
-      <div className="complist card">
-        {types.map((type) => {
-          const matches = byType[type].filter(
-            (s) => !query || s.title.toLowerCase().includes(query) || s.name.toLowerCase().includes(query),
-          )
-          if (matches.length === 0) return null
-          return (
-            <div key={type} className="sbsection">
-              <div className="sbtitle">{type}</div>
-              {matches.map((s) => {
+
+      {!category ? (
+        <p className="muted">Choose a category to browse components.</p>
+      ) : (
+        <>
+          <div className="search" style={{ marginBottom: 12 }}>
+            <input
+              type="search"
+              aria-label="Search components"
+              placeholder={`Search ${category} components…`}
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+            />
+          </div>
+          <div className="complist card">
+            {(byType[category] ?? [])
+              .filter((s) => !query || s.title.toLowerCase().includes(query) || s.name.toLowerCase().includes(query))
+              .map((s) => {
                 const selected = state.schema?.type === s.type && state.schema?.name === s.name
                 return (
                   <div
@@ -54,10 +67,9 @@ export function StepType({ state, dispatch }: Props) {
                   </div>
                 )
               })}
-            </div>
-          )
-        })}
-      </div>
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/web/src/pages/component-builder/StepType.tsx
+++ b/web/src/pages/component-builder/StepType.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useComponentSchemas } from '../../hooks/useComponentSchemas'
 import type { Action, ComponentBuilderState } from './reducer'
 
@@ -10,6 +10,10 @@ interface Props {
 export function StepType({ state, dispatch }: Props) {
   const { byType, isLoading } = useComponentSchemas()
   const [q, setQ] = useState('')
+
+  useEffect(() => {
+    setQ('')
+  }, [state.category])
 
   if (isLoading) return <p className="muted">Loading catalog…</p>
 

--- a/web/src/pages/component-builder/StepType.tsx
+++ b/web/src/pages/component-builder/StepType.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+import { useComponentSchemas } from '../../hooks/useComponentSchemas'
+import type { Action, ComponentBuilderState } from './reducer'
+
+interface Props {
+  state: ComponentBuilderState
+  dispatch: (a: Action) => void
+}
+
+export function StepType({ state, dispatch }: Props) {
+  const { byType, isLoading } = useComponentSchemas()
+  const [q, setQ] = useState('')
+
+  if (isLoading) return <p className="muted">Loading catalog…</p>
+
+  const query = q.trim().toLowerCase()
+  const types = Object.keys(byType).sort()
+
+  return (
+    <div>
+      <div className="search" style={{ marginBottom: 12 }}>
+        <input
+          type="search"
+          aria-label="Search components"
+          placeholder="Search components…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+      </div>
+      <div className="complist card">
+        {types.map((type) => {
+          const matches = byType[type].filter(
+            (s) => !query || s.title.toLowerCase().includes(query) || s.name.toLowerCase().includes(query),
+          )
+          if (matches.length === 0) return null
+          return (
+            <div key={type} className="sbsection">
+              <div className="sbtitle">{type}</div>
+              {matches.map((s) => {
+                const selected = state.schema?.type === s.type && state.schema?.name === s.name
+                return (
+                  <div
+                    key={`${s.type}.${s.name}`}
+                    className={`ci${selected ? ' sel' : ''}`}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => dispatch({ type: 'SELECT_SCHEMA', schema: s, version: s.version })}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') dispatch({ type: 'SELECT_SCHEMA', schema: s, version: s.version })
+                    }}
+                  >
+                    <span className="cn">{s.title}</span>
+                    <span className="ct">{`${s.type}.${s.name}`} · {s.version} · {s.status}</span>
+                  </div>
+                )
+              })}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/component-builder/reducer.test.ts
+++ b/web/src/pages/component-builder/reducer.test.ts
@@ -112,3 +112,48 @@ describe('assembleComponentSpec', () => {
     expect(spec.spec.metadata).toEqual([{ name: 'port', value: 6379 }, { name: 'tls', value: true }])
   })
 })
+
+describe('SELECT_CATEGORY', () => {
+  const redis = {
+    type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable',
+    metadata: [{ name: 'redisHost', required: true }, { name: 'enableTLS', type: 'bool' as const }],
+  }
+  it('sets the active category', () => {
+    const s = reducer(initialState(), { type: 'SELECT_CATEGORY', category: 'state' })
+    expect(s.category).toBe('state')
+    expect(s.activeStep).toBe(0)
+  })
+  it('SELECT_SCHEMA sets category = schema.type', () => {
+    const s = reducer(initialState(), { type: 'SELECT_SCHEMA', schema: redis, version: 'v1' })
+    expect(s.category).toBe('state')
+  })
+  it('switching to a different category clears schema + config', () => {
+    let s = reducer(initialState(), { type: 'SELECT_SCHEMA', schema: redis, version: 'v1' })
+    s = reducer(s, { type: 'SET_VALUE', field: 'redisHost', value: 'x' })
+    s = reducer(s, { type: 'SELECT_CATEGORY', category: 'pubsub' })
+    expect(s.category).toBe('pubsub')
+    expect(s.schema).toBeUndefined()
+    expect(s.version).toBe('')
+    expect(s.values).toEqual({})
+  })
+  it('re-selecting the same category keeps the schema', () => {
+    let s = reducer(initialState(), { type: 'SELECT_SCHEMA', schema: redis, version: 'v1' })
+    s = reducer(s, { type: 'SELECT_CATEGORY', category: 'state' })
+    expect(s.schema?.name).toBe('redis')
+  })
+})
+
+describe('REMOVE_OPTIONAL clears field state', () => {
+  it('removes the field from optionalAdded and clears its value/secret/useSecret', () => {
+    let s = initialState()
+    s = reducer(s, { type: 'ADD_OPTIONAL', field: 'enableTLS' })
+    s = reducer(s, { type: 'SET_VALUE', field: 'enableTLS', value: 'true' })
+    s = reducer(s, { type: 'TOGGLE_SECRET', field: 'enableTLS', on: true })
+    s = reducer(s, { type: 'SET_SECRET', field: 'enableTLS', ref: { name: 'n', key: 'k' } })
+    s = reducer(s, { type: 'REMOVE_OPTIONAL', field: 'enableTLS' })
+    expect(s.optionalAdded).not.toContain('enableTLS')
+    expect(s.values.enableTLS).toBeUndefined()
+    expect(s.secretRefs.enableTLS).toBeUndefined()
+    expect(s.useSecret.enableTLS).toBeUndefined()
+  })
+})

--- a/web/src/pages/component-builder/reducer.test.ts
+++ b/web/src/pages/component-builder/reducer.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { initialState, reducer, canContinue, assembleComponentSpec } from './reducer'
+import type { ComponentMetadataSchema } from '../../types/metadata'
+
+const redis: ComponentMetadataSchema = {
+  type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable',
+  metadata: [{ name: 'redisHost', required: true }, { name: 'enableTLS', type: 'bool' }],
+}
+
+function withSchema() {
+  return reducer(initialState(), { type: 'SELECT_SCHEMA', schema: redis, version: 'v1' })
+}
+
+describe('reducer / canContinue', () => {
+  it('step 0 requires a schema', () => {
+    expect(canContinue(initialState())).toBe(false)
+    expect(canContinue(withSchema())).toBe(true)
+  })
+
+  it('SELECT_SCHEMA advances to step 1 and detects no auth profiles', () => {
+    const s = withSchema()
+    expect(s.activeStep).toBe(1)
+    expect(s.hasAuthProfiles).toBe(false)
+  })
+
+  it('step 2 requires a valid name and all required fields filled', () => {
+    let s = withSchema()
+    s = reducer(s, { type: 'NEXT' }) // 1 -> 2
+    expect(s.activeStep).toBe(2)
+    expect(canContinue(s)).toBe(false) // no name, redisHost empty
+    s = reducer(s, { type: 'SET_NAME', name: 'order-store' })
+    s = reducer(s, { type: 'SET_VALUE', field: 'redisHost', value: 'localhost:6379' })
+    expect(canContinue(s)).toBe(true)
+  })
+
+  it('a required field satisfied by a secret ref also passes the gate', () => {
+    let s = withSchema()
+    s = reducer(s, { type: 'NEXT' })
+    s = reducer(s, { type: 'SET_NAME', name: 'order-store' })
+    s = reducer(s, { type: 'TOGGLE_SECRET', field: 'redisHost', on: true })
+    s = reducer(s, { type: 'SET_SECRET', field: 'redisHost', ref: { name: 'sec', key: 'host' } })
+    expect(canContinue(s)).toBe(true)
+  })
+})
+
+describe('assembleComponentSpec', () => {
+  it('builds spec.type from type.name and emits only populated metadata keys', () => {
+    let s = withSchema()
+    s = reducer(s, { type: 'NEXT' })
+    s = reducer(s, { type: 'SET_NAME', name: 'order-store' })
+    s = reducer(s, { type: 'SET_VALUE', field: 'redisHost', value: 'localhost:6379' })
+    const spec = assembleComponentSpec(s)
+    expect(spec.spec.type).toBe('state.redis')
+    expect(spec.spec.version).toBe('v1')
+    expect(spec.metadata.name).toBe('order-store')
+    expect(spec.spec.metadata).toEqual([{ name: 'redisHost', value: 'localhost:6379' }])
+  })
+
+  it('emits secretKeyRef (never value) when use-secret is on', () => {
+    let s = withSchema()
+    s = reducer(s, { type: 'NEXT' })
+    s = reducer(s, { type: 'SET_NAME', name: 'order-store' })
+    s = reducer(s, { type: 'TOGGLE_SECRET', field: 'redisHost', on: true })
+    s = reducer(s, { type: 'SET_SECRET', field: 'redisHost', ref: { name: 'sec', key: 'host' } })
+    const spec = assembleComponentSpec(s)
+    expect(spec.spec.metadata).toEqual([{ name: 'redisHost', secretKeyRef: { name: 'sec', key: 'host' } }])
+  })
+
+  it('coerces number and bool field values', () => {
+    const schema: ComponentMetadataSchema = {
+      type: 'state', name: 'x', version: 'v1', title: 'X', status: 'stable',
+      metadata: [{ name: 'port', type: 'number', required: true }, { name: 'tls', type: 'bool', required: true }],
+    }
+    let s = reducer(initialState(), { type: 'SELECT_SCHEMA', schema, version: 'v1' })
+    s = reducer(s, { type: 'NEXT' })
+    s = reducer(s, { type: 'SET_NAME', name: 'x1' })
+    s = reducer(s, { type: 'SET_VALUE', field: 'port', value: '6379' })
+    s = reducer(s, { type: 'SET_VALUE', field: 'tls', value: 'true' })
+    const spec = assembleComponentSpec(s)
+    expect(spec.spec.metadata).toEqual([{ name: 'port', value: 6379 }, { name: 'tls', value: true }])
+  })
+})

--- a/web/src/pages/component-builder/reducer.test.ts
+++ b/web/src/pages/component-builder/reducer.test.ts
@@ -66,6 +66,38 @@ describe('assembleComponentSpec', () => {
     expect(spec.spec.metadata).toEqual([{ name: 'redisHost', secretKeyRef: { name: 'sec', key: 'host' } }])
   })
 
+  it('does not emit secretKeyRef when use-secret is on but name/key are whitespace-only', () => {
+    const schema: ComponentMetadataSchema = {
+      type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable',
+      metadata: [{ name: 'redisHost', required: true }, { name: 'password', required: false }],
+    }
+    let s = reducer(initialState(), { type: 'SELECT_SCHEMA', schema, version: 'v1' })
+    s = reducer(s, { type: 'NEXT' })
+    s = reducer(s, { type: 'SET_NAME', name: 'order-store' })
+    s = reducer(s, { type: 'SET_VALUE', field: 'redisHost', value: 'localhost:6379' })
+    // Optional field with use-secret on but whitespace-only name and key
+    s = reducer(s, { type: 'ADD_OPTIONAL', field: 'password' })
+    s = reducer(s, { type: 'TOGGLE_SECRET', field: 'password', on: true })
+    s = reducer(s, { type: 'SET_SECRET', field: 'password', ref: { name: '  ', key: '  ' } })
+    const spec = assembleComponentSpec(s)
+    // Only redisHost should appear; whitespace-only secret ref must not be emitted
+    expect(spec.spec.metadata).toEqual([{ name: 'redisHost', value: 'localhost:6379' }])
+  })
+
+  it('keeps raw string value when number field contains non-numeric input (NaN guard)', () => {
+    const schema: ComponentMetadataSchema = {
+      type: 'state', name: 'x', version: 'v1', title: 'X', status: 'stable',
+      metadata: [{ name: 'port', type: 'number', required: true }],
+    }
+    let s = reducer(initialState(), { type: 'SELECT_SCHEMA', schema, version: 'v1' })
+    s = reducer(s, { type: 'NEXT' })
+    s = reducer(s, { type: 'SET_NAME', name: 'x1' })
+    s = reducer(s, { type: 'SET_VALUE', field: 'port', value: 'not-a-number' })
+    const spec = assembleComponentSpec(s)
+    // Should keep raw string, not emit NaN
+    expect(spec.spec.metadata).toEqual([{ name: 'port', value: 'not-a-number' }])
+  })
+
   it('coerces number and bool field values', () => {
     const schema: ComponentMetadataSchema = {
       type: 'state', name: 'x', version: 'v1', title: 'X', status: 'stable',

--- a/web/src/pages/component-builder/reducer.ts
+++ b/web/src/pages/component-builder/reducer.ts
@@ -5,6 +5,7 @@ import { activeFields } from '../../hooks/useComponentSchemas'
 
 export interface ComponentBuilderState {
   activeStep: number
+  category?: string
   schema?: ComponentMetadataSchema
   version: string
   authProfile?: AuthenticationProfile
@@ -27,6 +28,7 @@ export type Action =
   | { type: 'SET_SECRET'; field: string; ref: { name: string; key: string } }
   | { type: 'ADD_OPTIONAL'; field: string }
   | { type: 'REMOVE_OPTIONAL'; field: string }
+  | { type: 'SELECT_CATEGORY'; category: string }
   | { type: 'NEXT' }
   | { type: 'BACK' }
 
@@ -48,8 +50,32 @@ export function reducer(state: ComponentBuilderState, action: Action): Component
   switch (action.type) {
     case 'SELECT_SCHEMA': {
       const hasAuthProfiles = (action.schema.authenticationProfiles?.length ?? 0) > 0
-      return { ...state, schema: action.schema, version: action.version, hasAuthProfiles, activeStep: 1 }
+      return {
+        ...state,
+        category: action.schema.type,
+        schema: action.schema,
+        version: action.version,
+        hasAuthProfiles,
+        activeStep: 1,
+      }
     }
+    case 'SELECT_CATEGORY':
+      if (action.category === state.schema?.type) {
+        return { ...state, category: action.category }
+      }
+      // Switching category invalidates the chosen component + its config.
+      return {
+        ...state,
+        category: action.category,
+        schema: undefined,
+        version: '',
+        authProfile: undefined,
+        hasAuthProfiles: false,
+        values: {},
+        secretRefs: {},
+        useSecret: {},
+        optionalAdded: [],
+      }
     case 'SET_AUTH_PROFILE':
       return { ...state, authProfile: action.profile }
     case 'SET_NAME':
@@ -66,8 +92,21 @@ export function reducer(state: ComponentBuilderState, action: Action): Component
       return state.optionalAdded.includes(action.field)
         ? state
         : { ...state, optionalAdded: [...state.optionalAdded, action.field] }
-    case 'REMOVE_OPTIONAL':
-      return { ...state, optionalAdded: state.optionalAdded.filter((f) => f !== action.field) }
+    case 'REMOVE_OPTIONAL': {
+      const values = { ...state.values }
+      const secretRefs = { ...state.secretRefs }
+      const useSecret = { ...state.useSecret }
+      delete values[action.field]
+      delete secretRefs[action.field]
+      delete useSecret[action.field]
+      return {
+        ...state,
+        optionalAdded: state.optionalAdded.filter((f) => f !== action.field),
+        values,
+        secretRefs,
+        useSecret,
+      }
+    }
     case 'NEXT':
       return { ...state, activeStep: state.activeStep + 1 }
     case 'BACK':

--- a/web/src/pages/component-builder/reducer.ts
+++ b/web/src/pages/component-builder/reducer.ts
@@ -120,13 +120,13 @@ export function assembleComponentSpec(state: ComponentBuilderState): ComponentSp
   for (const [name, field] of byName) {
     if (state.useSecret[name]) {
       const ref = state.secretRefs[name]
-      if (ref && ref.name && ref.key) spec.spec.metadata.push({ name, secretKeyRef: ref })
+      if (ref && ref.name.trim() && ref.key.trim()) spec.spec.metadata.push({ name, secretKeyRef: ref })
       continue
     }
     const raw = (state.values[name] ?? '').trim()
     if (raw === '') continue
     let value: string | number | boolean = raw
-    if (field.type === 'number') value = Number(raw)
+    if (field.type === 'number') { const n = Number(raw); value = Number.isNaN(n) ? raw : n }
     else if (field.type === 'bool') value = raw === 'true'
     spec.spec.metadata.push({ name, value })
   }

--- a/web/src/pages/component-builder/reducer.ts
+++ b/web/src/pages/component-builder/reducer.ts
@@ -1,0 +1,134 @@
+import { defaultComponentSpec, type ComponentSpec } from '../../types/component'
+import type { ComponentMetadataSchema, AuthenticationProfile, MetadataField } from '../../types/metadata'
+import { validateResourceName } from '../../lib/validation'
+import { activeFields } from '../../hooks/useComponentSchemas'
+
+export interface ComponentBuilderState {
+  activeStep: number
+  schema?: ComponentMetadataSchema
+  version: string
+  authProfile?: AuthenticationProfile
+  hasAuthProfiles: boolean
+  name: string
+  namespace: string
+  values: Record<string, string>
+  secretRefs: Record<string, { name: string; key: string }>
+  useSecret: Record<string, boolean>
+  optionalAdded: string[]
+}
+
+export type Action =
+  | { type: 'SELECT_SCHEMA'; schema: ComponentMetadataSchema; version: string }
+  | { type: 'SET_AUTH_PROFILE'; profile?: AuthenticationProfile }
+  | { type: 'SET_NAME'; name: string }
+  | { type: 'SET_NAMESPACE'; namespace: string }
+  | { type: 'SET_VALUE'; field: string; value: string }
+  | { type: 'TOGGLE_SECRET'; field: string; on: boolean }
+  | { type: 'SET_SECRET'; field: string; ref: { name: string; key: string } }
+  | { type: 'ADD_OPTIONAL'; field: string }
+  | { type: 'REMOVE_OPTIONAL'; field: string }
+  | { type: 'NEXT' }
+  | { type: 'BACK' }
+
+export function initialState(): ComponentBuilderState {
+  return {
+    activeStep: 0,
+    version: '',
+    hasAuthProfiles: false,
+    name: '',
+    namespace: 'default',
+    values: {},
+    secretRefs: {},
+    useSecret: {},
+    optionalAdded: [],
+  }
+}
+
+export function reducer(state: ComponentBuilderState, action: Action): ComponentBuilderState {
+  switch (action.type) {
+    case 'SELECT_SCHEMA': {
+      const hasAuthProfiles = (action.schema.authenticationProfiles?.length ?? 0) > 0
+      return { ...state, schema: action.schema, version: action.version, hasAuthProfiles, activeStep: 1 }
+    }
+    case 'SET_AUTH_PROFILE':
+      return { ...state, authProfile: action.profile }
+    case 'SET_NAME':
+      return { ...state, name: action.name }
+    case 'SET_NAMESPACE':
+      return { ...state, namespace: action.namespace }
+    case 'SET_VALUE':
+      return { ...state, values: { ...state.values, [action.field]: action.value } }
+    case 'TOGGLE_SECRET':
+      return { ...state, useSecret: { ...state.useSecret, [action.field]: action.on } }
+    case 'SET_SECRET':
+      return { ...state, secretRefs: { ...state.secretRefs, [action.field]: action.ref } }
+    case 'ADD_OPTIONAL':
+      return state.optionalAdded.includes(action.field)
+        ? state
+        : { ...state, optionalAdded: [...state.optionalAdded, action.field] }
+    case 'REMOVE_OPTIONAL':
+      return { ...state, optionalAdded: state.optionalAdded.filter((f) => f !== action.field) }
+    case 'NEXT':
+      return { ...state, activeStep: state.activeStep + 1 }
+    case 'BACK':
+      return { ...state, activeStep: Math.max(0, state.activeStep - 1) }
+    default:
+      return state
+  }
+}
+
+// The fields shown on the Configure step: all required + any optional the user added.
+function configureFields(state: ComponentBuilderState): MetadataField[] {
+  if (!state.schema) return []
+  const { required, optional } = activeFields(state.schema, state.authProfile)
+  const added = optional.filter((f) => state.optionalAdded.includes(f.name))
+  return [...required, ...added]
+}
+
+function fieldSatisfied(state: ComponentBuilderState, f: MetadataField): boolean {
+  if (state.useSecret[f.name]) {
+    const ref = state.secretRefs[f.name]
+    return !!ref && ref.name.trim() !== '' && ref.key.trim() !== ''
+  }
+  return (state.values[f.name] ?? '').trim() !== ''
+}
+
+export function canContinue(state: ComponentBuilderState): boolean {
+  switch (state.activeStep) {
+    case 0:
+      return !!state.schema && state.version !== ''
+    case 1:
+      return true // auth profile optional
+    case 2: {
+      if (validateResourceName(state.name) !== null) return false
+      const required = configureFields(state).filter((f) => f.required)
+      return required.every((f) => fieldSatisfied(state, f))
+    }
+    default:
+      return true
+  }
+}
+
+export function assembleComponentSpec(state: ComponentBuilderState): ComponentSpec {
+  const spec = defaultComponentSpec()
+  spec.metadata.name = state.name
+  if (state.namespace.trim() !== '') spec.metadata.namespace = state.namespace
+  spec.spec.type = state.schema ? `${state.schema.type}.${state.schema.name}` : ''
+  spec.spec.version = state.version
+  const byName = new Map(configureFields(state).map((f) => [f.name, f]))
+  spec.spec.metadata = []
+  for (const [name, field] of byName) {
+    if (state.useSecret[name]) {
+      const ref = state.secretRefs[name]
+      if (ref && ref.name && ref.key) spec.spec.metadata.push({ name, secretKeyRef: ref })
+      continue
+    }
+    const raw = (state.values[name] ?? '').trim()
+    if (raw === '') continue
+    let value: string | number | boolean = raw
+    if (field.type === 'number') value = Number(raw)
+    else if (field.type === 'bool') value = raw === 'true'
+    spec.spec.metadata.push({ name, value })
+  }
+  return spec
+}

--- a/web/src/pages/resiliency-builder/NamedList.tsx
+++ b/web/src/pages/resiliency-builder/NamedList.tsx
@@ -1,0 +1,29 @@
+interface NamedListProps {
+  title: string
+  names: string[]
+  onAdd: () => void
+  onRemove: (name: string) => void
+}
+
+export function NamedList({ title, names, onAdd, onRemove }: NamedListProps) {
+  return (
+    <div className="sbsection">
+      <div className="sech">
+        {title}
+        <button type="button" className="btn ghost" style={{ marginLeft: 'auto' }} aria-label={`Add ${title}`} onClick={onAdd}>
+          + Add
+        </button>
+      </div>
+      {names.length === 0 ? (
+        <p className="none">None yet.</p>
+      ) : (
+        names.map((name) => (
+          <div key={name} className="chip k" style={{ marginRight: 6, marginBottom: 6 }}>
+            <b>{name}</b>
+            <button type="button" className="copybtn" aria-label={`Remove ${name}`} onClick={() => onRemove(name)}>✕</button>
+          </div>
+        ))
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/resiliency-builder/NamedList.tsx
+++ b/web/src/pages/resiliency-builder/NamedList.tsx
@@ -3,9 +3,10 @@ interface NamedListProps {
   names: string[]
   onAdd: () => void
   onRemove: (name: string) => void
+  onEdit?: (name: string) => void
 }
 
-export function NamedList({ title, names, onAdd, onRemove }: NamedListProps) {
+export function NamedList({ title, names, onAdd, onRemove, onEdit }: NamedListProps) {
   return (
     <div className="sbsection">
       <div className="sech">
@@ -19,8 +20,27 @@ export function NamedList({ title, names, onAdd, onRemove }: NamedListProps) {
       ) : (
         names.map((name) => (
           <div key={name} className="chip k" style={{ marginRight: 6, marginBottom: 6 }}>
-            <b>{name}</b>
-            <button type="button" className="copybtn" aria-label={`Remove ${name}`} onClick={() => onRemove(name)}>✕</button>
+            {onEdit ? (
+              <button
+                type="button"
+                className="chip-edit"
+                aria-label={`Edit ${name}`}
+                onClick={() => onEdit(name)}
+                style={{ background: 'none', border: 0, cursor: 'pointer', font: 'inherit', padding: 0 }}
+              >
+                <b>{name}</b>
+              </button>
+            ) : (
+              <b>{name}</b>
+            )}
+            <button
+              type="button"
+              className="copybtn"
+              aria-label={`Remove ${name}`}
+              onClick={(e) => { e.stopPropagation(); onRemove(name) }}
+            >
+              ✕
+            </button>
           </div>
         ))
       )}

--- a/web/src/pages/resiliency-builder/ResiliencyBuilder.test.tsx
+++ b/web/src/pages/resiliency-builder/ResiliencyBuilder.test.tsx
@@ -14,7 +14,7 @@ function renderBuilder() {
 describe('ResiliencyBuilder', () => {
   it('walks general → policies → targets → preview and emits YAML', async () => {
     renderBuilder()
-    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'my-res' } })
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'my-res' } })
     fireEvent.click(screen.getByRole('button', { name: /continue/i })) // 0->1
     fireEvent.click(screen.getByRole('button', { name: /add timeouts/i }))
     fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: '30s' } })

--- a/web/src/pages/resiliency-builder/ResiliencyBuilder.test.tsx
+++ b/web/src/pages/resiliency-builder/ResiliencyBuilder.test.tsx
@@ -28,4 +28,18 @@ describe('ResiliencyBuilder', () => {
     await waitFor(() => expect(document.querySelector('pre.code')?.textContent).toContain('kind: Resiliency'))
     expect(document.querySelector('pre.code')?.textContent).toContain('name: my-res')
   })
+
+  it('finishes with only a DaprBuiltIn override (no explicit target) and emits default namespace', async () => {
+    renderBuilder()
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'my-res' } })
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // 0->1
+    fireEvent.click(screen.getByRole('button', { name: /add DaprBuiltInServiceRetries/i }))
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // 1->2 (policy present)
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // 2->3 (override satisfies gating)
+    await waitFor(() => expect(document.querySelector('pre.code')?.textContent).toContain('kind: Resiliency'))
+    const yaml = document.querySelector('pre.code')?.textContent ?? ''
+    expect(yaml).toContain('namespace: default')
+    expect(yaml).toContain('DaprBuiltInServiceRetries')
+  })
 })

--- a/web/src/pages/resiliency-builder/ResiliencyBuilder.test.tsx
+++ b/web/src/pages/resiliency-builder/ResiliencyBuilder.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import { ResiliencyBuilder } from './ResiliencyBuilder'
+
+function renderBuilder() {
+  const router = createMemoryRouter(
+    [{ path: '/resiliency/new', element: <ResiliencyBuilder /> }, { path: '/resiliency', element: <div>resiliency list</div> }],
+    { initialEntries: ['/resiliency/new'], future: { v7_relativeSplatPath: true } },
+  )
+  return render(<RouterProvider router={router} future={{ v7_startTransition: true }} />)
+}
+
+describe('ResiliencyBuilder', () => {
+  it('walks general → policies → targets → preview and emits YAML', async () => {
+    renderBuilder()
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'my-res' } })
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // 0->1
+    fireEvent.click(screen.getByRole('button', { name: /add timeouts/i }))
+    fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: '30s' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // 1->2
+    fireEvent.click(screen.getByRole('button', { name: /add apps/i }))
+    fireEvent.change(screen.getByLabelText(/app id/i), { target: { value: 'orders' } })
+    fireEvent.change(screen.getByLabelText(/^timeout policy/i), { target: { value: 'timeout1' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    fireEvent.click(screen.getByRole('button', { name: /continue/i })) // 2->3
+    await waitFor(() => expect(document.querySelector('pre.code')?.textContent).toContain('kind: Resiliency'))
+    expect(document.querySelector('pre.code')?.textContent).toContain('name: my-res')
+  })
+})

--- a/web/src/pages/resiliency-builder/ResiliencyBuilder.tsx
+++ b/web/src/pages/resiliency-builder/ResiliencyBuilder.tsx
@@ -1,0 +1,48 @@
+import { useMemo, useReducer } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Wizard, type WizardStep } from '../../components/wizard'
+import { YamlPreview } from '../../components/YamlPreview'
+import { dumpYaml } from '../../lib/yaml-emit'
+import { initialState, reducer, canContinue, assembleResiliency } from './reducer'
+import { StepGeneral } from './StepGeneral'
+import { StepPolicies } from './StepPolicies'
+import { StepTargets } from './StepTargets'
+
+export function ResiliencyBuilder() {
+  const navigate = useNavigate()
+  const [state, dispatch] = useReducer(reducer, undefined, initialState)
+
+  const yaml = useMemo(
+    () => (state.activeStep === 3 ? dumpYaml(assembleResiliency(state.config)) : ''),
+    [state],
+  )
+
+  const steps: WizardStep[] = [
+    { label: 'General', content: <StepGeneral state={state} dispatch={dispatch} /> },
+    { label: 'Policies', content: <StepPolicies state={state} dispatch={dispatch} /> },
+    { label: 'Targets', content: <StepTargets state={state} dispatch={dispatch} /> },
+    { label: 'Preview', content: <YamlPreview yaml={yaml} filename={`${state.config.metadata.name || 'resiliency'}.yaml`} /> },
+  ]
+
+  return (
+    <div className="page">
+      <div className="phead">
+        <div>
+          <h1>New resiliency policy</h1>
+          <div className="sub">Build a Dapr resiliency YAML to copy or download</div>
+        </div>
+        <button type="button" className="btn ghost" onClick={() => navigate('/resiliency')}>Cancel</button>
+      </div>
+      <div className="card" style={{ padding: 18 }}>
+        <Wizard
+          steps={steps}
+          activeStep={state.activeStep}
+          canContinue={canContinue(state)}
+          onBack={() => dispatch({ type: 'BACK' })}
+          onContinue={() => dispatch({ type: 'NEXT' })}
+          onFinish={() => navigate('/resiliency')}
+        />
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/resiliency-builder/StepGeneral.tsx
+++ b/web/src/pages/resiliency-builder/StepGeneral.tsx
@@ -10,8 +10,8 @@ export function StepGeneral({ state, dispatch }: { state: ResiliencyState; dispa
       <Field label="Name" htmlFor="r-name" required error={nameErr}>
         <TextInput id="r-name" aria-label="Name" value={name} onChange={(v) => dispatch({ type: 'SET_NAME', name: v })} />
       </Field>
-      <Field label="Namespace">
-        <TextInput id="r-ns" value={state.config.metadata.namespace ?? ''} onChange={(v) => dispatch({ type: 'SET_NAMESPACE', namespace: v })} />
+      <Field label="Namespace" htmlFor="r-ns">
+        <TextInput id="r-ns" aria-label="Namespace" value={state.config.metadata.namespace ?? ''} onChange={(v) => dispatch({ type: 'SET_NAMESPACE', namespace: v })} />
       </Field>
     </div>
   )

--- a/web/src/pages/resiliency-builder/StepGeneral.tsx
+++ b/web/src/pages/resiliency-builder/StepGeneral.tsx
@@ -1,0 +1,18 @@
+import { Field, TextInput } from '../../components/form'
+import { validateResourceName } from '../../lib/validation'
+import type { Action, ResiliencyState } from './reducer'
+
+export function StepGeneral({ state, dispatch }: { state: ResiliencyState; dispatch: (a: Action) => void }) {
+  const name = state.config.metadata.name
+  const nameErr = name === '' ? null : validateResourceName(name)
+  return (
+    <div>
+      <Field label="Name" htmlFor="r-name" required error={nameErr}>
+        <TextInput id="r-name" aria-label="Name" value={name} onChange={(v) => dispatch({ type: 'SET_NAME', name: v })} />
+      </Field>
+      <Field label="Namespace">
+        <TextInput id="r-ns" value={state.config.metadata.namespace ?? ''} onChange={(v) => dispatch({ type: 'SET_NAMESPACE', namespace: v })} />
+      </Field>
+    </div>
+  )
+}

--- a/web/src/pages/resiliency-builder/StepGeneral.tsx
+++ b/web/src/pages/resiliency-builder/StepGeneral.tsx
@@ -10,6 +10,14 @@ export function StepGeneral({ state, dispatch }: { state: ResiliencyState; dispa
       <Field label="Name" htmlFor="r-name" required error={nameErr}>
         <TextInput id="r-name" aria-label="Name" value={name} onChange={(v) => dispatch({ type: 'SET_NAME', name: v })} />
       </Field>
+      <Field label="Namespace" htmlFor="r-ns">
+        <TextInput
+          id="r-ns"
+          aria-label="Namespace"
+          value={state.config.metadata.namespace ?? ''}
+          onChange={(v) => dispatch({ type: 'SET_NAMESPACE', namespace: v })}
+        />
+      </Field>
     </div>
   )
 }

--- a/web/src/pages/resiliency-builder/StepGeneral.tsx
+++ b/web/src/pages/resiliency-builder/StepGeneral.tsx
@@ -10,9 +10,6 @@ export function StepGeneral({ state, dispatch }: { state: ResiliencyState; dispa
       <Field label="Name" htmlFor="r-name" required error={nameErr}>
         <TextInput id="r-name" aria-label="Name" value={name} onChange={(v) => dispatch({ type: 'SET_NAME', name: v })} />
       </Field>
-      <Field label="Namespace" htmlFor="r-ns">
-        <TextInput id="r-ns" aria-label="Namespace" value={state.config.metadata.namespace ?? ''} onChange={(v) => dispatch({ type: 'SET_NAMESPACE', namespace: v })} />
-      </Field>
     </div>
   )
 }

--- a/web/src/pages/resiliency-builder/StepPolicies.tsx
+++ b/web/src/pages/resiliency-builder/StepPolicies.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+import { NamedList } from './NamedList'
+import { TimeoutDialog, RetryDialog, CircuitBreakerDialog } from './policyDialogs'
+import { nextName, type Action, type ResiliencyState } from './reducer'
+
+type Open = null | 'timeout' | 'retry' | 'cb'
+
+export function StepPolicies({ state, dispatch }: { state: ResiliencyState; dispatch: (a: Action) => void }) {
+  const [open, setOpen] = useState<Open>(null)
+  const pol = state.config.spec.policies
+  return (
+    <div>
+      <NamedList title="Timeouts" names={Object.keys(pol.timeouts)} onAdd={() => setOpen('timeout')} onRemove={(name) => dispatch({ type: 'REMOVE_TIMEOUT', name })} />
+      <NamedList title="Retries" names={Object.keys(pol.retries)} onAdd={() => setOpen('retry')} onRemove={(name) => dispatch({ type: 'REMOVE_RETRY', name })} />
+      <NamedList title="Circuit breakers" names={Object.keys(pol.circuitBreakers)} onAdd={() => setOpen('cb')} onRemove={(name) => dispatch({ type: 'REMOVE_CB', name })} />
+
+      <TimeoutDialog open={open === 'timeout'} initialName={nextName('timeout', pol.timeouts)} onClose={() => setOpen(null)}
+        onSave={(name, duration) => { dispatch({ type: 'UPSERT_TIMEOUT', name, duration }); setOpen(null) }} />
+      <RetryDialog open={open === 'retry'} initialName={nextName('retry', pol.retries)} onClose={() => setOpen(null)}
+        onSave={(name, policy) => { dispatch({ type: 'UPSERT_RETRY', name, policy }); setOpen(null) }} />
+      <CircuitBreakerDialog open={open === 'cb'} initialName={nextName('circuitBreaker', pol.circuitBreakers)} onClose={() => setOpen(null)}
+        onSave={(name, policy) => { dispatch({ type: 'UPSERT_CB', name, policy }); setOpen(null) }} />
+    </div>
+  )
+}

--- a/web/src/pages/resiliency-builder/StepPolicies.tsx
+++ b/web/src/pages/resiliency-builder/StepPolicies.tsx
@@ -14,12 +14,18 @@ export function StepPolicies({ state, dispatch }: { state: ResiliencyState; disp
       <NamedList title="Retries" names={Object.keys(pol.retries)} onAdd={() => setOpen('retry')} onRemove={(name) => dispatch({ type: 'REMOVE_RETRY', name })} />
       <NamedList title="Circuit breakers" names={Object.keys(pol.circuitBreakers)} onAdd={() => setOpen('cb')} onRemove={(name) => dispatch({ type: 'REMOVE_CB', name })} />
 
-      <TimeoutDialog open={open === 'timeout'} initialName={nextName('timeout', pol.timeouts)} onClose={() => setOpen(null)}
-        onSave={(name, duration) => { dispatch({ type: 'UPSERT_TIMEOUT', name, duration }); setOpen(null) }} />
-      <RetryDialog open={open === 'retry'} initialName={nextName('retry', pol.retries)} onClose={() => setOpen(null)}
-        onSave={(name, policy) => { dispatch({ type: 'UPSERT_RETRY', name, policy }); setOpen(null) }} />
-      <CircuitBreakerDialog open={open === 'cb'} initialName={nextName('circuitBreaker', pol.circuitBreakers)} onClose={() => setOpen(null)}
-        onSave={(name, policy) => { dispatch({ type: 'UPSERT_CB', name, policy }); setOpen(null) }} />
+      {open === 'timeout' && (
+        <TimeoutDialog open initialName={nextName('timeout', pol.timeouts)} onClose={() => setOpen(null)}
+          onSave={(name, duration) => { dispatch({ type: 'UPSERT_TIMEOUT', name, duration }); setOpen(null) }} />
+      )}
+      {open === 'retry' && (
+        <RetryDialog open initialName={nextName('retry', pol.retries)} onClose={() => setOpen(null)}
+          onSave={(name, policy) => { dispatch({ type: 'UPSERT_RETRY', name, policy }); setOpen(null) }} />
+      )}
+      {open === 'cb' && (
+        <CircuitBreakerDialog open initialName={nextName('circuitBreaker', pol.circuitBreakers)} onClose={() => setOpen(null)}
+          onSave={(name, policy) => { dispatch({ type: 'UPSERT_CB', name, policy }); setOpen(null) }} />
+      )}
     </div>
   )
 }

--- a/web/src/pages/resiliency-builder/StepPolicies.tsx
+++ b/web/src/pages/resiliency-builder/StepPolicies.tsx
@@ -1,30 +1,93 @@
 import { useState } from 'react'
 import { NamedList } from './NamedList'
 import { TimeoutDialog, RetryDialog, CircuitBreakerDialog } from './policyDialogs'
+import { DEFAULT_DAPR_RETRY_POLICIES, isDefaultPolicyName, presetToRetryPolicy } from './defaultPolicies'
 import { nextName, type Action, type ResiliencyState } from './reducer'
 
-type Open = null | 'timeout' | 'retry' | 'cb'
+type Dialog =
+  | null
+  | { kind: 'timeout' | 'retry' | 'cb'; editName?: string }
+  | { kind: 'override'; label: string; editing: boolean }
 
 export function StepPolicies({ state, dispatch }: { state: ResiliencyState; dispatch: (a: Action) => void }) {
-  const [open, setOpen] = useState<Open>(null)
+  const [open, setOpen] = useState<Dialog>(null)
   const pol = state.config.spec.policies
+  const customRetryNames = Object.keys(pol.retries).filter((n) => !isDefaultPolicyName(n))
+
+  function renameThenUpsert<A extends Action>(editName: string | undefined, name: string, removeType: Action['type'], upsert: A) {
+    if (editName && editName !== name) dispatch({ type: removeType, name: editName } as Action)
+    dispatch(upsert)
+  }
+
   return (
     <div>
-      <NamedList title="Timeouts" names={Object.keys(pol.timeouts)} onAdd={() => setOpen('timeout')} onRemove={(name) => dispatch({ type: 'REMOVE_TIMEOUT', name })} />
-      <NamedList title="Retries" names={Object.keys(pol.retries)} onAdd={() => setOpen('retry')} onRemove={(name) => dispatch({ type: 'REMOVE_RETRY', name })} />
-      <NamedList title="Circuit breakers" names={Object.keys(pol.circuitBreakers)} onAdd={() => setOpen('cb')} onRemove={(name) => dispatch({ type: 'REMOVE_CB', name })} />
+      <NamedList title="Timeouts" names={Object.keys(pol.timeouts)}
+        onAdd={() => setOpen({ kind: 'timeout' })}
+        onEdit={(name) => setOpen({ kind: 'timeout', editName: name })}
+        onRemove={(name) => dispatch({ type: 'REMOVE_TIMEOUT', name })} />
+      <NamedList title="Retries" names={customRetryNames}
+        onAdd={() => setOpen({ kind: 'retry' })}
+        onEdit={(name) => setOpen({ kind: 'retry', editName: name })}
+        onRemove={(name) => dispatch({ type: 'REMOVE_RETRY', name })} />
+      <NamedList title="Circuit breakers" names={Object.keys(pol.circuitBreakers)}
+        onAdd={() => setOpen({ kind: 'cb' })}
+        onEdit={(name) => setOpen({ kind: 'cb', editName: name })}
+        onRemove={(name) => dispatch({ type: 'REMOVE_CB', name })} />
 
-      {open === 'timeout' && (
-        <TimeoutDialog open initialName={nextName('timeout', pol.timeouts)} onClose={() => setOpen(null)}
-          onSave={(name, duration) => { dispatch({ type: 'UPSERT_TIMEOUT', name, duration }); setOpen(null) }} />
+      <div className="sbsection">
+        <div className="sech">Default policy overrides</div>
+        <p className="none" style={{ marginTop: 0 }}>&#9888; These override Dapr's built-in retry behavior globally.</p>
+        {DEFAULT_DAPR_RETRY_POLICIES.map((preset) => {
+          const exists = pol.retries[preset.label] !== undefined
+          return exists ? (
+            <div key={preset.label} className="chip k" style={{ marginRight: 6, marginBottom: 6 }}>
+              <button type="button" aria-label={`Edit ${preset.label}`}
+                onClick={() => setOpen({ kind: 'override', label: preset.label, editing: true })}
+                style={{ background: 'none', border: 0, cursor: 'pointer', font: 'inherit', padding: 0 }}>
+                <b>{preset.label}</b>
+              </button>
+              <button type="button" className="copybtn" aria-label={`Remove ${preset.label}`}
+                onClick={(e) => { e.stopPropagation(); dispatch({ type: 'REMOVE_RETRY', name: preset.label }) }}>&#x2715;</button>
+            </div>
+          ) : (
+            <div key={preset.label} className="sech" style={{ fontWeight: 'normal' }}>
+              {preset.label}
+              <button type="button" className="btn ghost" style={{ marginLeft: 'auto' }}
+                aria-label={`Add ${preset.label}`} onClick={() => setOpen({ kind: 'override', label: preset.label, editing: false })}>
+                + Add
+              </button>
+            </div>
+          )
+        })}
+      </div>
+
+      {open?.kind === 'timeout' && (
+        <TimeoutDialog open editing={!!open.editName}
+          initialName={open.editName ?? nextName('timeout', pol.timeouts)}
+          initialDuration={open.editName ? pol.timeouts[open.editName] : undefined}
+          onClose={() => setOpen(null)}
+          onSave={(name, duration) => { renameThenUpsert(open.editName, name, 'REMOVE_TIMEOUT', { type: 'UPSERT_TIMEOUT', name, duration }); setOpen(null) }} />
       )}
-      {open === 'retry' && (
-        <RetryDialog open initialName={nextName('retry', pol.retries)} onClose={() => setOpen(null)}
-          onSave={(name, policy) => { dispatch({ type: 'UPSERT_RETRY', name, policy }); setOpen(null) }} />
+      {open?.kind === 'retry' && (
+        <RetryDialog open editing={!!open.editName}
+          initialName={open.editName ?? nextName('retry', pol.retries)}
+          initialPolicy={open.editName ? pol.retries[open.editName] : undefined}
+          onClose={() => setOpen(null)}
+          onSave={(name, policy) => { renameThenUpsert(open.editName, name, 'REMOVE_RETRY', { type: 'UPSERT_RETRY', name, policy }); setOpen(null) }} />
       )}
-      {open === 'cb' && (
-        <CircuitBreakerDialog open initialName={nextName('circuitBreaker', pol.circuitBreakers)} onClose={() => setOpen(null)}
-          onSave={(name, policy) => { dispatch({ type: 'UPSERT_CB', name, policy }); setOpen(null) }} />
+      {open?.kind === 'cb' && (
+        <CircuitBreakerDialog open editing={!!open.editName}
+          initialName={open.editName ?? nextName('circuitBreaker', pol.circuitBreakers)}
+          initialPolicy={open.editName ? pol.circuitBreakers[open.editName] : undefined}
+          onClose={() => setOpen(null)}
+          onSave={(name, policy) => { renameThenUpsert(open.editName, name, 'REMOVE_CB', { type: 'UPSERT_CB', name, policy }); setOpen(null) }} />
+      )}
+      {open?.kind === 'override' && (
+        <RetryDialog open lockName keepDurationForExponential editing={open.editing}
+          initialName={open.label}
+          initialPolicy={open.editing ? pol.retries[open.label] : presetToRetryPolicy(DEFAULT_DAPR_RETRY_POLICIES.find((p) => p.label === open.label)!)}
+          onClose={() => setOpen(null)}
+          onSave={(_name, policy) => { dispatch({ type: 'UPSERT_RETRY', name: open.label, policy }); setOpen(null) }} />
       )}
     </div>
   )

--- a/web/src/pages/resiliency-builder/StepTargets.tsx
+++ b/web/src/pages/resiliency-builder/StepTargets.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import { NamedList } from './NamedList'
+import { AppTargetDialog, ActorTargetDialog, ComponentTargetDialog, type PolicyNames } from './targetDialogs'
+import { type Action, type ResiliencyState } from './reducer'
+
+type Open = null | 'app' | 'actor' | 'component'
+
+export function StepTargets({ state, dispatch }: { state: ResiliencyState; dispatch: (a: Action) => void }) {
+  const [open, setOpen] = useState<Open>(null)
+  const { policies, targets } = state.config.spec
+  const names: PolicyNames = {
+    timeouts: Object.keys(policies.timeouts),
+    retries: Object.keys(policies.retries),
+    circuitBreakers: Object.keys(policies.circuitBreakers),
+  }
+  return (
+    <div>
+      <NamedList title="Apps" names={Object.keys(targets.apps ?? {})} onAdd={() => setOpen('app')} onRemove={(name) => dispatch({ type: 'REMOVE_APP', name })} />
+      <NamedList title="Actors" names={Object.keys(targets.actors ?? {})} onAdd={() => setOpen('actor')} onRemove={(name) => dispatch({ type: 'REMOVE_ACTOR', name })} />
+      <NamedList title="Components" names={Object.keys(targets.components ?? {})} onAdd={() => setOpen('component')} onRemove={(name) => dispatch({ type: 'REMOVE_COMPONENT', name })} />
+
+      <AppTargetDialog open={open === 'app'} policies={names} onClose={() => setOpen(null)}
+        onSave={(name, target) => { dispatch({ type: 'UPSERT_APP', name, target }); setOpen(null) }} />
+      <ActorTargetDialog open={open === 'actor'} policies={names} onClose={() => setOpen(null)}
+        onSave={(name, target) => { dispatch({ type: 'UPSERT_ACTOR', name, target }); setOpen(null) }} />
+      <ComponentTargetDialog open={open === 'component'} policies={names} onClose={() => setOpen(null)}
+        onSave={(name, target) => { dispatch({ type: 'UPSERT_COMPONENT', name, target }); setOpen(null) }} />
+    </div>
+  )
+}

--- a/web/src/pages/resiliency-builder/StepTargets.tsx
+++ b/web/src/pages/resiliency-builder/StepTargets.tsx
@@ -19,12 +19,18 @@ export function StepTargets({ state, dispatch }: { state: ResiliencyState; dispa
       <NamedList title="Actors" names={Object.keys(targets.actors ?? {})} onAdd={() => setOpen('actor')} onRemove={(name) => dispatch({ type: 'REMOVE_ACTOR', name })} />
       <NamedList title="Components" names={Object.keys(targets.components ?? {})} onAdd={() => setOpen('component')} onRemove={(name) => dispatch({ type: 'REMOVE_COMPONENT', name })} />
 
-      <AppTargetDialog open={open === 'app'} policies={names} onClose={() => setOpen(null)}
-        onSave={(name, target) => { dispatch({ type: 'UPSERT_APP', name, target }); setOpen(null) }} />
-      <ActorTargetDialog open={open === 'actor'} policies={names} onClose={() => setOpen(null)}
-        onSave={(name, target) => { dispatch({ type: 'UPSERT_ACTOR', name, target }); setOpen(null) }} />
-      <ComponentTargetDialog open={open === 'component'} policies={names} onClose={() => setOpen(null)}
-        onSave={(name, target) => { dispatch({ type: 'UPSERT_COMPONENT', name, target }); setOpen(null) }} />
+      {open === 'app' && (
+        <AppTargetDialog open policies={names} onClose={() => setOpen(null)}
+          onSave={(name, target) => { dispatch({ type: 'UPSERT_APP', name, target }); setOpen(null) }} />
+      )}
+      {open === 'actor' && (
+        <ActorTargetDialog open policies={names} onClose={() => setOpen(null)}
+          onSave={(name, target) => { dispatch({ type: 'UPSERT_ACTOR', name, target }); setOpen(null) }} />
+      )}
+      {open === 'component' && (
+        <ComponentTargetDialog open policies={names} onClose={() => setOpen(null)}
+          onSave={(name, target) => { dispatch({ type: 'UPSERT_COMPONENT', name, target }); setOpen(null) }} />
+      )}
     </div>
   )
 }

--- a/web/src/pages/resiliency-builder/StepTargets.tsx
+++ b/web/src/pages/resiliency-builder/StepTargets.tsx
@@ -3,33 +3,52 @@ import { NamedList } from './NamedList'
 import { AppTargetDialog, ActorTargetDialog, ComponentTargetDialog, type PolicyNames } from './targetDialogs'
 import { type Action, type ResiliencyState } from './reducer'
 
-type Open = null | 'app' | 'actor' | 'component'
+type Dialog = null | { kind: 'app' | 'actor' | 'component'; editName?: string }
 
 export function StepTargets({ state, dispatch }: { state: ResiliencyState; dispatch: (a: Action) => void }) {
-  const [open, setOpen] = useState<Open>(null)
+  const [open, setOpen] = useState<Dialog>(null)
   const { policies, targets } = state.config.spec
   const names: PolicyNames = {
     timeouts: Object.keys(policies.timeouts),
     retries: Object.keys(policies.retries),
     circuitBreakers: Object.keys(policies.circuitBreakers),
   }
+  const apps = targets.apps ?? {}
+  const actors = targets.actors ?? {}
+  const components = targets.components ?? {}
+
   return (
     <div>
-      <NamedList title="Apps" names={Object.keys(targets.apps ?? {})} onAdd={() => setOpen('app')} onRemove={(name) => dispatch({ type: 'REMOVE_APP', name })} />
-      <NamedList title="Actors" names={Object.keys(targets.actors ?? {})} onAdd={() => setOpen('actor')} onRemove={(name) => dispatch({ type: 'REMOVE_ACTOR', name })} />
-      <NamedList title="Components" names={Object.keys(targets.components ?? {})} onAdd={() => setOpen('component')} onRemove={(name) => dispatch({ type: 'REMOVE_COMPONENT', name })} />
+      <NamedList title="Apps" names={Object.keys(apps)}
+        onAdd={() => setOpen({ kind: 'app' })}
+        onEdit={(name) => setOpen({ kind: 'app', editName: name })}
+        onRemove={(name) => dispatch({ type: 'REMOVE_APP', name })} />
+      <NamedList title="Actors" names={Object.keys(actors)}
+        onAdd={() => setOpen({ kind: 'actor' })}
+        onEdit={(name) => setOpen({ kind: 'actor', editName: name })}
+        onRemove={(name) => dispatch({ type: 'REMOVE_ACTOR', name })} />
+      <NamedList title="Components" names={Object.keys(components)}
+        onAdd={() => setOpen({ kind: 'component' })}
+        onEdit={(name) => setOpen({ kind: 'component', editName: name })}
+        onRemove={(name) => dispatch({ type: 'REMOVE_COMPONENT', name })} />
 
-      {open === 'app' && (
-        <AppTargetDialog open policies={names} onClose={() => setOpen(null)}
-          onSave={(name, target) => { dispatch({ type: 'UPSERT_APP', name, target }); setOpen(null) }} />
+      {open?.kind === 'app' && (
+        <AppTargetDialog open policies={names} editing={!!open.editName}
+          initialName={open.editName} initialTarget={open.editName ? apps[open.editName] : undefined}
+          onClose={() => setOpen(null)}
+          onSave={(name, target) => { if (open.editName && open.editName !== name) dispatch({ type: 'REMOVE_APP', name: open.editName }); dispatch({ type: 'UPSERT_APP', name, target }); setOpen(null) }} />
       )}
-      {open === 'actor' && (
-        <ActorTargetDialog open policies={names} onClose={() => setOpen(null)}
-          onSave={(name, target) => { dispatch({ type: 'UPSERT_ACTOR', name, target }); setOpen(null) }} />
+      {open?.kind === 'actor' && (
+        <ActorTargetDialog open policies={names} editing={!!open.editName}
+          initialName={open.editName} initialTarget={open.editName ? actors[open.editName] : undefined}
+          onClose={() => setOpen(null)}
+          onSave={(name, target) => { if (open.editName && open.editName !== name) dispatch({ type: 'REMOVE_ACTOR', name: open.editName }); dispatch({ type: 'UPSERT_ACTOR', name, target }); setOpen(null) }} />
       )}
-      {open === 'component' && (
-        <ComponentTargetDialog open policies={names} onClose={() => setOpen(null)}
-          onSave={(name, target) => { dispatch({ type: 'UPSERT_COMPONENT', name, target }); setOpen(null) }} />
+      {open?.kind === 'component' && (
+        <ComponentTargetDialog open policies={names} editing={!!open.editName}
+          initialName={open.editName} initialTarget={open.editName ? components[open.editName] : undefined}
+          onClose={() => setOpen(null)}
+          onSave={(name, target) => { if (open.editName && open.editName !== name) dispatch({ type: 'REMOVE_COMPONENT', name: open.editName }); dispatch({ type: 'UPSERT_COMPONENT', name, target }); setOpen(null) }} />
       )}
     </div>
   )

--- a/web/src/pages/resiliency-builder/defaultPolicies.test.ts
+++ b/web/src/pages/resiliency-builder/defaultPolicies.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { DEFAULT_DAPR_RETRY_POLICIES, isDefaultPolicyName, presetToRetryPolicy } from './defaultPolicies'
+
+describe('DEFAULT_DAPR_RETRY_POLICIES', () => {
+  it('has the four Dapr built-in retry policies with documented defaults', () => {
+    expect(DEFAULT_DAPR_RETRY_POLICIES).toHaveLength(4)
+    const service = DEFAULT_DAPR_RETRY_POLICIES.find((p) => p.label === 'DaprBuiltInServiceRetries')
+    expect(service).toEqual({ label: 'DaprBuiltInServiceRetries', policy: 'constant', duration: '1s', maxInterval: '', maxRetries: 3 })
+    const reminder = DEFAULT_DAPR_RETRY_POLICIES.find((p) => p.label === 'DaprBuiltInActorReminderRetries')
+    expect(reminder).toEqual({ label: 'DaprBuiltInActorReminderRetries', policy: 'exponential', duration: '15m', maxInterval: '60s', maxRetries: 3 })
+  })
+})
+
+describe('isDefaultPolicyName', () => {
+  it('matches only DaprBuiltIn* names', () => {
+    expect(isDefaultPolicyName('DaprBuiltInServiceRetries')).toBe(true)
+    expect(isDefaultPolicyName('retry1')).toBe(false)
+  })
+})
+
+describe('presetToRetryPolicy', () => {
+  it('carries duration + maxInterval for exponential presets', () => {
+    const reminder = DEFAULT_DAPR_RETRY_POLICIES.find((p) => p.label === 'DaprBuiltInActorReminderRetries')!
+    expect(presetToRetryPolicy(reminder)).toEqual({ policy: 'exponential', duration: '15m', maxInterval: '60s', maxRetries: 3 })
+  })
+  it('drops empty maxInterval for constant presets', () => {
+    const service = DEFAULT_DAPR_RETRY_POLICIES.find((p) => p.label === 'DaprBuiltInServiceRetries')!
+    expect(presetToRetryPolicy(service)).toEqual({ policy: 'constant', duration: '1s', maxInterval: undefined, maxRetries: 3 })
+  })
+})

--- a/web/src/pages/resiliency-builder/defaultPolicies.ts
+++ b/web/src/pages/resiliency-builder/defaultPolicies.ts
@@ -1,0 +1,32 @@
+import type { RetryPolicy } from '../../types/resiliency'
+
+export interface DefaultPolicyPreset {
+  label: string
+  policy: 'constant' | 'exponential'
+  duration: string
+  maxInterval: string
+  maxRetries: number
+}
+
+/** The four reserved Dapr built-in retry policies (mirrors cloudgrid DEFAULT_DAPR_RETRY_POLICIES). */
+export const DEFAULT_DAPR_RETRY_POLICIES: DefaultPolicyPreset[] = [
+  { label: 'DaprBuiltInServiceRetries', policy: 'constant', duration: '1s', maxInterval: '', maxRetries: 3 },
+  { label: 'DaprBuiltInActorRetries', policy: 'constant', duration: '1s', maxInterval: '', maxRetries: 3 },
+  { label: 'DaprBuiltInActorReminderRetries', policy: 'exponential', duration: '15m', maxInterval: '60s', maxRetries: 3 },
+  { label: 'DaprBuiltInInitializationRetries', policy: 'exponential', duration: '10s', maxInterval: '500ms', maxRetries: 3 },
+]
+
+/** True for the reserved built-in override keys (they live only in the overrides section). */
+export function isDefaultPolicyName(name: string): boolean {
+  return name.startsWith('DaprBuiltIn')
+}
+
+/** Convert a preset to a RetryPolicy; empty maxInterval becomes undefined so it isn't emitted for constant. */
+export function presetToRetryPolicy(p: DefaultPolicyPreset): RetryPolicy {
+  return {
+    policy: p.policy,
+    duration: p.duration,
+    maxInterval: p.maxInterval || undefined,
+    maxRetries: p.maxRetries,
+  }
+}

--- a/web/src/pages/resiliency-builder/policyDialogs.test.tsx
+++ b/web/src/pages/resiliency-builder/policyDialogs.test.tsx
@@ -12,6 +12,16 @@ describe('NamedList', () => {
     fireEvent.click(screen.getByRole('button', { name: /remove timeout1/i }))
     expect(onRemove).toHaveBeenCalledWith('timeout1')
   })
+  it('fires onEdit from the chip body and not on remove', () => {
+    const onEdit = vi.fn(); const onRemove = vi.fn()
+    render(<NamedList title="Timeouts" names={['timeout1']} onAdd={vi.fn()} onRemove={onRemove} onEdit={onEdit} />)
+    fireEvent.click(screen.getByRole('button', { name: /edit timeout1/i }))
+    expect(onEdit).toHaveBeenCalledWith('timeout1')
+    expect(onRemove).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: /remove timeout1/i }))
+    expect(onRemove).toHaveBeenCalledWith('timeout1')
+    expect(onEdit).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('TimeoutDialog', () => {

--- a/web/src/pages/resiliency-builder/policyDialogs.test.tsx
+++ b/web/src/pages/resiliency-builder/policyDialogs.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { NamedList, TimeoutDialog, RetryDialog } from './policyDialogs'
+
+describe('NamedList', () => {
+  it('renders names, add, and remove', () => {
+    const onAdd = vi.fn(); const onRemove = vi.fn()
+    render(<NamedList title="Timeouts" names={['timeout1']} onAdd={onAdd} onRemove={onRemove} />)
+    expect(screen.getByText('timeout1')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /add timeouts/i }))
+    expect(onAdd).toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: /remove timeout1/i }))
+    expect(onRemove).toHaveBeenCalledWith('timeout1')
+  })
+})
+
+describe('TimeoutDialog', () => {
+  it('saves a valid name + duration and blocks invalid duration', () => {
+    const onSave = vi.fn(); const onClose = vi.fn()
+    render(<TimeoutDialog open initialName="timeout1" onClose={onClose} onSave={onSave} />)
+    const confirm = screen.getByRole('button', { name: /save/i })
+    fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: 'nope' } })
+    expect(confirm).toBeDisabled()
+    fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: '30s' } })
+    expect(confirm).toBeEnabled()
+    fireEvent.click(confirm)
+    expect(onSave).toHaveBeenCalledWith('timeout1', '30s')
+  })
+})
+
+describe('RetryDialog', () => {
+  it('saves a constant retry policy', () => {
+    const onSave = vi.fn()
+    render(<RetryDialog open initialName="retry1" onClose={vi.fn()} onSave={onSave} />)
+    fireEvent.change(screen.getByLabelText(/^duration/i), { target: { value: '5s' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(onSave).toHaveBeenCalledWith('retry1', expect.objectContaining({ policy: 'constant', duration: '5s' }))
+  })
+})

--- a/web/src/pages/resiliency-builder/policyDialogs.test.tsx
+++ b/web/src/pages/resiliency-builder/policyDialogs.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
-import { NamedList, TimeoutDialog, RetryDialog } from './policyDialogs'
+import { NamedList, TimeoutDialog, RetryDialog, CircuitBreakerDialog } from './policyDialogs'
 
 describe('NamedList', () => {
   it('renders names, add, and remove', () => {
@@ -45,5 +45,49 @@ describe('RetryDialog', () => {
     fireEvent.change(screen.getByLabelText(/^duration/i), { target: { value: '5s' } })
     fireEvent.click(screen.getByRole('button', { name: /save/i }))
     expect(onSave).toHaveBeenCalledWith('retry1', expect.objectContaining({ policy: 'constant', duration: '5s' }))
+  })
+})
+
+describe('TimeoutDialog defaults + edit', () => {
+  it('prefills 5s on add', () => {
+    render(<TimeoutDialog open initialName="timeout1" onClose={vi.fn()} onSave={vi.fn()} />)
+    expect((screen.getByLabelText(/duration/i) as HTMLInputElement).value).toBe('5s')
+  })
+  it('prefills the existing duration and title on edit', () => {
+    const onSave = vi.fn()
+    render(<TimeoutDialog open editing initialName="timeout1" initialDuration="42s" onClose={vi.fn()} onSave={onSave} />)
+    expect(screen.getByText(/edit timeout policy/i)).toBeInTheDocument()
+    expect((screen.getByLabelText(/duration/i) as HTMLInputElement).value).toBe('42s')
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(onSave).toHaveBeenCalledWith('timeout1', '42s')
+  })
+})
+
+describe('CircuitBreakerDialog defaults', () => {
+  it('prefills canonical defaults as real text', () => {
+    render(<CircuitBreakerDialog open initialName="circuitBreaker1" onClose={vi.fn()} onSave={vi.fn()} />)
+    expect((screen.getByLabelText(/max requests/i) as HTMLInputElement).value).toBe('1')
+    expect((screen.getByLabelText(/^timeout/i) as HTMLInputElement).value).toBe('45s')
+    expect((screen.getByLabelText(/trip/i) as HTMLInputElement).value).toBe('consecutiveFailures >= 5')
+    expect((screen.getByLabelText(/interval/i) as HTMLInputElement).value).toBe('8s')
+  })
+})
+
+describe('RetryDialog edit + lock + keep-duration', () => {
+  it('locks the name when lockName is set', () => {
+    render(<RetryDialog open initialName="DaprBuiltInServiceRetries" lockName onClose={vi.fn()} onSave={vi.fn()} />)
+    expect(screen.queryByLabelText(/retry name/i)).not.toBeInTheDocument()
+    expect(screen.getByText('DaprBuiltInServiceRetries')).toBeInTheDocument()
+  })
+  it('keeps duration for an exponential override on save', () => {
+    const onSave = vi.fn()
+    render(
+      <RetryDialog open editing lockName keepDurationForExponential
+        initialName="DaprBuiltInActorReminderRetries"
+        initialPolicy={{ policy: 'exponential', duration: '15m', maxInterval: '60s', maxRetries: 3 }}
+        onClose={vi.fn()} onSave={onSave} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(onSave).toHaveBeenCalledWith('DaprBuiltInActorReminderRetries', expect.objectContaining({ policy: 'exponential', duration: '15m', maxInterval: '60s', maxRetries: 3 }))
   })
 })

--- a/web/src/pages/resiliency-builder/policyDialogs.tsx
+++ b/web/src/pages/resiliency-builder/policyDialogs.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react'
+import { Modal } from '../../components/Modal'
+import { Field, TextInput, NumberInput, SelectInput } from '../../components/form'
+import { validateResourceName, validateGoDuration, validateStatusCodes, integerError } from '../../lib/validation'
+import type { RetryPolicy, CircuitBreakerPolicy } from '../../types/resiliency'
+export { NamedList } from './NamedList'
+
+function DialogShell({ open, title, onClose, onSave, canSave, children }: {
+  open: boolean; title: string; onClose: () => void; onSave: () => void; canSave: boolean; children: React.ReactNode
+}) {
+  return (
+    <Modal open={open} title={title} onClose={onClose}>
+      {children}
+      <div className="modal-actions">
+        <button type="button" className="btn ghost" onClick={onClose}>Cancel</button>
+        <button type="button" className="btn ghost" disabled={!canSave} onClick={onSave}>Save</button>
+      </div>
+    </Modal>
+  )
+}
+
+export function TimeoutDialog({ open, initialName, onClose, onSave }: {
+  open: boolean; initialName: string; onClose: () => void; onSave: (name: string, duration: string) => void
+}) {
+  const [name, setName] = useState(initialName)
+  const [duration, setDuration] = useState('')
+  const nameErr = name === '' ? 'Name is required' : validateResourceName(name)
+  const durOk = duration !== '' && validateGoDuration(duration).valid
+  return (
+    <DialogShell open={open} title="Add timeout policy" onClose={onClose} canSave={!nameErr && durOk}
+      onSave={() => onSave(name, duration)}>
+      <Field label="Name" required error={name === '' ? null : nameErr}>
+        <TextInput aria-label="Timeout name" value={name} onChange={setName} />
+      </Field>
+      <Field label="Duration" required error={duration === '' ? null : (durOk ? null : validateGoDuration(duration).error)}>
+        <TextInput aria-label="Duration" placeholder="30s" value={duration} onChange={setDuration} />
+      </Field>
+    </DialogShell>
+  )
+}
+
+export function RetryDialog({ open, initialName, onClose, onSave }: {
+  open: boolean; initialName: string; onClose: () => void; onSave: (name: string, policy: RetryPolicy) => void
+}) {
+  const [name, setName] = useState(initialName)
+  const [policy, setPolicy] = useState<'constant' | 'exponential'>('constant')
+  const [duration, setDuration] = useState('5s')
+  const [maxInterval, setMaxInterval] = useState('60s')
+  const [maxRetries, setMaxRetries] = useState('-1')
+  const [http, setHttp] = useState('')
+  const [grpc, setGrpc] = useState('')
+  const nameErr = name === '' ? 'Name is required' : validateResourceName(name)
+  const durField = policy === 'constant' ? duration : maxInterval
+  const durOk = validateGoDuration(durField).valid
+  const numOk = integerError(maxRetries) === null
+  const codesOk = validateStatusCodes(http) === null && validateStatusCodes(grpc) === null
+  const canSave = !nameErr && durOk && numOk && codesOk
+  function save() {
+    const p: RetryPolicy = {
+      policy,
+      maxRetries: maxRetries === '' ? undefined : Number(maxRetries),
+      matching: { httpStatusCodes: http, grpcStatusCodes: grpc },
+    }
+    if (policy === 'constant') p.duration = duration
+    else p.maxInterval = maxInterval
+    onSave(name, p)
+  }
+  return (
+    <DialogShell open={open} title="Add retry policy" onClose={onClose} canSave={canSave} onSave={save}>
+      <Field label="Name" required error={name === '' ? null : nameErr}>
+        <TextInput aria-label="Retry name" value={name} onChange={setName} />
+      </Field>
+      <Field label="Policy" required>
+        <SelectInput aria-label="Retry policy type" value={policy}
+          options={[{ label: 'constant', value: 'constant' }, { label: 'exponential', value: 'exponential' }]}
+          onChange={(v) => setPolicy(v === 'exponential' ? 'exponential' : 'constant')} />
+      </Field>
+      {policy === 'constant' ? (
+        <Field label="Duration" required error={durOk ? null : validateGoDuration(duration).error}>
+          <TextInput aria-label="Duration" placeholder="5s" value={duration} onChange={setDuration} />
+        </Field>
+      ) : (
+        <Field label="Max interval" required error={durOk ? null : validateGoDuration(maxInterval).error}>
+          <TextInput aria-label="Max interval" placeholder="60s" value={maxInterval} onChange={setMaxInterval} />
+        </Field>
+      )}
+      <Field label="Max retries" error={numOk ? null : 'Must be an integer'}>
+        <NumberInput aria-label="Max retries" value={maxRetries} onChange={setMaxRetries} />
+      </Field>
+      <Field label="HTTP status codes" error={validateStatusCodes(http)}>
+        <TextInput aria-label="HTTP status codes" placeholder="429,500-504" value={http} onChange={setHttp} />
+      </Field>
+      <Field label="gRPC status codes" error={validateStatusCodes(grpc)}>
+        <TextInput aria-label="gRPC status codes" placeholder="4,8,14" value={grpc} onChange={setGrpc} />
+      </Field>
+    </DialogShell>
+  )
+}
+
+export function CircuitBreakerDialog({ open, initialName, onClose, onSave }: {
+  open: boolean; initialName: string; onClose: () => void; onSave: (name: string, policy: CircuitBreakerPolicy) => void
+}) {
+  const [name, setName] = useState(initialName)
+  const [maxRequests, setMaxRequests] = useState('')
+  const [timeout, setTimeout] = useState('')
+  const [trip, setTrip] = useState('')
+  const [interval, setInterval] = useState('')
+  const nameErr = name === '' ? 'Name is required' : validateResourceName(name)
+  const numOk = integerError(maxRequests) === null
+  const toOk = validateGoDuration(timeout).valid
+  const ivOk = validateGoDuration(interval).valid
+  const canSave = !nameErr && numOk && toOk && ivOk
+  function save() {
+    onSave(name, {
+      maxRequests: maxRequests === '' ? undefined : Number(maxRequests),
+      timeout, trip, interval,
+    })
+  }
+  return (
+    <DialogShell open={open} title="Add circuit breaker policy" onClose={onClose} canSave={canSave} onSave={save}>
+      <Field label="Name" required error={name === '' ? null : nameErr}>
+        <TextInput aria-label="Circuit breaker name" value={name} onChange={setName} />
+      </Field>
+      <Field label="Max requests" error={numOk ? null : 'Must be an integer'}>
+        <NumberInput aria-label="Max requests" value={maxRequests} onChange={setMaxRequests} />
+      </Field>
+      <Field label="Timeout" error={timeout === '' ? null : (toOk ? null : validateGoDuration(timeout).error)}>
+        <TextInput aria-label="Timeout" placeholder="30s" value={timeout} onChange={setTimeout} />
+      </Field>
+      <Field label="Trip (CEL)">
+        <TextInput aria-label="Trip" placeholder="consecutiveFailures >= 5" value={trip} onChange={setTrip} />
+      </Field>
+      <Field label="Interval" error={interval === '' ? null : (ivOk ? null : validateGoDuration(interval).error)}>
+        <TextInput aria-label="Interval" placeholder="8s" value={interval} onChange={setInterval} />
+      </Field>
+    </DialogShell>
+  )
+}

--- a/web/src/pages/resiliency-builder/policyDialogs.tsx
+++ b/web/src/pages/resiliency-builder/policyDialogs.tsx
@@ -19,15 +19,15 @@ function DialogShell({ open, title, onClose, onSave, canSave, children }: {
   )
 }
 
-export function TimeoutDialog({ open, initialName, onClose, onSave }: {
-  open: boolean; initialName: string; onClose: () => void; onSave: (name: string, duration: string) => void
+export function TimeoutDialog({ open, initialName, initialDuration, editing, onClose, onSave }: {
+  open: boolean; initialName: string; initialDuration?: string; editing?: boolean; onClose: () => void; onSave: (name: string, duration: string) => void
 }) {
   const [name, setName] = useState(initialName)
-  const [duration, setDuration] = useState('')
+  const [duration, setDuration] = useState(initialDuration ?? '5s')
   const nameErr = name === '' ? 'Name is required' : validateResourceName(name)
   const durOk = duration !== '' && validateGoDuration(duration).valid
   return (
-    <DialogShell open={open} title="Add timeout policy" onClose={onClose} canSave={!nameErr && durOk}
+    <DialogShell open={open} title={editing ? 'Edit timeout policy' : 'Add timeout policy'} onClose={onClose} canSave={!nameErr && durOk}
       onSave={() => onSave(name, duration)}>
       <Field label="Name" required error={name === '' ? null : nameErr}>
         <TextInput aria-label="Timeout name" value={name} onChange={setName} />
@@ -39,16 +39,17 @@ export function TimeoutDialog({ open, initialName, onClose, onSave }: {
   )
 }
 
-export function RetryDialog({ open, initialName, onClose, onSave }: {
-  open: boolean; initialName: string; onClose: () => void; onSave: (name: string, policy: RetryPolicy) => void
+export function RetryDialog({ open, initialName, initialPolicy, editing, lockName, keepDurationForExponential, onClose, onSave }: {
+  open: boolean; initialName: string; initialPolicy?: RetryPolicy; editing?: boolean; lockName?: boolean; keepDurationForExponential?: boolean
+  onClose: () => void; onSave: (name: string, policy: RetryPolicy) => void
 }) {
   const [name, setName] = useState(initialName)
-  const [policy, setPolicy] = useState<'constant' | 'exponential'>('constant')
-  const [duration, setDuration] = useState('5s')
-  const [maxInterval, setMaxInterval] = useState('60s')
-  const [maxRetries, setMaxRetries] = useState('-1')
-  const [http, setHttp] = useState('')
-  const [grpc, setGrpc] = useState('')
+  const [policy, setPolicy] = useState<'constant' | 'exponential'>(initialPolicy?.policy ?? 'constant')
+  const [duration, setDuration] = useState(initialPolicy?.duration ?? '5s')
+  const [maxInterval, setMaxInterval] = useState(initialPolicy?.maxInterval ?? '60s')
+  const [maxRetries, setMaxRetries] = useState(initialPolicy?.maxRetries?.toString() ?? '-1')
+  const [http, setHttp] = useState(initialPolicy?.matching?.httpStatusCodes ?? '')
+  const [grpc, setGrpc] = useState(initialPolicy?.matching?.grpcStatusCodes ?? '')
   const nameErr = name === '' ? 'Name is required' : validateResourceName(name)
   const durField = policy === 'constant' ? duration : maxInterval
   const durOk = validateGoDuration(durField).valid
@@ -61,15 +62,23 @@ export function RetryDialog({ open, initialName, onClose, onSave }: {
       maxRetries: maxRetries === '' ? undefined : Number(maxRetries),
       matching: { httpStatusCodes: http, grpcStatusCodes: grpc },
     }
-    if (policy === 'constant') p.duration = duration
-    else p.maxInterval = maxInterval
+    if (policy === 'constant') {
+      p.duration = duration
+    } else {
+      p.maxInterval = maxInterval
+      if (keepDurationForExponential && duration !== '') p.duration = duration
+    }
     onSave(name, p)
   }
   return (
-    <DialogShell open={open} title="Add retry policy" onClose={onClose} canSave={canSave} onSave={save}>
-      <Field label="Name" required error={name === '' ? null : nameErr}>
-        <TextInput aria-label="Retry name" value={name} onChange={setName} />
-      </Field>
+    <DialogShell open={open} title={editing ? 'Edit retry policy' : 'Add retry policy'} onClose={onClose} canSave={canSave} onSave={save}>
+      {lockName ? (
+        <Field label="Name"><b>{name}</b></Field>
+      ) : (
+        <Field label="Name" required error={name === '' ? null : nameErr}>
+          <TextInput aria-label="Retry name" value={name} onChange={setName} />
+        </Field>
+      )}
       <Field label="Policy" required>
         <SelectInput aria-label="Retry policy type" value={policy}
           options={[{ label: 'constant', value: 'constant' }, { label: 'exponential', value: 'exponential' }]}
@@ -97,14 +106,14 @@ export function RetryDialog({ open, initialName, onClose, onSave }: {
   )
 }
 
-export function CircuitBreakerDialog({ open, initialName, onClose, onSave }: {
-  open: boolean; initialName: string; onClose: () => void; onSave: (name: string, policy: CircuitBreakerPolicy) => void
+export function CircuitBreakerDialog({ open, initialName, initialPolicy, editing, onClose, onSave }: {
+  open: boolean; initialName: string; initialPolicy?: CircuitBreakerPolicy; editing?: boolean; onClose: () => void; onSave: (name: string, policy: CircuitBreakerPolicy) => void
 }) {
   const [name, setName] = useState(initialName)
-  const [maxRequests, setMaxRequests] = useState('')
-  const [timeoutDur, setTimeoutDur] = useState('')
-  const [trip, setTrip] = useState('')
-  const [intervalDur, setIntervalDur] = useState('')
+  const [maxRequests, setMaxRequests] = useState(initialPolicy?.maxRequests?.toString() ?? '1')
+  const [timeoutDur, setTimeoutDur] = useState(initialPolicy?.timeout ?? '45s')
+  const [trip, setTrip] = useState(initialPolicy?.trip ?? 'consecutiveFailures >= 5')
+  const [intervalDur, setIntervalDur] = useState(initialPolicy?.interval ?? '8s')
   const nameErr = name === '' ? 'Name is required' : validateResourceName(name)
   const numOk = integerError(maxRequests) === null
   const toOk = validateGoDuration(timeoutDur).valid
@@ -117,7 +126,7 @@ export function CircuitBreakerDialog({ open, initialName, onClose, onSave }: {
     })
   }
   return (
-    <DialogShell open={open} title="Add circuit breaker policy" onClose={onClose} canSave={canSave} onSave={save}>
+    <DialogShell open={open} title={editing ? 'Edit circuit breaker policy' : 'Add circuit breaker policy'} onClose={onClose} canSave={canSave} onSave={save}>
       <Field label="Name" required error={name === '' ? null : nameErr}>
         <TextInput aria-label="Circuit breaker name" value={name} onChange={setName} />
       </Field>

--- a/web/src/pages/resiliency-builder/policyDialogs.tsx
+++ b/web/src/pages/resiliency-builder/policyDialogs.tsx
@@ -102,18 +102,18 @@ export function CircuitBreakerDialog({ open, initialName, onClose, onSave }: {
 }) {
   const [name, setName] = useState(initialName)
   const [maxRequests, setMaxRequests] = useState('')
-  const [timeout, setTimeout] = useState('')
+  const [timeoutDur, setTimeoutDur] = useState('')
   const [trip, setTrip] = useState('')
-  const [interval, setInterval] = useState('')
+  const [intervalDur, setIntervalDur] = useState('')
   const nameErr = name === '' ? 'Name is required' : validateResourceName(name)
   const numOk = integerError(maxRequests) === null
-  const toOk = validateGoDuration(timeout).valid
-  const ivOk = validateGoDuration(interval).valid
+  const toOk = validateGoDuration(timeoutDur).valid
+  const ivOk = validateGoDuration(intervalDur).valid
   const canSave = !nameErr && numOk && toOk && ivOk
   function save() {
     onSave(name, {
       maxRequests: maxRequests === '' ? undefined : Number(maxRequests),
-      timeout, trip, interval,
+      timeout: timeoutDur, trip, interval: intervalDur,
     })
   }
   return (
@@ -124,14 +124,14 @@ export function CircuitBreakerDialog({ open, initialName, onClose, onSave }: {
       <Field label="Max requests" error={numOk ? null : 'Must be an integer'}>
         <NumberInput aria-label="Max requests" value={maxRequests} onChange={setMaxRequests} />
       </Field>
-      <Field label="Timeout" error={timeout === '' ? null : (toOk ? null : validateGoDuration(timeout).error)}>
-        <TextInput aria-label="Timeout" placeholder="30s" value={timeout} onChange={setTimeout} />
+      <Field label="Timeout" error={timeoutDur === '' ? null : (toOk ? null : validateGoDuration(timeoutDur).error)}>
+        <TextInput aria-label="Timeout" placeholder="30s" value={timeoutDur} onChange={setTimeoutDur} />
       </Field>
       <Field label="Trip (CEL)">
         <TextInput aria-label="Trip" placeholder="consecutiveFailures >= 5" value={trip} onChange={setTrip} />
       </Field>
-      <Field label="Interval" error={interval === '' ? null : (ivOk ? null : validateGoDuration(interval).error)}>
-        <TextInput aria-label="Interval" placeholder="8s" value={interval} onChange={setInterval} />
+      <Field label="Interval" error={intervalDur === '' ? null : (ivOk ? null : validateGoDuration(intervalDur).error)}>
+        <TextInput aria-label="Interval" placeholder="8s" value={intervalDur} onChange={setIntervalDur} />
       </Field>
     </DialogShell>
   )

--- a/web/src/pages/resiliency-builder/reducer.test.ts
+++ b/web/src/pages/resiliency-builder/reducer.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { initialState, reducer, canContinue, assembleResiliency, nextName } from './reducer'
+
+describe('nextName', () => {
+  it('produces sequential names by count of existing keys', () => {
+    expect(nextName('retry', {})).toBe('retry1')
+    expect(nextName('retry', { retry1: {}, retry2: {} })).toBe('retry3')
+  })
+})
+
+describe('canContinue', () => {
+  it('step 0 needs a valid name', () => {
+    let s = initialState()
+    expect(canContinue(s)).toBe(false)
+    s = reducer(s, { type: 'SET_NAME', name: 'my-resiliency' })
+    expect(canContinue(s)).toBe(true)
+  })
+  it('step 1 needs at least one policy of any kind', () => {
+    let s = reducer(initialState(), { type: 'SET_NAME', name: 'r' })
+    s = reducer(s, { type: 'NEXT' }) // -> 1
+    expect(canContinue(s)).toBe(false)
+    s = reducer(s, { type: 'UPSERT_TIMEOUT', name: 'timeout1', duration: '30s' })
+    expect(canContinue(s)).toBe(true)
+  })
+  it('step 2 needs at least one target of any kind', () => {
+    let s = reducer(initialState(), { type: 'SET_NAME', name: 'r' })
+    s = reducer(s, { type: 'UPSERT_TIMEOUT', name: 'timeout1', duration: '30s' })
+    s = reducer(s, { type: 'NEXT' }) // 0->1
+    s = reducer(s, { type: 'NEXT' }) // 1->2
+    expect(canContinue(s)).toBe(false)
+    s = reducer(s, { type: 'UPSERT_APP', name: 'orders', target: { timeout: 'timeout1' } })
+    expect(canContinue(s)).toBe(true)
+  })
+})
+
+describe('reducer upserts/removes', () => {
+  it('adds and removes a retry policy', () => {
+    let s = reducer(initialState(), { type: 'UPSERT_RETRY', name: 'retry1', policy: { policy: 'constant', duration: '5s', maxRetries: 3 } })
+    expect(s.config.spec.policies.retries.retry1.duration).toBe('5s')
+    s = reducer(s, { type: 'REMOVE_RETRY', name: 'retry1' })
+    expect(s.config.spec.policies.retries.retry1).toBeUndefined()
+  })
+})
+
+describe('assembleResiliency', () => {
+  it('cleans spec, keeps name, omits empty namespace/scopes', () => {
+    let s = reducer(initialState(), { type: 'SET_NAME', name: 'r' })
+    s = reducer(s, { type: 'UPSERT_RETRY', name: 'retry1', policy: { policy: 'constant', duration: '5s', maxRetries: 3, maxInterval: '', matching: { httpStatusCodes: '', grpcStatusCodes: '' } } })
+    const out = assembleResiliency(s.config) as any
+    expect(out.metadata).toEqual({ name: 'r' }) // no empty namespace
+    expect(out.scopes).toBeUndefined()
+    // empty maxInterval + empty matching pruned by recursivelyRemoveEmptyValues:
+    expect(out.spec.policies.retries.retry1).toEqual({ policy: 'constant', duration: '5s', maxRetries: 3 })
+  })
+})

--- a/web/src/pages/resiliency-builder/reducer.test.ts
+++ b/web/src/pages/resiliency-builder/reducer.test.ts
@@ -31,6 +31,20 @@ describe('canContinue', () => {
     s = reducer(s, { type: 'UPSERT_APP', name: 'orders', target: { timeout: 'timeout1' } })
     expect(canContinue(s)).toBe(true)
   })
+  it('step 2 passes with a DaprBuiltIn override and no explicit target', () => {
+    let s = reducer(initialState(), { type: 'SET_NAME', name: 'r' })
+    s = reducer(s, { type: 'UPSERT_RETRY', name: 'DaprBuiltInServiceRetries', policy: { policy: 'constant', duration: '1s', maxRetries: 3 } })
+    s = reducer(s, { type: 'NEXT' }) // 0->1
+    s = reducer(s, { type: 'NEXT' }) // 1->2
+    expect(canContinue(s)).toBe(true)
+  })
+  it('step 2 fails with only a non-builtin retry and no target', () => {
+    let s = reducer(initialState(), { type: 'SET_NAME', name: 'r' })
+    s = reducer(s, { type: 'UPSERT_RETRY', name: 'retry1', policy: { policy: 'constant', duration: '5s' } })
+    s = reducer(s, { type: 'NEXT' })
+    s = reducer(s, { type: 'NEXT' })
+    expect(canContinue(s)).toBe(false)
+  })
 })
 
 describe('reducer upserts/removes', () => {

--- a/web/src/pages/resiliency-builder/reducer.test.ts
+++ b/web/src/pages/resiliency-builder/reducer.test.ts
@@ -43,13 +43,18 @@ describe('reducer upserts/removes', () => {
 })
 
 describe('assembleResiliency', () => {
-  it('cleans spec, keeps name, omits empty namespace/scopes', () => {
+  it('keeps name + default namespace, cleans spec, omits empty scopes', () => {
     let s = reducer(initialState(), { type: 'SET_NAME', name: 'r' })
     s = reducer(s, { type: 'UPSERT_RETRY', name: 'retry1', policy: { policy: 'constant', duration: '5s', maxRetries: 3, maxInterval: '', matching: { httpStatusCodes: '', grpcStatusCodes: '' } } })
     const out = assembleResiliency(s.config) as any
-    expect(out.metadata).toEqual({ name: 'r' }) // no empty namespace
+    expect(out.metadata).toEqual({ name: 'r', namespace: 'default' })
     expect(out.scopes).toBeUndefined()
-    // empty maxInterval + empty matching pruned by recursivelyRemoveEmptyValues:
     expect(out.spec.policies.retries.retry1).toEqual({ policy: 'constant', duration: '5s', maxRetries: 3 })
+  })
+  it('omits namespace when cleared', () => {
+    let s = reducer(initialState(), { type: 'SET_NAME', name: 'r' })
+    s = reducer(s, { type: 'SET_NAMESPACE', namespace: '' })
+    const out = assembleResiliency(s.config) as any
+    expect(out.metadata).toEqual({ name: 'r' })
   })
 })

--- a/web/src/pages/resiliency-builder/reducer.ts
+++ b/web/src/pages/resiliency-builder/reducer.ts
@@ -1,0 +1,121 @@
+import {
+  defaultResiliencyConfig, type DaprResiliency, type RetryPolicy, type CircuitBreakerPolicy,
+  type AppTarget, type ActorTarget, type ComponentTarget,
+} from '../../types/resiliency'
+import { validateResourceName } from '../../lib/validation'
+import { recursivelyRemoveEmptyValues } from '../../lib/yaml-emit'
+
+export interface ResiliencyState {
+  config: DaprResiliency
+  activeStep: number
+}
+
+export type Action =
+  | { type: 'SET_NAME'; name: string }
+  | { type: 'SET_NAMESPACE'; namespace: string }
+  | { type: 'UPSERT_TIMEOUT'; name: string; duration: string }
+  | { type: 'REMOVE_TIMEOUT'; name: string }
+  | { type: 'UPSERT_RETRY'; name: string; policy: RetryPolicy }
+  | { type: 'REMOVE_RETRY'; name: string }
+  | { type: 'UPSERT_CB'; name: string; policy: CircuitBreakerPolicy }
+  | { type: 'REMOVE_CB'; name: string }
+  | { type: 'UPSERT_APP'; name: string; target: AppTarget }
+  | { type: 'REMOVE_APP'; name: string }
+  | { type: 'UPSERT_ACTOR'; name: string; target: ActorTarget }
+  | { type: 'REMOVE_ACTOR'; name: string }
+  | { type: 'UPSERT_COMPONENT'; name: string; target: ComponentTarget }
+  | { type: 'REMOVE_COMPONENT'; name: string }
+  | { type: 'NEXT' }
+  | { type: 'BACK' }
+
+export function initialState(): ResiliencyState {
+  return { config: defaultResiliencyConfig(), activeStep: 0 }
+}
+
+/** `retry1`, `retry2`, ... based on the count of existing keys (matches cloudgrid). */
+export function nextName(prefix: string, existing: Record<string, unknown>): string {
+  return `${prefix}${Object.keys(existing).length + 1}`
+}
+
+function withoutKey<T>(map: Record<string, T>, key: string): Record<string, T> {
+  const next = { ...map }
+  delete next[key]
+  return next
+}
+
+export function reducer(state: ResiliencyState, action: Action): ResiliencyState {
+  const cfg = state.config
+  const pol = cfg.spec.policies
+  const tgt = cfg.spec.targets
+  const set = (patch: Partial<DaprResiliency['spec']>): ResiliencyState => ({
+    ...state,
+    config: { ...cfg, spec: { ...cfg.spec, ...patch } },
+  })
+  switch (action.type) {
+    case 'SET_NAME':
+      return { ...state, config: { ...cfg, metadata: { ...cfg.metadata, name: action.name } } }
+    case 'SET_NAMESPACE':
+      return { ...state, config: { ...cfg, metadata: { ...cfg.metadata, namespace: action.namespace } } }
+    case 'UPSERT_TIMEOUT':
+      return set({ policies: { ...pol, timeouts: { ...pol.timeouts, [action.name]: action.duration } } })
+    case 'REMOVE_TIMEOUT':
+      return set({ policies: { ...pol, timeouts: withoutKey(pol.timeouts, action.name) } })
+    case 'UPSERT_RETRY':
+      return set({ policies: { ...pol, retries: { ...pol.retries, [action.name]: action.policy } } })
+    case 'REMOVE_RETRY':
+      return set({ policies: { ...pol, retries: withoutKey(pol.retries, action.name) } })
+    case 'UPSERT_CB':
+      return set({ policies: { ...pol, circuitBreakers: { ...pol.circuitBreakers, [action.name]: action.policy } } })
+    case 'REMOVE_CB':
+      return set({ policies: { ...pol, circuitBreakers: withoutKey(pol.circuitBreakers, action.name) } })
+    case 'UPSERT_APP':
+      return set({ targets: { ...tgt, apps: { ...(tgt.apps ?? {}), [action.name]: action.target } } })
+    case 'REMOVE_APP':
+      return set({ targets: { ...tgt, apps: withoutKey(tgt.apps ?? {}, action.name) } })
+    case 'UPSERT_ACTOR':
+      return set({ targets: { ...tgt, actors: { ...(tgt.actors ?? {}), [action.name]: action.target } } })
+    case 'REMOVE_ACTOR':
+      return set({ targets: { ...tgt, actors: withoutKey(tgt.actors ?? {}, action.name) } })
+    case 'UPSERT_COMPONENT':
+      return set({ targets: { ...tgt, components: { ...(tgt.components ?? {}), [action.name]: action.target } } })
+    case 'REMOVE_COMPONENT':
+      return set({ targets: { ...tgt, components: withoutKey(tgt.components ?? {}, action.name) } })
+    case 'NEXT':
+      return { ...state, activeStep: state.activeStep + 1 }
+    case 'BACK':
+      return { ...state, activeStep: Math.max(0, state.activeStep - 1) }
+    default:
+      return state
+  }
+}
+
+function countAll(map: Record<string, unknown> | undefined): number {
+  return map ? Object.keys(map).length : 0
+}
+
+export function canContinue(state: ResiliencyState): boolean {
+  const { config, activeStep } = state
+  const { policies, targets } = config.spec
+  switch (activeStep) {
+    case 0:
+      return validateResourceName(config.metadata.name) === null
+    case 1:
+      return countAll(policies.timeouts) + countAll(policies.retries) + countAll(policies.circuitBreakers) > 0
+    case 2:
+      return countAll(targets.apps) + countAll(targets.actors) + countAll(targets.components) > 0
+    default:
+      return true
+  }
+}
+
+/** Build the emit object: name (+ namespace if set), no empty scopes, spec cleaned. */
+export function assembleResiliency(config: DaprResiliency): Record<string, unknown> {
+  const metadata: Record<string, unknown> = { name: config.metadata.name }
+  if ((config.metadata.namespace ?? '').trim() !== '') metadata.namespace = config.metadata.namespace
+  return {
+    apiVersion: config.apiVersion,
+    kind: config.kind,
+    metadata,
+    spec: recursivelyRemoveEmptyValues(config.spec),
+  }
+}

--- a/web/src/pages/resiliency-builder/reducer.ts
+++ b/web/src/pages/resiliency-builder/reducer.ts
@@ -4,6 +4,7 @@ import {
 } from '../../types/resiliency'
 import { validateResourceName } from '../../lib/validation'
 import { recursivelyRemoveEmptyValues } from '../../lib/yaml-emit'
+import { isDefaultPolicyName } from './defaultPolicies'
 
 export interface ResiliencyState {
   config: DaprResiliency
@@ -101,8 +102,11 @@ export function canContinue(state: ResiliencyState): boolean {
       return validateResourceName(config.metadata.name) === null
     case 1:
       return countAll(policies.timeouts) + countAll(policies.retries) + countAll(policies.circuitBreakers) > 0
-    case 2:
-      return countAll(targets.apps) + countAll(targets.actors) + countAll(targets.components) > 0
+    case 2: {
+      const hasTarget = countAll(targets.apps) + countAll(targets.actors) + countAll(targets.components) > 0
+      const hasOverride = Object.keys(policies.retries).some(isDefaultPolicyName)
+      return hasTarget || hasOverride
+    }
     default:
       return true
   }

--- a/web/src/pages/resiliency-builder/steps.test.tsx
+++ b/web/src/pages/resiliency-builder/steps.test.tsx
@@ -8,7 +8,7 @@ describe('StepGeneral', () => {
   it('dispatches SET_NAME', () => {
     const dispatch = vi.fn()
     render(<StepGeneral state={initialState()} dispatch={dispatch} />)
-    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'my-res' } })
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'my-res' } })
     expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NAME', name: 'my-res' })
   })
 })

--- a/web/src/pages/resiliency-builder/steps.test.tsx
+++ b/web/src/pages/resiliency-builder/steps.test.tsx
@@ -11,6 +11,12 @@ describe('StepGeneral', () => {
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'my-res' } })
     expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NAME', name: 'my-res' })
   })
+  it('dispatches SET_NAMESPACE', () => {
+    const dispatch = vi.fn()
+    render(<StepGeneral state={initialState()} dispatch={dispatch} />)
+    fireEvent.change(screen.getByLabelText('Namespace'), { target: { value: 'my-ns' } })
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NAMESPACE', namespace: 'my-ns' })
+  })
 })
 
 describe('StepPolicies', () => {

--- a/web/src/pages/resiliency-builder/steps.test.tsx
+++ b/web/src/pages/resiliency-builder/steps.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { StepGeneral } from './StepGeneral'
+import { StepPolicies } from './StepPolicies'
+import { initialState, reducer } from './reducer'
+
+describe('StepGeneral', () => {
+  it('dispatches SET_NAME', () => {
+    const dispatch = vi.fn()
+    render(<StepGeneral state={initialState()} dispatch={dispatch} />)
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'my-res' } })
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NAME', name: 'my-res' })
+  })
+})
+
+describe('StepPolicies', () => {
+  it('opens the timeout dialog and dispatches UPSERT_TIMEOUT on save', () => {
+    const dispatch = vi.fn()
+    render(<StepPolicies state={initialState()} dispatch={dispatch} />)
+    fireEvent.click(screen.getByRole('button', { name: /add timeouts/i }))
+    fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: '30s' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(dispatch).toHaveBeenCalledWith({ type: 'UPSERT_TIMEOUT', name: 'timeout1', duration: '30s' })
+  })
+  it('lists an existing retry and removes it', () => {
+    const dispatch = vi.fn()
+    const s = reducer(initialState(), { type: 'UPSERT_RETRY', name: 'retry1', policy: { policy: 'constant', duration: '5s' } })
+    render(<StepPolicies state={s} dispatch={dispatch} />)
+    fireEvent.click(screen.getByRole('button', { name: /remove retry1/i }))
+    expect(dispatch).toHaveBeenCalledWith({ type: 'REMOVE_RETRY', name: 'retry1' })
+  })
+})

--- a/web/src/pages/resiliency-builder/steps.test.tsx
+++ b/web/src/pages/resiliency-builder/steps.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import { StepGeneral } from './StepGeneral'
 import { StepPolicies } from './StepPolicies'
+import { StepTargets } from './StepTargets'
 import { initialState, reducer } from './reducer'
 
 describe('StepGeneral', () => {
@@ -72,5 +73,18 @@ describe('StepPolicies', () => {
     // present as an editable override chip, but not offered as an "Add" row anymore
     expect(screen.getByRole('button', { name: /edit DaprBuiltInServiceRetries/i })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /add DaprBuiltInServiceRetries/i })).not.toBeInTheDocument()
+  })
+})
+
+describe('StepTargets', () => {
+  it('edits an existing app target via chip click', () => {
+    const dispatch = vi.fn()
+    let s = reducer(initialState(), { type: 'UPSERT_TIMEOUT', name: 'timeout1', duration: '30s' })
+    s = reducer(s, { type: 'UPSERT_APP', name: 'orders', target: { timeout: 'timeout1' } })
+    render(<StepTargets state={s} dispatch={dispatch} />)
+    fireEvent.click(screen.getByRole('button', { name: /edit orders/i }))
+    expect((screen.getByLabelText(/app id/i) as HTMLInputElement).value).toBe('orders')
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(dispatch).toHaveBeenCalledWith({ type: 'UPSERT_APP', name: 'orders', target: expect.objectContaining({ timeout: 'timeout1' }) })
   })
 })

--- a/web/src/pages/resiliency-builder/steps.test.tsx
+++ b/web/src/pages/resiliency-builder/steps.test.tsx
@@ -28,6 +28,15 @@ describe('StepPolicies', () => {
     fireEvent.click(screen.getByRole('button', { name: /save/i }))
     expect(dispatch).toHaveBeenCalledWith({ type: 'UPSERT_TIMEOUT', name: 'timeout1', duration: '30s' })
   })
+  it('second add timeout uses name timeout2 not timeout1', () => {
+    const dispatch = vi.fn()
+    const s = reducer(initialState(), { type: 'UPSERT_TIMEOUT', name: 'timeout1', duration: '30s' })
+    render(<StepPolicies state={s} dispatch={dispatch} />)
+    fireEvent.click(screen.getByRole('button', { name: /add timeouts/i }))
+    fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: '60s' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(dispatch).toHaveBeenCalledWith({ type: 'UPSERT_TIMEOUT', name: 'timeout2', duration: '60s' })
+  })
   it('lists an existing retry and removes it', () => {
     const dispatch = vi.fn()
     const s = reducer(initialState(), { type: 'UPSERT_RETRY', name: 'retry1', policy: { policy: 'constant', duration: '5s' } })

--- a/web/src/pages/resiliency-builder/steps.test.tsx
+++ b/web/src/pages/resiliency-builder/steps.test.tsx
@@ -44,4 +44,33 @@ describe('StepPolicies', () => {
     fireEvent.click(screen.getByRole('button', { name: /remove retry1/i }))
     expect(dispatch).toHaveBeenCalledWith({ type: 'REMOVE_RETRY', name: 'retry1' })
   })
+  it('edits an existing timeout via chip click (rename dispatches remove + upsert)', () => {
+    const dispatch = vi.fn()
+    const s = reducer(initialState(), { type: 'UPSERT_TIMEOUT', name: 'timeout1', duration: '30s' })
+    render(<StepPolicies state={s} dispatch={dispatch} />)
+    fireEvent.click(screen.getByRole('button', { name: /edit timeout1/i }))
+    fireEvent.change(screen.getByLabelText(/timeout name/i), { target: { value: 'renamed' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(dispatch).toHaveBeenCalledWith({ type: 'REMOVE_TIMEOUT', name: 'timeout1' })
+    expect(dispatch).toHaveBeenCalledWith({ type: 'UPSERT_TIMEOUT', name: 'renamed', duration: '30s' })
+  })
+  it('adds a DaprBuiltIn override with prefilled defaults', () => {
+    const dispatch = vi.fn()
+    render(<StepPolicies state={initialState()} dispatch={dispatch} />)
+    fireEvent.click(screen.getByRole('button', { name: /add DaprBuiltInServiceRetries/i }))
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'UPSERT_RETRY',
+      name: 'DaprBuiltInServiceRetries',
+      policy: expect.objectContaining({ policy: 'constant', duration: '1s', maxRetries: 3 }),
+    })
+  })
+  it('does not list a DaprBuiltIn override in the regular Retries list', () => {
+    const dispatch = vi.fn()
+    const s = reducer(initialState(), { type: 'UPSERT_RETRY', name: 'DaprBuiltInServiceRetries', policy: { policy: 'constant', duration: '1s', maxRetries: 3 } })
+    render(<StepPolicies state={s} dispatch={dispatch} />)
+    // present as an editable override chip, but not offered as an "Add" row anymore
+    expect(screen.getByRole('button', { name: /edit DaprBuiltInServiceRetries/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /add DaprBuiltInServiceRetries/i })).not.toBeInTheDocument()
+  })
 })

--- a/web/src/pages/resiliency-builder/targetDialogs.test.tsx
+++ b/web/src/pages/resiliency-builder/targetDialogs.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { AppTargetDialog, ComponentTargetDialog } from './targetDialogs'
+
+const policies = { timeouts: ['timeout1'], retries: ['retry1'], circuitBreakers: ['cb1'] }
+
+describe('AppTargetDialog', () => {
+  it('requires a name and at least one policy reference', () => {
+    const onSave = vi.fn()
+    render(<AppTargetDialog open policies={policies} onClose={vi.fn()} onSave={onSave} />)
+    const save = screen.getByRole('button', { name: /save/i })
+    expect(save).toBeDisabled()
+    fireEvent.change(screen.getByLabelText(/app id/i), { target: { value: 'orders' } })
+    expect(save).toBeDisabled() // no policy chosen yet
+    fireEvent.change(screen.getByLabelText(/^timeout/i), { target: { value: 'timeout1' } })
+    expect(save).toBeEnabled()
+    fireEvent.click(save)
+    expect(onSave).toHaveBeenCalledWith('orders', expect.objectContaining({ timeout: 'timeout1' }))
+  })
+})
+
+describe('ComponentTargetDialog', () => {
+  it('saves an outbound-only component target', () => {
+    const onSave = vi.fn()
+    render(<ComponentTargetDialog open policies={policies} onClose={vi.fn()} onSave={onSave} />)
+    fireEvent.change(screen.getByLabelText(/component name/i), { target: { value: 'statestore' } })
+    fireEvent.change(screen.getByLabelText(/direction/i), { target: { value: 'outbound' } })
+    fireEvent.change(screen.getByLabelText(/^retry/i), { target: { value: 'retry1' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(onSave).toHaveBeenCalledWith('statestore', { outbound: { retry: 'retry1' } })
+  })
+})

--- a/web/src/pages/resiliency-builder/targetDialogs.test.tsx
+++ b/web/src/pages/resiliency-builder/targetDialogs.test.tsx
@@ -30,3 +30,23 @@ describe('ComponentTargetDialog', () => {
     expect(onSave).toHaveBeenCalledWith('statestore', { outbound: { retry: 'retry1' } })
   })
 })
+
+describe('AppTargetDialog edit', () => {
+  it('prefills name + policy refs and title on edit', () => {
+    const onSave = vi.fn()
+    render(<AppTargetDialog open editing policies={policies} initialName="orders" initialTarget={{ timeout: 'timeout1', retry: 'retry1' }} onClose={vi.fn()} onSave={onSave} />)
+    expect(screen.getByText(/edit app target/i)).toBeInTheDocument()
+    expect((screen.getByLabelText(/app id/i) as HTMLInputElement).value).toBe('orders')
+    expect((screen.getByLabelText(/^timeout policy/i) as HTMLSelectElement).value).toBe('timeout1')
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(onSave).toHaveBeenCalledWith('orders', expect.objectContaining({ timeout: 'timeout1', retry: 'retry1' }))
+  })
+})
+
+describe('ComponentTargetDialog edit', () => {
+  it('derives both-direction and prefills from outbound leg', () => {
+    render(<ComponentTargetDialog open editing policies={policies} initialName="statestore" initialTarget={{ outbound: { retry: 'retry1' }, inbound: { retry: 'retry1' } }} onClose={vi.fn()} onSave={vi.fn()} />)
+    expect((screen.getByLabelText(/direction/i) as HTMLSelectElement).value).toBe('both')
+    expect((screen.getByLabelText(/^retry policy/i) as HTMLSelectElement).value).toBe('retry1')
+  })
+})

--- a/web/src/pages/resiliency-builder/targetDialogs.tsx
+++ b/web/src/pages/resiliency-builder/targetDialogs.tsx
@@ -1,0 +1,152 @@
+import { useState } from 'react'
+import { Modal } from '../../components/Modal'
+import { Field, TextInput, NumberInput, SelectInput } from '../../components/form'
+import { validateResourceName, integerError } from '../../lib/validation'
+import type { AppTarget, ActorTarget, ComponentTarget } from '../../types/resiliency'
+
+export interface PolicyNames {
+  timeouts: string[]
+  retries: string[]
+  circuitBreakers: string[]
+}
+
+function opts(names: string[]) {
+  return names.map((n) => ({ label: n, value: n }))
+}
+
+function Shell({ open, title, onClose, onSave, canSave, children }: {
+  open: boolean; title: string; onClose: () => void; onSave: () => void; canSave: boolean; children: React.ReactNode
+}) {
+  return (
+    <Modal open={open} title={title} onClose={onClose}>
+      {children}
+      <div className="modal-actions">
+        <button type="button" className="btn ghost" onClick={onClose}>Cancel</button>
+        <button type="button" className="btn ghost" disabled={!canSave} onClick={onSave}>Save</button>
+      </div>
+    </Modal>
+  )
+}
+
+function PolicyPickers({ policies, timeout, retry, cb, setTimeout, setRetry, setCb }: {
+  policies: PolicyNames
+  timeout: string; retry: string; cb: string
+  setTimeout: (v: string) => void; setRetry: (v: string) => void; setCb: (v: string) => void
+}) {
+  return (
+    <>
+      <Field label="Timeout policy"><SelectInput aria-label="Timeout policy" value={timeout} options={opts(policies.timeouts)} onChange={setTimeout} /></Field>
+      <Field label="Retry policy"><SelectInput aria-label="Retry policy" value={retry} options={opts(policies.retries)} onChange={setRetry} /></Field>
+      <Field label="Circuit breaker policy"><SelectInput aria-label="Circuit breaker policy" value={cb} options={opts(policies.circuitBreakers)} onChange={setCb} /></Field>
+    </>
+  )
+}
+
+export function AppTargetDialog({ open, policies, onClose, onSave }: {
+  open: boolean; policies: PolicyNames; onClose: () => void; onSave: (name: string, target: AppTarget) => void
+}) {
+  const [name, setName] = useState('')
+  const [timeout, setTimeout] = useState('')
+  const [retry, setRetry] = useState('')
+  const [cb, setCb] = useState('')
+  const nameOk = validateResourceName(name) === null
+  const anyPolicy = !!(timeout || retry || cb)
+  function save() {
+    const t: AppTarget = {}
+    if (timeout) t.timeout = timeout
+    if (retry) t.retry = retry
+    if (cb) t.circuitBreaker = cb
+    onSave(name, t)
+  }
+  return (
+    <Shell open={open} title="Add app target" onClose={onClose} canSave={nameOk && anyPolicy} onSave={save}>
+      <Field label="App ID" required error={name === '' ? null : validateResourceName(name)}>
+        <TextInput aria-label="App ID" value={name} onChange={setName} />
+      </Field>
+      <PolicyPickers policies={policies} timeout={timeout} retry={retry} cb={cb} setTimeout={setTimeout} setRetry={setRetry} setCb={setCb} />
+    </Shell>
+  )
+}
+
+export function ActorTargetDialog({ open, policies, onClose, onSave }: {
+  open: boolean; policies: PolicyNames; onClose: () => void; onSave: (name: string, target: ActorTarget) => void
+}) {
+  const [name, setName] = useState('')
+  const [timeout, setTimeout] = useState('')
+  const [retry, setRetry] = useState('')
+  const [cb, setCb] = useState('')
+  const [scope, setScope] = useState<'' | 'type' | 'id' | 'both'>('')
+  const [cacheSize, setCacheSize] = useState('')
+  const nameOk = validateResourceName(name) === null
+  const anyPolicy = !!(timeout || retry || cb)
+  const cacheOk = integerError(cacheSize) === null
+  function save() {
+    const t: ActorTarget = {}
+    if (timeout) t.timeout = timeout
+    if (retry) t.retry = retry
+    if (cb) {
+      t.circuitBreaker = cb
+      if (scope) t.circuitBreakerScope = scope
+      if (cacheSize) t.circuitBreakerCacheSize = Number(cacheSize)
+    }
+    onSave(name, t)
+  }
+  return (
+    <Shell open={open} title="Add actor target" onClose={onClose} canSave={nameOk && anyPolicy && cacheOk} onSave={save}>
+      <Field label="Actor type" required error={name === '' ? null : validateResourceName(name)}>
+        <TextInput aria-label="Actor type" value={name} onChange={setName} />
+      </Field>
+      <PolicyPickers policies={policies} timeout={timeout} retry={retry} cb={cb} setTimeout={setTimeout} setRetry={setRetry} setCb={setCb} />
+      {cb && (
+        <>
+          <Field label="Circuit breaker scope">
+            <SelectInput aria-label="Circuit breaker scope" value={scope}
+              options={[{ label: 'type', value: 'type' }, { label: 'id', value: 'id' }, { label: 'both', value: 'both' }]}
+              onChange={(v) => setScope((v as '' | 'type' | 'id' | 'both'))} />
+          </Field>
+          <Field label="Circuit breaker cache size" error={cacheOk ? null : 'Must be an integer'}>
+            <NumberInput aria-label="Circuit breaker cache size" value={cacheSize} onChange={setCacheSize} />
+          </Field>
+        </>
+      )}
+    </Shell>
+  )
+}
+
+export function ComponentTargetDialog({ open, policies, onClose, onSave }: {
+  open: boolean; policies: PolicyNames; onClose: () => void; onSave: (name: string, target: ComponentTarget) => void
+}) {
+  const [name, setName] = useState('')
+  const [direction, setDirection] = useState<'outbound' | 'inbound' | 'both'>('outbound')
+  const [timeout, setTimeout] = useState('')
+  const [retry, setRetry] = useState('')
+  const [cb, setCb] = useState('')
+  const nameOk = validateResourceName(name) === null
+  const anyPolicy = !!(timeout || retry || cb)
+  function leg() {
+    const l: { timeout?: string; retry?: string; circuitBreaker?: string } = {}
+    if (timeout) l.timeout = timeout
+    if (retry) l.retry = retry
+    if (cb) l.circuitBreaker = cb
+    return l
+  }
+  function save() {
+    const t: ComponentTarget = {}
+    if (direction === 'outbound' || direction === 'both') t.outbound = leg()
+    if (direction === 'inbound' || direction === 'both') t.inbound = leg()
+    onSave(name, t)
+  }
+  return (
+    <Shell open={open} title="Add component target" onClose={onClose} canSave={nameOk && anyPolicy} onSave={save}>
+      <Field label="Component name" required error={name === '' ? null : validateResourceName(name)}>
+        <TextInput aria-label="Component name" value={name} onChange={setName} />
+      </Field>
+      <Field label="Direction" required>
+        <SelectInput aria-label="Direction" value={direction}
+          options={[{ label: 'outbound', value: 'outbound' }, { label: 'inbound', value: 'inbound' }, { label: 'both', value: 'both' }]}
+          onChange={(v) => setDirection(v === 'inbound' ? 'inbound' : v === 'both' ? 'both' : 'outbound')} />
+      </Field>
+      <PolicyPickers policies={policies} timeout={timeout} retry={retry} cb={cb} setTimeout={setTimeout} setRetry={setRetry} setCb={setCb} />
+    </Shell>
+  )
+}

--- a/web/src/pages/resiliency-builder/targetDialogs.tsx
+++ b/web/src/pages/resiliency-builder/targetDialogs.tsx
@@ -42,13 +42,13 @@ function PolicyPickers({ policies, timeout, retry, cb, setTimeout, setRetry, set
   )
 }
 
-export function AppTargetDialog({ open, policies, onClose, onSave }: {
-  open: boolean; policies: PolicyNames; onClose: () => void; onSave: (name: string, target: AppTarget) => void
+export function AppTargetDialog({ open, policies, initialName, initialTarget, editing, onClose, onSave }: {
+  open: boolean; policies: PolicyNames; initialName?: string; initialTarget?: AppTarget; editing?: boolean; onClose: () => void; onSave: (name: string, target: AppTarget) => void
 }) {
-  const [name, setName] = useState('')
-  const [timeoutRef, setTimeoutRef] = useState('')
-  const [retry, setRetry] = useState('')
-  const [cb, setCb] = useState('')
+  const [name, setName] = useState(initialName ?? '')
+  const [timeoutRef, setTimeoutRef] = useState(initialTarget?.timeout ?? '')
+  const [retry, setRetry] = useState(initialTarget?.retry ?? '')
+  const [cb, setCb] = useState(initialTarget?.circuitBreaker ?? '')
   const nameOk = validateResourceName(name) === null
   const anyPolicy = !!(timeoutRef || retry || cb)
   function save() {
@@ -59,7 +59,7 @@ export function AppTargetDialog({ open, policies, onClose, onSave }: {
     onSave(name, t)
   }
   return (
-    <Shell open={open} title="Add app target" onClose={onClose} canSave={nameOk && anyPolicy} onSave={save}>
+    <Shell open={open} title={editing ? 'Edit app target' : 'Add app target'} onClose={onClose} canSave={nameOk && anyPolicy} onSave={save}>
       <Field label="App ID" required error={name === '' ? null : validateResourceName(name)}>
         <TextInput aria-label="App ID" value={name} onChange={setName} />
       </Field>
@@ -68,15 +68,15 @@ export function AppTargetDialog({ open, policies, onClose, onSave }: {
   )
 }
 
-export function ActorTargetDialog({ open, policies, onClose, onSave }: {
-  open: boolean; policies: PolicyNames; onClose: () => void; onSave: (name: string, target: ActorTarget) => void
+export function ActorTargetDialog({ open, policies, initialName, initialTarget, editing, onClose, onSave }: {
+  open: boolean; policies: PolicyNames; initialName?: string; initialTarget?: ActorTarget; editing?: boolean; onClose: () => void; onSave: (name: string, target: ActorTarget) => void
 }) {
-  const [name, setName] = useState('')
-  const [timeoutRef, setTimeoutRef] = useState('')
-  const [retry, setRetry] = useState('')
-  const [cb, setCb] = useState('')
-  const [scope, setScope] = useState<'' | 'type' | 'id' | 'both'>('')
-  const [cacheSize, setCacheSize] = useState('')
+  const [name, setName] = useState(initialName ?? '')
+  const [timeoutRef, setTimeoutRef] = useState(initialTarget?.timeout ?? '')
+  const [retry, setRetry] = useState(initialTarget?.retry ?? '')
+  const [cb, setCb] = useState(initialTarget?.circuitBreaker ?? '')
+  const [scope, setScope] = useState<'' | 'type' | 'id' | 'both'>(initialTarget?.circuitBreakerScope ?? '')
+  const [cacheSize, setCacheSize] = useState(initialTarget?.circuitBreakerCacheSize?.toString() ?? '')
   const nameOk = validateResourceName(name) === null
   const anyPolicy = !!(timeoutRef || retry || cb)
   const cacheOk = integerError(cacheSize) === null
@@ -92,7 +92,7 @@ export function ActorTargetDialog({ open, policies, onClose, onSave }: {
     onSave(name, t)
   }
   return (
-    <Shell open={open} title="Add actor target" onClose={onClose} canSave={nameOk && anyPolicy && cacheOk} onSave={save}>
+    <Shell open={open} title={editing ? 'Edit actor target' : 'Add actor target'} onClose={onClose} canSave={nameOk && anyPolicy && cacheOk} onSave={save}>
       <Field label="Actor type" required error={name === '' ? null : validateResourceName(name)}>
         <TextInput aria-label="Actor type" value={name} onChange={setName} />
       </Field>
@@ -113,14 +113,18 @@ export function ActorTargetDialog({ open, policies, onClose, onSave }: {
   )
 }
 
-export function ComponentTargetDialog({ open, policies, onClose, onSave }: {
-  open: boolean; policies: PolicyNames; onClose: () => void; onSave: (name: string, target: ComponentTarget) => void
+export function ComponentTargetDialog({ open, policies, initialName, initialTarget, editing, onClose, onSave }: {
+  open: boolean; policies: PolicyNames; initialName?: string; initialTarget?: ComponentTarget; editing?: boolean; onClose: () => void; onSave: (name: string, target: ComponentTarget) => void
 }) {
-  const [name, setName] = useState('')
-  const [direction, setDirection] = useState<'outbound' | 'inbound' | 'both'>('outbound')
-  const [timeoutRef, setTimeoutRef] = useState('')
-  const [retry, setRetry] = useState('')
-  const [cb, setCb] = useState('')
+  const hasOut = !!initialTarget?.outbound
+  const hasIn = !!initialTarget?.inbound
+  const initialDirection: 'outbound' | 'inbound' | 'both' = hasOut && hasIn ? 'both' : hasIn ? 'inbound' : 'outbound'
+  const initialLeg = initialTarget?.outbound ?? initialTarget?.inbound
+  const [name, setName] = useState(initialName ?? '')
+  const [direction, setDirection] = useState<'outbound' | 'inbound' | 'both'>(initialDirection)
+  const [timeoutRef, setTimeoutRef] = useState(initialLeg?.timeout ?? '')
+  const [retry, setRetry] = useState(initialLeg?.retry ?? '')
+  const [cb, setCb] = useState(initialLeg?.circuitBreaker ?? '')
   const nameOk = validateResourceName(name) === null
   const anyPolicy = !!(timeoutRef || retry || cb)
   function leg() {
@@ -137,7 +141,7 @@ export function ComponentTargetDialog({ open, policies, onClose, onSave }: {
     onSave(name, t)
   }
   return (
-    <Shell open={open} title="Add component target" onClose={onClose} canSave={nameOk && anyPolicy} onSave={save}>
+    <Shell open={open} title={editing ? 'Edit component target' : 'Add component target'} onClose={onClose} canSave={nameOk && anyPolicy} onSave={save}>
       <Field label="Component name" required error={name === '' ? null : validateResourceName(name)}>
         <TextInput aria-label="Component name" value={name} onChange={setName} />
       </Field>

--- a/web/src/pages/resiliency-builder/targetDialogs.tsx
+++ b/web/src/pages/resiliency-builder/targetDialogs.tsx
@@ -46,14 +46,14 @@ export function AppTargetDialog({ open, policies, onClose, onSave }: {
   open: boolean; policies: PolicyNames; onClose: () => void; onSave: (name: string, target: AppTarget) => void
 }) {
   const [name, setName] = useState('')
-  const [timeout, setTimeout] = useState('')
+  const [timeoutRef, setTimeoutRef] = useState('')
   const [retry, setRetry] = useState('')
   const [cb, setCb] = useState('')
   const nameOk = validateResourceName(name) === null
-  const anyPolicy = !!(timeout || retry || cb)
+  const anyPolicy = !!(timeoutRef || retry || cb)
   function save() {
     const t: AppTarget = {}
-    if (timeout) t.timeout = timeout
+    if (timeoutRef) t.timeout = timeoutRef
     if (retry) t.retry = retry
     if (cb) t.circuitBreaker = cb
     onSave(name, t)
@@ -63,7 +63,7 @@ export function AppTargetDialog({ open, policies, onClose, onSave }: {
       <Field label="App ID" required error={name === '' ? null : validateResourceName(name)}>
         <TextInput aria-label="App ID" value={name} onChange={setName} />
       </Field>
-      <PolicyPickers policies={policies} timeout={timeout} retry={retry} cb={cb} setTimeout={setTimeout} setRetry={setRetry} setCb={setCb} />
+      <PolicyPickers policies={policies} timeout={timeoutRef} retry={retry} cb={cb} setTimeout={setTimeoutRef} setRetry={setRetry} setCb={setCb} />
     </Shell>
   )
 }
@@ -72,17 +72,17 @@ export function ActorTargetDialog({ open, policies, onClose, onSave }: {
   open: boolean; policies: PolicyNames; onClose: () => void; onSave: (name: string, target: ActorTarget) => void
 }) {
   const [name, setName] = useState('')
-  const [timeout, setTimeout] = useState('')
+  const [timeoutRef, setTimeoutRef] = useState('')
   const [retry, setRetry] = useState('')
   const [cb, setCb] = useState('')
   const [scope, setScope] = useState<'' | 'type' | 'id' | 'both'>('')
   const [cacheSize, setCacheSize] = useState('')
   const nameOk = validateResourceName(name) === null
-  const anyPolicy = !!(timeout || retry || cb)
+  const anyPolicy = !!(timeoutRef || retry || cb)
   const cacheOk = integerError(cacheSize) === null
   function save() {
     const t: ActorTarget = {}
-    if (timeout) t.timeout = timeout
+    if (timeoutRef) t.timeout = timeoutRef
     if (retry) t.retry = retry
     if (cb) {
       t.circuitBreaker = cb
@@ -96,7 +96,7 @@ export function ActorTargetDialog({ open, policies, onClose, onSave }: {
       <Field label="Actor type" required error={name === '' ? null : validateResourceName(name)}>
         <TextInput aria-label="Actor type" value={name} onChange={setName} />
       </Field>
-      <PolicyPickers policies={policies} timeout={timeout} retry={retry} cb={cb} setTimeout={setTimeout} setRetry={setRetry} setCb={setCb} />
+      <PolicyPickers policies={policies} timeout={timeoutRef} retry={retry} cb={cb} setTimeout={setTimeoutRef} setRetry={setRetry} setCb={setCb} />
       {cb && (
         <>
           <Field label="Circuit breaker scope">
@@ -118,14 +118,14 @@ export function ComponentTargetDialog({ open, policies, onClose, onSave }: {
 }) {
   const [name, setName] = useState('')
   const [direction, setDirection] = useState<'outbound' | 'inbound' | 'both'>('outbound')
-  const [timeout, setTimeout] = useState('')
+  const [timeoutRef, setTimeoutRef] = useState('')
   const [retry, setRetry] = useState('')
   const [cb, setCb] = useState('')
   const nameOk = validateResourceName(name) === null
-  const anyPolicy = !!(timeout || retry || cb)
+  const anyPolicy = !!(timeoutRef || retry || cb)
   function leg() {
     const l: { timeout?: string; retry?: string; circuitBreaker?: string } = {}
-    if (timeout) l.timeout = timeout
+    if (timeoutRef) l.timeout = timeoutRef
     if (retry) l.retry = retry
     if (cb) l.circuitBreaker = cb
     return l
@@ -146,7 +146,7 @@ export function ComponentTargetDialog({ open, policies, onClose, onSave }: {
           options={[{ label: 'outbound', value: 'outbound' }, { label: 'inbound', value: 'inbound' }, { label: 'both', value: 'both' }]}
           onChange={(v) => setDirection(v === 'inbound' ? 'inbound' : v === 'both' ? 'both' : 'outbound')} />
       </Field>
-      <PolicyPickers policies={policies} timeout={timeout} retry={retry} cb={cb} setTimeout={setTimeout} setRetry={setRetry} setCb={setCb} />
+      <PolicyPickers policies={policies} timeout={timeoutRef} retry={retry} cb={cb} setTimeout={setTimeoutRef} setRetry={setRetry} setCb={setCb} />
     </Shell>
   )
 }

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -9,6 +9,8 @@ import { Actors } from './pages/Actors'
 import { Subscriptions } from './pages/Subscriptions'
 import { ResourceList } from './pages/ResourceList'
 import { ComponentBuilder } from './pages/component-builder/ComponentBuilder'
+import { Resiliency } from './pages/Resiliency'
+import { ResiliencyBuilder } from './pages/resiliency-builder/ResiliencyBuilder'
 
 export const routes: RouteObject[] = [
   {
@@ -26,6 +28,8 @@ export const routes: RouteObject[] = [
       { path: 'components/:name', element: <ResourceList kind="component" /> },
       { path: 'configurations', element: <ResourceList kind="configuration" /> },
       { path: 'configurations/:name', element: <ResourceList kind="configuration" /> },
+      { path: 'resiliency', element: <Resiliency /> },
+      { path: 'resiliency/new', element: <ResiliencyBuilder /> },
       { path: 'logs', element: <Logs /> },
     ],
   },

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -8,6 +8,7 @@ import { WorkflowDetail } from './pages/WorkflowDetail'
 import { Actors } from './pages/Actors'
 import { Subscriptions } from './pages/Subscriptions'
 import { ResourceList } from './pages/ResourceList'
+import { ComponentBuilder } from './pages/component-builder/ComponentBuilder'
 
 export const routes: RouteObject[] = [
   {
@@ -20,6 +21,7 @@ export const routes: RouteObject[] = [
       { path: 'workflows/:appId/:instanceId', element: <WorkflowDetail /> },
       { path: 'actors', element: <Actors /> },
       { path: 'subscriptions', element: <Subscriptions /> },
+      { path: 'components/new', element: <ComponentBuilder /> },
       { path: 'components', element: <ResourceList kind="component" /> },
       { path: 'components/:name', element: <ResourceList kind="component" /> },
       { path: 'configurations', element: <ResourceList kind="configuration" /> },

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -210,6 +210,7 @@ table.t.click tbody tr:hover { background: var(--surface-2); }
 .btn { font: inherit; font-size: 12.5px; font-weight: 600; border-radius: 8px; padding: 7px 13px; cursor: pointer; border: 1px solid transparent; }
 .btn.primary { background: var(--accent2); color: #06231a; border-color: transparent; }
 .btn.ghost { background: transparent; color: var(--text); border-color: var(--line); }
+.btn.ghost:disabled { color: var(--faint); border-color: var(--line-soft); cursor: default; }
 .btn.danger { background: transparent; color: var(--fail-fg); border-color: color-mix(in srgb, var(--fail-fg) 45%, transparent); }
 .btn:focus-visible { outline: 2px solid var(--accent2); outline-offset: 2px; }
 .copybtn { font: inherit; font-family: var(--mono); font-size: 10.5px; color: var(--muted); background: var(--surface-2); border: 1px solid var(--line); border-radius: 6px; padding: 3px 8px; cursor: pointer; display: inline-flex; align-items: center; gap: 5px; }
@@ -463,9 +464,7 @@ details[open] .caret { transform: rotate(90deg); }
 .section-label { font-size: 11px; letter-spacing: .04em; text-transform: uppercase; color: var(--muted); border-top: 1px solid var(--line-soft); padding-top: 10px; margin: 6px 0 8px; }
 
 /* ---- Wizard (component/resiliency builders) ---- */
-/* Monochrome primary button — deliberately NOT the green .btn.primary. */
-.btn.mono { background: var(--text); color: var(--bg); border-color: transparent; }
-.btn.mono:disabled { opacity: .45; cursor: default; }
+/* Wizard/builder actions use the transparent .btn.ghost style (see above). */
 .wizard { display: flex; flex-direction: column; gap: 18px; }
 .stepper { display: flex; flex-wrap: wrap; gap: 8px; }
 .stepper .step { font-family: var(--mono); font-size: 11px; letter-spacing: .06em; text-transform: uppercase; color: var(--muted); border: 1px solid var(--line); border-radius: 999px; padding: 4px 11px; }

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -461,3 +461,16 @@ details[open] .caret { transform: rotate(90deg); }
 .field-err { color: var(--fail-fg); font-size: 11px; margin-top: 2px; }
 .field-row { display: flex; align-items: center; gap: 8px; }
 .section-label { font-size: 11px; letter-spacing: .04em; text-transform: uppercase; color: var(--muted); border-top: 1px solid var(--line-soft); padding-top: 10px; margin: 6px 0 8px; }
+
+/* ---- Wizard (component/resiliency builders) ---- */
+/* Monochrome primary button — deliberately NOT the green .btn.primary. */
+.btn.mono { background: var(--text); color: var(--bg); border-color: transparent; }
+.btn.mono:disabled { opacity: .45; cursor: default; }
+.wizard { display: flex; flex-direction: column; gap: 18px; }
+.stepper { display: flex; flex-wrap: wrap; gap: 8px; }
+.stepper .step { font-family: var(--mono); font-size: 11px; letter-spacing: .06em; text-transform: uppercase; color: var(--muted); border: 1px solid var(--line); border-radius: 999px; padding: 4px 11px; }
+.stepper .step.active { color: var(--text); border-color: var(--faint); background: var(--surface-2); }
+.stepper .step.done { color: var(--accent2); }
+.wizard-body { min-height: 120px; }
+.stepnav { display: flex; justify-content: space-between; gap: 10px; }
+.stepnav .spacer { flex: 1; }

--- a/web/src/types/builders.test.ts
+++ b/web/src/types/builders.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { defaultComponentSpec } from './component'
+import { defaultResiliencyConfig } from './resiliency'
+
+describe('defaultComponentSpec', () => {
+  it('returns a v1alpha1 Component skeleton', () => {
+    const c = defaultComponentSpec()
+    expect(c.apiVersion).toBe('dapr.io/v1alpha1')
+    expect(c.kind).toBe('Component')
+    expect(c.metadata).toEqual({ name: '', namespace: 'default' })
+    expect(c.scopes).toEqual([])
+    expect(c.spec).toEqual({ type: '', version: '', metadata: [] })
+  })
+  it('returns a fresh object each call (no shared refs)', () => {
+    const a = defaultComponentSpec()
+    const b = defaultComponentSpec()
+    expect(a.spec.metadata).not.toBe(b.spec.metadata)
+  })
+})
+
+describe('defaultResiliencyConfig', () => {
+  it('returns a v1alpha1 Resiliency skeleton with empty policy/target maps', () => {
+    const r = defaultResiliencyConfig()
+    expect(r.apiVersion).toBe('dapr.io/v1alpha1')
+    expect(r.kind).toBe('Resiliency')
+    expect(r.metadata).toEqual({ name: '', namespace: '' })
+    expect(r.spec.policies).toEqual({ timeouts: {}, retries: {}, circuitBreakers: {} })
+    expect(r.spec.targets).toEqual({ apps: {}, actors: {}, components: {} })
+  })
+})

--- a/web/src/types/builders.test.ts
+++ b/web/src/types/builders.test.ts
@@ -23,7 +23,7 @@ describe('defaultResiliencyConfig', () => {
     const r = defaultResiliencyConfig()
     expect(r.apiVersion).toBe('dapr.io/v1alpha1')
     expect(r.kind).toBe('Resiliency')
-    expect(r.metadata).toEqual({ name: '', namespace: '' })
+    expect(r.metadata).toEqual({ name: '', namespace: 'default' })
     expect(r.spec.policies).toEqual({ timeouts: {}, retries: {}, circuitBreakers: {} })
     expect(r.spec.targets).toEqual({ apps: {}, actors: {}, components: {} })
   })

--- a/web/src/types/component.ts
+++ b/web/src/types/component.ts
@@ -1,0 +1,27 @@
+export interface ComponentMetadataItem {
+  name: string
+  value?: string | number | boolean
+  secretKeyRef?: { name: string; key: string }
+}
+
+export interface ComponentSpec {
+  apiVersion: string
+  kind: string
+  metadata: { name: string; namespace: string; [key: string]: unknown }
+  scopes: string[]
+  spec: {
+    type: string
+    version: string
+    metadata: ComponentMetadataItem[]
+  }
+}
+
+export function defaultComponentSpec(): ComponentSpec {
+  return {
+    apiVersion: 'dapr.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: '', namespace: 'default' },
+    scopes: [],
+    spec: { type: '', version: '', metadata: [] },
+  }
+}

--- a/web/src/types/metadata.ts
+++ b/web/src/types/metadata.ts
@@ -7,7 +7,15 @@ export interface MetadataField {
   default?: string
   example?: string
   allowedValues?: string[]
+  isCert?: boolean
+  binding?: { input?: boolean; output?: boolean }
   url?: { title: string; url: string }
+}
+
+export interface AuthenticationProfile {
+  title: string
+  description?: string
+  metadata: MetadataField[]
 }
 
 export interface ComponentMetadataSchema {
@@ -18,6 +26,7 @@ export interface ComponentMetadataSchema {
   status: string
   description?: string
   metadata?: MetadataField[]
+  authenticationProfiles?: AuthenticationProfile[]
 }
 
 export interface MetadataBundle {

--- a/web/src/types/resiliency.ts
+++ b/web/src/types/resiliency.ts
@@ -1,0 +1,68 @@
+export interface RetryPolicy {
+  policy?: 'constant' | 'exponential'
+  duration?: string
+  maxRetries?: number
+  maxInterval?: string
+  matching?: { httpStatusCodes?: string; grpcStatusCodes?: string }
+}
+
+export interface CircuitBreakerPolicy {
+  maxRequests?: number
+  timeout?: string
+  trip?: string
+  interval?: string
+}
+
+export type TimeoutPolicy = { [name: string]: string }
+
+export interface Policies {
+  timeouts: TimeoutPolicy
+  retries: { [name: string]: RetryPolicy }
+  circuitBreakers: { [name: string]: CircuitBreakerPolicy }
+}
+
+export interface AppTarget {
+  timeout?: string
+  retry?: string
+  circuitBreaker?: string
+}
+
+export interface ActorTarget {
+  timeout?: string
+  retry?: string
+  circuitBreaker?: string
+  circuitBreakerScope?: 'type' | 'id' | 'both' | ''
+  circuitBreakerCacheSize?: number
+}
+
+export interface ComponentTarget {
+  outbound?: { timeout?: string; retry?: string; circuitBreaker?: string }
+  inbound?: { timeout?: string; retry?: string; circuitBreaker?: string }
+}
+
+export interface Targets {
+  apps?: { [name: string]: AppTarget }
+  actors?: { [name: string]: ActorTarget }
+  components?: { [name: string]: ComponentTarget }
+}
+
+export interface DaprResiliency {
+  apiVersion: string
+  kind: string
+  metadata: { name: string; namespace?: string; [key: string]: unknown }
+  scopes: string[]
+  spec: { policies: Policies; targets: Targets }
+}
+
+export function defaultResiliencyConfig(): DaprResiliency {
+  return {
+    apiVersion: 'dapr.io/v1alpha1',
+    kind: 'Resiliency',
+    metadata: { name: '', namespace: '' },
+    scopes: [],
+    spec: {
+      policies: { timeouts: {}, retries: {}, circuitBreakers: {} },
+      targets: { apps: {}, actors: {}, components: {} },
+    },
+  }
+}

--- a/web/src/types/resiliency.ts
+++ b/web/src/types/resiliency.ts
@@ -58,7 +58,7 @@ export function defaultResiliencyConfig(): DaprResiliency {
   return {
     apiVersion: 'dapr.io/v1alpha1',
     kind: 'Resiliency',
-    metadata: { name: '', namespace: '' },
+    metadata: { name: '', namespace: 'default' },
     scopes: [],
     spec: {
       policies: { timeouts: {}, retries: {}, circuitBreakers: {} },


### PR DESCRIPTION
## Summary

Adds two YAML **builders** to the dev-dashboard web app, ported/adapted from cloudgrid, plus a round of resiliency-builder enhancements.

### Component Builder (`/components/new`)
4-step wizard (Type → Auth → Configure → Preview) that generates a Dapr Component YAML to copy/download. Type-filter category chips, removable optional fields, secret-vs-value metadata handling, shared editable `YamlPreview` finalizer.

### Resiliency Builder (`/resiliency/new`)
Wizard (General → Policies → Targets → Preview) that generates a Dapr Resiliency YAML. Timeouts/retries/circuit-breakers, app/actor/component targets, go-duration & status-code validation.

### Resiliency Builder enhancements (this round)
- **Namespace defaults to `default`** (still omitted from YAML if cleared).
- **Real, editable default values** in dialogs (timeout `5s`; circuit breaker `maxRequests 1` / `timeout 45s` / `trip consecutiveFailures >= 5` / `interval 8s`).
- **Editable chips** — click any policy or target chip to edit it; rename = remove-old + upsert-new.
- **Default policy overrides** — new "Default policy overrides" section for the 4 reserved `DaprBuiltIn*` retry presets (prefilled with Dapr's documented defaults, name locked). Targets step can be completed with an override alone (no explicit target), and exponential presets preserve their `duration`.

### Shared foundation
`lib/yaml-emit`, `lib/validation`, `lib/download`, `components/form/*`, `components/wizard/*`, `components/YamlPreview`, and `types/component` + `types/resiliency`.

## Testing
- `npx tsc -b` clean; full web suite **449 tests / 68 files** passing.
- TDD throughout; each task independently spec+quality reviewed, plus a final whole-branch review (verdict: ready to merge, no Critical/Important findings).

## Notes
Design specs and implementation plans live under `docs/superpowers/{specs,plans}/`. A few cosmetic polish items (unused `chip-edit` CSS hook, a CB timeout placeholder `30s` vs default `45s`) were deferred as non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
