### PR TITLE
fix(web): keep untimestamped log lines at top; narrow source column

### DIFF
--- a/web/src/pages/Logs.test.tsx
+++ b/web/src/pages/Logs.test.tsx
@@ -405,6 +405,46 @@ describe('Logs', () => {
     expect(daprdIdx).toBeLessThan(appIdx)
   })
 
+  // Regression: untimestamped daprd startup banner lines (no clock token) must
+  // stay anchored where they arrived — at the TOP — instead of sorting to the
+  // bottom because parseLogTime returns Infinity for them.
+  it('F2 — untimestamped startup banner stays at the top, not the bottom', async () => {
+    server.use(
+      http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+      http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+    )
+
+    renderAt('/logs?app=order&source=both')
+
+    await waitFor(() => expect(FakeES.instances).toHaveLength(2))
+
+    const daprdES = FakeES.instances.find(es => es.url.includes('source=daprd'))
+    const appES = FakeES.instances.find(es => es.url.includes('source=app'))
+
+    // daprd emits its untimestamped startup banner first, THEN timestamped logs
+    act(() => {
+      daprdES!.onmessage?.({ data: "You're up and running! Dapr logs will appear here." })
+      daprdES!.onmessage?.({ data: 'Updating metadata for app command: dotnet run' })
+      daprdES!.onmessage?.({ data: '12:04:50.980 level=info daprd-real-log' })
+      appES!.onmessage?.({ data: '12:04:51.300 level=info app-real-log' })
+    })
+
+    await screen.findByText(/up and running/)
+    await screen.findByText(/daprd-real-log/)
+
+    const rows = document.querySelectorAll('.logrow')
+    const texts = Array.from(rows).map(r => r.querySelector('.lmsg')?.textContent ?? '')
+    const bannerIdx = texts.findIndex(t => t.includes('up and running'))
+    const metaIdx = texts.findIndex(t => t.includes('Updating metadata'))
+    const realIdx = texts.findIndex(t => t.includes('daprd-real-log'))
+    expect(bannerIdx).toBeGreaterThanOrEqual(0)
+    expect(realIdx).toBeGreaterThanOrEqual(0)
+    // Banner + metadata lines (no timestamp, arrived first) must sort ABOVE the
+    // timestamped log, and keep their own arrival order.
+    expect(bannerIdx).toBeLessThan(metaIdx)
+    expect(metaIdx).toBeLessThan(realIdx)
+  })
+
   // F3: dynamic subtitle
   it('F3 — subtitle shows "daprd + application" for source=both', async () => {
     server.use(

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -15,6 +15,31 @@ interface MergedLine {
   src: 'daprd' | 'app'
   /** Arrival index across the merged list — used as tiebreaker when timestamps match */
   arrival: number
+  /**
+   * Effective time used for chronological sorting. A line without its own clock
+   * token inherits the last timestamp seen earlier in the SAME stream so it stays
+   * anchored to its neighbours (e.g. the daprd startup banner). Leading lines with
+   * no prior timestamp get -Infinity so they sort to the top rather than the bottom.
+   */
+  sortTime: number
+}
+
+/**
+ * Tag one stream's lines with source, arrival index, and a carry-forward sortTime.
+ * Lines are assumed to be in arrival (chronological) order within the stream.
+ */
+function tagStream(
+  lines: LogLine[],
+  src: 'daprd' | 'app',
+  arrivalBase: number,
+  arrivalStep: number,
+): MergedLine[] {
+  let last = -Infinity
+  return lines.map((line, i) => {
+    const t = parseLogTime(line.text)
+    if (Number.isFinite(t)) last = t
+    return { line, src, arrival: arrivalBase + i * arrivalStep, sortTime: last }
+  })
 }
 
 /** Extract a timestamp token from a log line, returning an empty string if none found. */
@@ -104,28 +129,20 @@ function LogViewerCore({
   // Build the merged list chronologically
   const merged: MergedLine[] = useMemo(() => {
     if (source === 'daprd') {
-      return daprdResult.lines.map((line, i) => ({ line, src: 'daprd' as const, arrival: i }))
+      return tagStream(daprdResult.lines, 'daprd', 0, 1)
     }
     if (source === 'app') {
-      return appResult.lines.map((line, i) => ({ line, src: 'app' as const, arrival: i }))
+      return tagStream(appResult.lines, 'app', 0, 1)
     }
-    // 'both': tag each stream's lines, merge and sort chronologically
-    const dLines: MergedLine[] = daprdResult.lines.map((line, i) => ({
-      line,
-      src: 'daprd' as const,
-      arrival: i * 2,       // interleave arrival order so equal timestamps retain stream order
-    }))
-    const aLines: MergedLine[] = appResult.lines.map((line, i) => ({
-      line,
-      src: 'app' as const,
-      arrival: i * 2 + 1,
-    }))
+    // 'both': tag each stream's lines, merge and sort chronologically.
+    // Interleave arrival order (daprd even, app odd) so equal timestamps retain stream order.
+    const dLines = tagStream(daprdResult.lines, 'daprd', 0, 2)
+    const aLines = tagStream(appResult.lines, 'app', 1, 2)
     const all = [...dLines, ...aLines]
-    // Stable sort: primary key = parsed timestamp (ms since midnight), secondary = arrival
+    // Stable sort: primary key = effective (carry-forward) timestamp, secondary = arrival.
+    // Guard against Infinity/-Infinity subtraction (which yields NaN) via the equality check.
     all.sort((a, b) => {
-      const ta = parseLogTime(a.line.text)
-      const tb = parseLogTime(b.line.text)
-      if (ta !== tb) return ta - tb
+      if (a.sortTime !== b.sortTime) return a.sortTime - b.sortTime
       return a.arrival - b.arrival
     })
     // Apply line cap after merge

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -269,7 +269,7 @@ pre.code { margin: 0; padding: 14px; font-family: var(--mono); font-size: 12px; 
 .followbtn .d { width: 8px; height: 8px; border-radius: 50%; background: var(--done-fg); animation: beat 2.4s ease-out infinite; }
 .followbtn.on { color: var(--text); border-color: color-mix(in srgb, var(--done-fg) 45%, transparent); }
 .logwin { background: var(--surface); border: 1px solid var(--line); border-radius: 12px; box-shadow: var(--shadow); overflow: auto; max-height: 60vh; }
-.logrow { display: grid; grid-template-columns: 104px 60px 124px 1fr; gap: 12px; padding: 4px 14px; border-bottom: 1px solid var(--line-soft); align-items: baseline; font-family: var(--mono); font-size: 12px; line-height: 1.5; }
+.logrow { display: grid; grid-template-columns: 104px 60px 62px 1fr; gap: 12px; padding: 4px 14px; border-bottom: 1px solid var(--line-soft); align-items: baseline; font-family: var(--mono); font-size: 12px; line-height: 1.5; }
 .logrow:hover { background: var(--surface-2); }
 .logrow:last-child { border-bottom: none; }
 .ltime { color: var(--faint); white-space: nowrap; }


### PR DESCRIPTION
## Summary

Two fixes to the **Logs** page:

1. **Untimestamped log lines no longer sink to the bottom.** In the merged (`daprd + app`) view, lines were sorted by a timestamp parsed out of the line text. Lines with no clock token — the daprd startup banner (blank line, `You're up and running!`, `Updating metadata for app command/PID`) — got `Infinity` from `parseLogTime` and sorted *after* every timestamped line, ending up at the bottom despite being emitted first.

   Each line now gets a **carry-forward `sortTime`**: a line without its own timestamp inherits the last timestamp seen earlier in the same stream, so it stays anchored to its chronological neighbours. Leading untimestamped lines get `-Infinity` so the startup banner sorts to the **top**. The comparator uses an equality guard before subtracting to avoid `Infinity - Infinity = NaN`.

2. **Narrowed the log source (`.lsrc`) column** from `124px` to `62px` — it only ever holds `daprd`/`app`. The extra space goes to the message column.

## Testing

- Added a regression test asserting the startup banner + metadata lines sort above timestamped logs and keep their arrival order.
- `npx tsc -b` clean; full suite green (348 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)