### PR TITLE
Resources sidebar: add Community/Dapr Support, reorder sections, move news bell

### DIFF
--- a/web/src/components/ResourcesSidebar.test.tsx
+++ b/web/src/components/ResourcesSidebar.test.tsx
@@ -103,10 +103,34 @@ describe('ResourcesSidebar static links', () => {
   it('renders section titles', () => {
     renderSidebar()
     // sbtitle elements (CSS uppercases them, but text content is mixed case)
+    expect(screen.getByText('Community')).toBeInTheDocument()
     expect(screen.getByText('Build')).toBeInTheDocument()
     expect(screen.getByText('Learn')).toBeInTheDocument()
     expect(screen.getByText('Read')).toBeInTheDocument()
     expect(screen.getByText('Run & Operate')).toBeInTheDocument()
+  })
+
+  it('renders Dapr Discord link under Community', () => {
+    renderSidebar()
+    const link = screen.getByRole('link', { name: /Dapr Discord/ })
+    expect(link).toHaveAttribute('href', 'https://diagrid.ws/dev-dashboard-dapr-discord')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders Dapr Support link under Run & Operate', () => {
+    renderSidebar()
+    const link = screen.getByRole('link', { name: /Dapr Support/ })
+    expect(link).toHaveAttribute('href', 'https://diagrid.ws/dev-dashboard-dapr-support')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('orders sections Community, Read, Learn, Build, Run & Operate, News', async () => {
+    renderSidebar()
+    await screen.findByRole('link', { name: /Blog A/i })
+    const titles = Array.from(document.querySelectorAll('.sbtitle')).map((el) => el.textContent)
+    expect(titles).toEqual(['Community', 'Read', 'Learn', 'Build', 'Run & Operate', 'News'])
   })
 })
 

--- a/web/src/components/ResourcesSidebar.tsx
+++ b/web/src/components/ResourcesSidebar.tsx
@@ -38,10 +38,14 @@ interface Section {
 
 const SECTIONS: Section[] = [
   {
-    heading: 'Build',
+    heading: 'Community',
+    links: [{ label: 'Dapr Discord', href: 'https://diagrid.ws/dev-dashboard-dapr-discord' }],
+  },
+  {
+    heading: 'Read',
     links: [
-      { label: 'Dapr Workflow Skills', href: 'https://diagrid.ws/dev-dashboard-workflow-skill' },
-      { label: 'Dapr Composer', href: 'https://diagrid.ws/dev-dashboard-workflow-composer' },
+      { label: 'Dapr Docs', href: 'https://diagrid.ws/dev-dashboard-dapr-docs' },
+      { label: 'Diagrid Docs', href: 'https://diagrid.ws/dev-dashboard-diagrid-docs' },
     ],
   },
   {
@@ -52,15 +56,18 @@ const SECTIONS: Section[] = [
     ],
   },
   {
-    heading: 'Read',
+    heading: 'Build',
     links: [
-      { label: 'Dapr Docs', href: 'https://diagrid.ws/dev-dashboard-dapr-docs' },
-      { label: 'Diagrid Docs', href: 'https://diagrid.ws/dev-dashboard-diagrid-docs' },
+      { label: 'Dapr Workflow Skills', href: 'https://diagrid.ws/dev-dashboard-workflow-skill' },
+      { label: 'Dapr Composer', href: 'https://diagrid.ws/dev-dashboard-workflow-composer' },
     ],
   },
   {
     heading: 'Run & Operate',
-    links: [{ label: 'Diagrid Catalyst', href: 'https://diagrid.ws/dev-dashboard-try-catalyst' }],
+    links: [
+      { label: 'Diagrid Catalyst', href: 'https://diagrid.ws/dev-dashboard-try-catalyst' },
+      { label: 'Dapr Support', href: 'https://diagrid.ws/dev-dashboard-dapr-support' },
+    ],
   },
 ]
 
@@ -102,7 +109,18 @@ interface NewsSectionProps {
 function NewsSection({ news, onMarkSeen }: NewsSectionProps) {
   return (
     <div className="sbsection">
-      <div className="sbtitle">News</div>
+      <div className="sbtitle newstitle">
+        <span>News</span>
+        {/* Bell visible when panel is open + has-new (CSS-controlled via .app.has-new) */}
+        <button
+          className="bellbtn"
+          id="bell-h"
+          onClick={onMarkSeen}
+          aria-label="Mark news as seen"
+        >
+          <BellIcon />
+        </button>
+      </div>
       {NEWS_SLOTS.map(({ key, label }) => {
         const item = news[key]
         if (!item) return null
@@ -168,16 +186,6 @@ export function ResourcesSidebar({ collapsed, onCollapsedChange, hasNew, onHasNe
   return (
     <aside className="sidebar" aria-label="Resources">
       <div className="sbhead">
-        {/* Bell visible when expanded + has-new (CSS-controlled via .app.has-new) */}
-        <button
-          className="bellbtn"
-          id="bell-h"
-          onClick={handleMarkSeen}
-          aria-label="Mark news as seen"
-        >
-          <BellIcon />
-          <span className="badge" />
-        </button>
         <span className="lbl">Resources</span>
         <button
           className="sbtoggle"
@@ -191,9 +199,6 @@ export function ResourcesSidebar({ collapsed, onCollapsedChange, hasNew, onHasNe
       </div>
 
       <nav className="sbscroll">
-        {/* News section */}
-        {news && <NewsSection news={news} onMarkSeen={handleMarkSeen} />}
-
         {SECTIONS.map((section) => (
           <div key={section.heading} className="sbsection">
             <div className="sbtitle">{section.heading}</div>
@@ -211,6 +216,9 @@ export function ResourcesSidebar({ collapsed, onCollapsedChange, hasNew, onHasNe
             ))}
           </div>
         ))}
+
+        {/* News section */}
+        {news && <NewsSection news={news} onMarkSeen={handleMarkSeen} />}
       </nav>
 
       {/* Collapsed vertical panel */}
@@ -222,7 +230,6 @@ export function ResourcesSidebar({ collapsed, onCollapsedChange, hasNew, onHasNe
           aria-label="Mark news as seen"
         >
           <BellIcon />
-          <span className="badge" />
         </button>
         <span
           className="vtext"

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -86,6 +86,7 @@ body {
 .sbsection:first-child { margin-top: 6px; }
 .policy-sections > .sbsection + .sbsection { margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--line-soft); }
 .sbtitle { font-family: var(--mono); font-size: 9.5px; letter-spacing: .15em; text-transform: uppercase; color: var(--muted); padding: 5px 10px 4px; white-space: nowrap; }
+.sbtitle.newstitle { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .sblink { display: flex; align-items: center; gap: 10px; padding: 7px 10px; border-radius: 7px; color: var(--text); text-decoration: none; font-size: 13px; line-height: 1.3; white-space: nowrap; }
 .sblink:hover { background: var(--surface-2); }
 .sblink:focus-visible { outline: 2px solid var(--accent2); outline-offset: -2px; }
@@ -104,7 +105,6 @@ body {
 .bellbtn { display: none; position: relative; background: transparent; border: none; cursor: pointer; color: var(--muted); padding: 2px; line-height: 0; }
 .bellbtn:hover { color: var(--text); }
 .bellbtn .bellico { display: block; }
-.bellbtn .badge { position: absolute; top: -1px; right: -1px; width: 7px; height: 7px; border-radius: 50%; background: var(--accent2); box-shadow: 0 0 0 2px var(--surface); }
 .app.has-new:not(.collapsed) #bell-h { display: inline-flex; }
 .app.has-new.collapsed #bell-v { display: inline-flex; }
 .sbvert { display: none; }


### PR DESCRIPTION
## Summary
- Add a **COMMUNITY** section (Dapr Discord) and a **Dapr Support** link under **RUN & OPERATE**.
- Reorder sidebar sections to: Community → Read → Learn → Build → Run & Operate → News.
- Move the unseen-news bell indicator from the sidebar header to the right side of the **NEWS** section title (only shown when the panel is expanded and there's unseen news); the collapsed-panel bell position is unchanged.
- Remove the redundant green dot from the bell icon (from a prior change) — the bell's presence alone signals unseen news.

## Test plan
- [x] `npx vitest run src/components/ResourcesSidebar.test.tsx` — 32/32 passing
- [x] Rendered the actual sidebar markup/CSS in a headless browser to visually confirm section order and bell placement next to "NEWS"