### PR TITLE
feat(web): wizard stepper arrows + resiliency policy dividers

### DIFF
--- a/web/src/components/wizard/Stepper.tsx
+++ b/web/src/components/wizard/Stepper.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react'
+
 interface StepperProps {
   steps: { label: string }[]
   activeStep: number
@@ -7,14 +9,20 @@ export function Stepper({ steps, activeStep }: StepperProps) {
   return (
     <div className="stepper" role="list" aria-label="Wizard steps">
       {steps.map((s, i) => (
-        <span
-          key={s.label}
-          role="listitem"
-          aria-current={i === activeStep ? 'step' : undefined}
-          className={`step${i === activeStep ? ' active' : ''}${i < activeStep ? ' done' : ''}`}
-        >
-          {s.label}
-        </span>
+        <Fragment key={s.label}>
+          {i > 0 && (
+            <span className="step-arrow" aria-hidden="true">
+              →
+            </span>
+          )}
+          <span
+            role="listitem"
+            aria-current={i === activeStep ? 'step' : undefined}
+            className={`step${i === activeStep ? ' active' : ''}${i < activeStep ? ' done' : ''}`}
+          >
+            {s.label}
+          </span>
+        </Fragment>
       ))}
     </div>
   )

--- a/web/src/pages/resiliency-builder/NamedList.tsx
+++ b/web/src/pages/resiliency-builder/NamedList.tsx
@@ -16,7 +16,7 @@ export function NamedList({ title, names, onAdd, onRemove, onEdit }: NamedListPr
         </button>
       </div>
       {names.length === 0 ? (
-        <p className="none">None yet.</p>
+        <p className="none">-</p>
       ) : (
         names.map((name) => (
           <div key={name} className="chip k" style={{ marginRight: 6, marginBottom: 6 }}>

--- a/web/src/pages/resiliency-builder/StepPolicies.tsx
+++ b/web/src/pages/resiliency-builder/StepPolicies.tsx
@@ -20,7 +20,7 @@ export function StepPolicies({ state, dispatch }: { state: ResiliencyState; disp
   }
 
   return (
-    <div>
+    <div className="policy-sections">
       <NamedList title="Timeouts" names={Object.keys(pol.timeouts)}
         onAdd={() => setOpen({ kind: 'timeout' })}
         onEdit={(name) => setOpen({ kind: 'timeout', editName: name })}
@@ -36,7 +36,7 @@ export function StepPolicies({ state, dispatch }: { state: ResiliencyState; disp
 
       <div className="sbsection">
         <div className="sech">Default policy overrides</div>
-        <p className="none" style={{ marginTop: 0 }}>&#9888; These override Dapr's built-in retry behavior globally.</p>
+        <p className="sub" style={{ marginTop: 0 }}>&#9888; These override Dapr's built-in retry behavior globally.</p>
         {DEFAULT_DAPR_RETRY_POLICIES.map((preset) => {
           const exists = pol.retries[preset.label] !== undefined
           return exists ? (

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -84,6 +84,7 @@ body {
 .app.collapsed .sbscroll { display: none; }
 .sbsection { margin-top: 12px; }
 .sbsection:first-child { margin-top: 6px; }
+.policy-sections > .sbsection + .sbsection { margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--line-soft); }
 .sbtitle { font-family: var(--mono); font-size: 9.5px; letter-spacing: .15em; text-transform: uppercase; color: var(--muted); padding: 5px 10px 4px; white-space: nowrap; }
 .sblink { display: flex; align-items: center; gap: 10px; padding: 7px 10px; border-radius: 7px; color: var(--text); text-decoration: none; font-size: 13px; line-height: 1.3; white-space: nowrap; }
 .sblink:hover { background: var(--surface-2); }
@@ -138,6 +139,7 @@ body {
 .page { max-width: 1240px; margin: 0 auto; padding: clamp(16px, 3vw, 30px); }
 .phead { display: flex; align-items: flex-end; justify-content: space-between; gap: 16px; flex-wrap: wrap; margin-bottom: 18px; }
 .phead h1 { margin: 0; font-size: 22px; font-weight: 680; letter-spacing: -.01em; }
+.sub { color: var(--muted); font-size: 13px; }
 .phead .sub { color: var(--muted); font-size: 13px; margin-top: 4px; }
 .live { display: inline-flex; align-items: center; gap: 7px; color: var(--muted); font-size: 12px; font-family: var(--mono); }
 .live .beat { width: 8px; height: 8px; border-radius: 50%; background: var(--accent-bright); animation: beat 2.4s ease-out infinite; }
@@ -466,10 +468,11 @@ details[open] .caret { transform: rotate(90deg); }
 /* ---- Wizard (component/resiliency builders) ---- */
 /* Wizard/builder actions use the transparent .btn.ghost style (see above). */
 .wizard { display: flex; flex-direction: column; gap: 18px; }
-.stepper { display: flex; flex-wrap: wrap; gap: 8px; }
+.stepper { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; padding-bottom: 14px; border-bottom: 1px solid var(--line-soft); }
 .stepper .step { font-family: var(--mono); font-size: 11px; letter-spacing: .06em; text-transform: uppercase; color: var(--muted); border: 1px solid var(--line); border-radius: 999px; padding: 4px 11px; }
 .stepper .step.active { color: var(--text); border-color: var(--faint); background: var(--surface-2); }
 .stepper .step.done { color: var(--accent2); }
+.stepper .step-arrow { font-family: var(--mono); font-size: 12px; line-height: 1; color: var(--faint); user-select: none; }
 .wizard-body { min-height: 120px; }
 .stepnav { display: flex; justify-content: space-between; gap: 10px; }
 .stepnav .spacer { flex: 1; }


### PR DESCRIPTION
## Summary

UX polish for the component/resiliency builder wizards and the resiliency policies step.

- **Stepper**: decorative `→` arrows (aria-hidden) between step pills, plus a horizontal divider under the step row, so the flow reads clearly as a multi-step wizard. Shared component → applies to both the component and resiliency builders.
- **Resiliency policies step**: horizontal dividers between **Timeouts**, **Retries**, **Circuit breakers**, and **Default policy overrides**. Scoped via a new `.policy-sections` wrapper so other `.sbsection` usages are unaffected.
- Empty-state text `None yet.` replaced with a dash `-`.
- The built-in-retry override warning now uses a `.sub` paragraph; added a base `.sub` rule for the muted-subtitle style (more specific `.phead .sub` / `.sblink .col .sub` still win where they apply).

## Testing

- `vitest` — wizard + resiliency builder suites pass (46 tests).
- `tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)