### PR TITLE
fix(discovery): fall back to run template path basename when name is unset

### DIFF
--- a/pkg/discovery/metadata.go
+++ b/pkg/discovery/metadata.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"strconv"
 )
 
@@ -69,6 +70,21 @@ type rawMetadata struct {
 	} `json:"actorRuntime"`
 }
 
+// runTemplateFromExtended returns the run template's display name. The
+// CLI's "runTemplateName" is the run template YAML's optional top-level
+// `name` field, which is commonly left unset; in that case fall back to the
+// basename of "runTemplatePath" (the absolute path to the template file,
+// always set by the CLI when apps are started via `dapr run -f`).
+func runTemplateFromExtended(extended map[string]string) string {
+	if name := extended["runTemplateName"]; name != "" {
+		return name
+	}
+	if path := extended["runTemplatePath"]; path != "" {
+		return filepath.Base(path)
+	}
+	return ""
+}
+
 // FetchMetadata queries a sidecar's /v1.0/metadata endpoint.
 func FetchMetadata(ctx context.Context, client *http.Client, httpPort int) (Metadata, error) {
 	url := fmt.Sprintf("http://127.0.0.1:%d/v1.0/metadata", httpPort)
@@ -109,7 +125,7 @@ func FetchMetadata(ctx context.Context, client *http.Client, httpPort int) (Meta
 		AppCommand:      raw.Extended["appCommand"],
 		AppLogPath:      raw.Extended["appLogPath"],
 		DaprdLogPath:    raw.Extended["daprdLogPath"],
-		RunTemplate:     raw.Extended["runTemplateName"],
+		RunTemplate:     runTemplateFromExtended(raw.Extended),
 		Actors:          raw.Actors,
 		Components:      raw.Components,
 		Subscriptions:   subs,

--- a/pkg/discovery/metadata_test.go
+++ b/pkg/discovery/metadata_test.go
@@ -63,3 +63,29 @@ func TestFetchMetadata(t *testing.T) {
 	require.Equal(t, "go run ./cmd/order", md.AppCommand)
 	require.Equal(t, "dapr.yaml", md.RunTemplate)
 }
+
+func TestFetchMetadataRunTemplateFallsBackToPathBasename(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"order","extended":{"runTemplateName":"","runTemplatePath":"/home/dev/myapp/dapr.yaml"}}`))
+	}))
+	t.Cleanup(srv.Close)
+	u, _ := url.Parse(srv.URL)
+	port, _ := strconv.Atoi(u.Port())
+
+	md, err := FetchMetadata(context.Background(), &http.Client{Timeout: 2 * time.Second}, port)
+	require.NoError(t, err)
+	require.Equal(t, "dapr.yaml", md.RunTemplate)
+}
+
+func TestFetchMetadataRunTemplateEmptyWhenNeitherFieldSet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"order","extended":{}}`))
+	}))
+	t.Cleanup(srv.Close)
+	u, _ := url.Parse(srv.URL)
+	port, _ := strconv.Atoi(u.Port())
+
+	md, err := FetchMetadata(context.Background(), &http.Client{Timeout: 2 * time.Second}, port)
+	require.NoError(t, err)
+	require.Equal(t, "", md.RunTemplate)
+}


### PR DESCRIPTION
## Summary
- The Applications page RUN TEMPLATE card showed `—` for standalone multi-app runs whenever the run template YAML omitted its optional top-level `name` field (the common case) — daprd's `runTemplateName` extended metadata ends up empty in that scenario.
- `pkg/discovery/metadata.go` now falls back to the basename of `runTemplatePath` (always set by the CLI to the template file's absolute path) when `runTemplateName` is empty.

## Test plan
- [x] Added `TestFetchMetadataRunTemplateFallsBackToPathBasename` and `TestFetchMetadataRunTemplateEmptyWhenNeitherFieldSet` in `pkg/discovery/metadata_test.go`
- [x] `go test ./pkg/discovery/... -tags unit` passes (pre-existing, unrelated `TestDcpSessionDir` Windows path-separator failures confirmed present on `main` too)
- [x] `go build ./...` and `go vet ./pkg/discovery/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)