### PR TITLE
fix: first batch of code-review fixes (race, CSRF, builder state, bulk purge)

### DIFF
--- a/cmd/connpool.go
+++ b/cmd/connpool.go
@@ -115,7 +115,18 @@ func (p *connPool) evict(c statestore.Component) {
 		delete(p.slots, id)
 	}
 	p.mu.Unlock()
-	if ok && slot.store != nil {
+	if !ok {
+		return
+	}
+	// Fix 3: an open may still be in flight for this slot — openOrGet writes
+	// slot.store outside the lock, after its Fix 1 re-check. Wait for the open
+	// to finish (as Close does) before reading slot.store; otherwise we race
+	// with that write and, if we observe nil, leak the freshly opened store,
+	// which is no longer in the map for Close to reach. If the open is still
+	// before its Fix 1 re-check, it will see the slot gone, close the store
+	// itself, and close done.
+	<-slot.done
+	if slot.store != nil {
 		_ = slot.store.Close()
 	}
 }

--- a/cmd/connpool_test.go
+++ b/cmd/connpool_test.go
@@ -155,10 +155,26 @@ func TestConnPool_EvictDuringOpenClosesStore(t *testing.T) {
 		// tight spin — opens is incremented inside open(), right at entry
 	}
 
-	// Evict the slot while the open is still blocked.
-	p.evict(comp)
+	// Evict the slot while the open is still blocked. evict waits for the
+	// in-flight open to finish (Fix 3), so it must run in its own goroutine;
+	// we release the opener only once evict has removed the slot from the map,
+	// preserving the evict-before-Fix-1-check interleaving this test covers.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		p.evict(comp)
+	}()
+	id := identity(&comp)
+	for {
+		p.mu.Lock()
+		_, present := p.slots[id]
+		p.mu.Unlock()
+		if !present {
+			break
+		}
+	}
 
-	// Release the blocked open so the goroutine can finish.
+	// Release the blocked open so both goroutines can finish.
 	close(block)
 	wg.Wait()
 
@@ -175,6 +191,50 @@ func TestConnPool_EvictDuringOpenClosesStore(t *testing.T) {
 	p2 := newConnPool("default", &http.Client{}, nil, o2.open)
 	_, err := p2.openOrGet(context.Background(), comp)
 	require.NoError(t, err) // sanity: a fresh pool works normally
+}
+
+// TestConnPool_EvictDuringStoreAssignment_NoLeakNoRace exercises the other
+// evict interleaving: the opener returns successfully and openOrGet passes the
+// Fix 1 re-check, then evict runs while the unsynchronized `slot.store = st`
+// assignment (which happens outside the lock) is still pending. Without Fix 3,
+// evict read slot.store without waiting on slot.done: a data race with that
+// assignment, and — if it observed nil — a freshly opened store that is closed
+// by nobody and no longer in the map, so even Close() can't reach it.
+//
+// There is no seam between the Fix 1 check and the store assignment, so this
+// is a stress test: each iteration releases evict the moment the opener
+// returns. Whenever evict takes the lock after the Fix 1 check, its slot.store
+// read has no happens-before edge to the write, so -race flags it; the
+// close-count assertion catches the leak.
+func TestConnPool_EvictDuringStoreAssignment_NoLeakNoRace(t *testing.T) {
+	comp := compA()
+	for i := 0; i < 200; i++ {
+		o := &poolOpener{}
+		returning := make(chan struct{})
+		open := func(ctx context.Context, c statestore.Component) (statestore.Store, error) {
+			st, err := o.open(ctx, c)
+			close(returning) // signal "opener about to return"; the store write happens after this
+			return st, err
+		}
+		p := newConnPool("default", &http.Client{}, nil, open)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = p.openOrGet(context.Background(), comp)
+		}()
+
+		<-returning
+		p.evict(comp)
+		wg.Wait()
+
+		// Exactly one close, whichever side won: Fix 1 closes the fresh store
+		// if evict got there first, evict closes the cached one otherwise.
+		// Zero means the store leaked.
+		require.Equal(t, int32(1), atomic.LoadInt32(&o.closes),
+			"iteration %d: store must be closed exactly once", i)
+	}
 }
 
 // TestConnPool_OpenOrGetAfterCloseErrors verifies Fix 2: after Close() no new

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// localhostGuard hardens the loopback-only server against browser-borne
+// attacks:
+//
+//   - DNS rebinding: every request must carry a loopback Host header
+//     (localhost, 127.0.0.1, or ::1 — with or without a port). A rebinding
+//     attack resolves an attacker-controlled name to 127.0.0.1, so the Host
+//     header still names the attacker's domain and is rejected here.
+//   - CSRF: state-changing requests (POST/PUT/DELETE/PATCH) with an Origin
+//     header must originate from a loopback origin on any port (the Vite dev
+//     server runs on its own port). Requests without an Origin header (curl,
+//     CLI tools) are allowed.
+func localhostGuard(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isLoopbackHostname(stripPort(r.Host)) {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden: non-local Host header"})
+			return
+		}
+		switch r.Method {
+		case http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch:
+			if origin := r.Header.Get("Origin"); origin != "" && !isLoopbackOrigin(origin) {
+				writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden: cross-origin request"})
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// stripPort returns the host part of a Host header value, which may or may
+// not include a port (e.g. "localhost", "127.0.0.1:9090", "[::1]:8080").
+func stripPort(hostport string) string {
+	if host, _, err := net.SplitHostPort(hostport); err == nil {
+		return host
+	}
+	// No port present; unbracket a bare IPv6 literal like "[::1]".
+	return strings.TrimSuffix(strings.TrimPrefix(hostport, "["), "]")
+}
+
+// isLoopbackHostname reports whether host (no port, no brackets) is one of
+// the names the dashboard is reachable under when bound to 127.0.0.1.
+func isLoopbackHostname(host string) bool {
+	switch strings.ToLower(host) {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	}
+	return false
+}
+
+// isLoopbackOrigin reports whether an Origin header value points at a
+// loopback host on any port.
+func isLoopbackOrigin(origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	return isLoopbackHostname(u.Hostname())
+}

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -1,0 +1,114 @@
+//go:build unit
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// okHandler is the terminal handler used to observe that the guard let a
+// request through.
+var okHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+
+func guardedRequest(t *testing.T, method, host, origin string) *http.Response {
+	t.Helper()
+	req := httptest.NewRequest(method, "/api/health", nil)
+	req.Host = host
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+	rec := httptest.NewRecorder()
+	localhostGuard(okHandler).ServeHTTP(rec, req)
+	return rec.Result()
+}
+
+func TestLocalhostGuardHost(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want int
+	}{
+		{"localhost without port", "localhost", http.StatusOK},
+		{"localhost with port", "localhost:9090", http.StatusOK},
+		{"loopback IPv4 without port", "127.0.0.1", http.StatusOK},
+		{"loopback IPv4 with port", "127.0.0.1:8080", http.StatusOK},
+		{"loopback IPv6 without port", "[::1]", http.StatusOK},
+		{"loopback IPv6 with port", "[::1]:8080", http.StatusOK},
+		{"uppercase localhost", "LOCALHOST:9090", http.StatusOK},
+		{"evil host", "evil.example.com", http.StatusForbidden},
+		{"evil host with port", "evil.example.com:9090", http.StatusForbidden},
+		{"localhost subdomain of evil", "localhost.evil.example.com", http.StatusForbidden},
+		{"loopback prefix of evil", "127.0.0.1.evil.example.com", http.StatusForbidden},
+		{"empty host", "", http.StatusForbidden},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res := guardedRequest(t, http.MethodGet, tc.host, "")
+			require.Equal(t, tc.want, res.StatusCode)
+			if tc.want == http.StatusForbidden {
+				require.Equal(t, "application/json", res.Header.Get("Content-Type"))
+			}
+		})
+	}
+}
+
+func TestLocalhostGuardOrigin(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		origin string
+		want   int
+	}{
+		{"POST without Origin (curl)", http.MethodPost, "", http.StatusOK},
+		{"POST from Vite dev server", http.MethodPost, "http://localhost:5173", http.StatusOK},
+		{"POST from same origin", http.MethodPost, "http://127.0.0.1:9090", http.StatusOK},
+		{"POST from IPv6 loopback origin", http.MethodPost, "http://[::1]:9090", http.StatusOK},
+		{"POST from evil origin", http.MethodPost, "https://evil.example.com", http.StatusForbidden},
+		{"POST from evil origin with local-looking subdomain", http.MethodPost, "https://localhost.evil.example.com", http.StatusForbidden},
+		{"POST with null origin", http.MethodPost, "null", http.StatusForbidden},
+		{"PUT from evil origin", http.MethodPut, "https://evil.example.com", http.StatusForbidden},
+		{"DELETE from evil origin", http.MethodDelete, "https://evil.example.com", http.StatusForbidden},
+		{"PATCH from evil origin", http.MethodPatch, "https://evil.example.com", http.StatusForbidden},
+		{"GET ignores Origin", http.MethodGet, "https://evil.example.com", http.StatusOK},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res := guardedRequest(t, tc.method, "127.0.0.1:9090", tc.origin)
+			require.Equal(t, tc.want, res.StatusCode)
+		})
+	}
+}
+
+// TestRouterAppliesLocalhostGuard proves the guard is wired into the full
+// router, in front of the API and the SPA fallback.
+func TestRouterAppliesLocalhostGuard(t *testing.T) {
+	h := newTestRouter("")
+
+	send := func(method, path, host, origin string) *http.Response {
+		req := httptest.NewRequest(method, path, nil)
+		req.Host = host
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec.Result()
+	}
+
+	// DNS rebinding: foreign Host is rejected on API and SPA routes alike.
+	require.Equal(t, http.StatusForbidden, send(http.MethodGet, "/api/health", "evil.example.com", "").StatusCode)
+	require.Equal(t, http.StatusForbidden, send(http.MethodGet, "/workflows", "evil.example.com", "").StatusCode)
+
+	// CSRF: cross-site POST is rejected before routing.
+	require.Equal(t, http.StatusForbidden, send(http.MethodPost, "/api/workflows/purge", "127.0.0.1:9090", "https://evil.example.com").StatusCode)
+
+	// Legitimate local traffic still works.
+	require.Equal(t, http.StatusOK, send(http.MethodGet, "/api/health", "127.0.0.1:9090", "").StatusCode)
+	require.Equal(t, http.StatusOK, send(http.MethodGet, "/api/health", "[::1]:8080", "").StatusCode)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -37,6 +37,7 @@ func NewRouter(opts Options) http.Handler {
 
 	r := chi.NewRouter()
 	r.Use(middleware.Recoverer)
+	r.Use(localhostGuard)
 
 	mount := func(router chi.Router) {
 		router.Mount("/api", apiRouter(opts.Version, opts.Apps, opts.Backend, opts.Stores, opts.Resources, opts.News, opts.ControlPlane))

--- a/pkg/server/spa_test.go
+++ b/pkg/server/spa_test.go
@@ -22,6 +22,7 @@ func testFS() fstest.MapFS {
 func get(t *testing.T, h http.Handler, path string) (*http.Response, string) {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Host = "127.0.0.1:9090" // httptest defaults to example.com, which localhostGuard rejects
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 	res := rec.Result()

--- a/web/src/pages/Workflows.test.tsx
+++ b/web/src/pages/Workflows.test.tsx
@@ -681,6 +681,32 @@ describe('Workflows page — store selector', () => {
     expect(link).toHaveAttribute('href', '/workflows/order/abc?store=statestore-b')
   })
 
+  it('bulk removal sends ?store=<id> for the selected (non-active) store', async () => {
+    window.localStorage.setItem('devdash.workflowStore', 'statestore-b')
+    let capturedStore: string | null = null
+    server.use(
+      http.get('/api/statestores', () => HttpResponse.json(twoStores)),
+      http.get('/api/workflows', () =>
+        HttpResponse.json({ items: [{ appId: 'order', instanceId: 'abc', name: 'OrderWorkflow', status: 'Running', createdAt: '2026-06-29T10:00:00Z' }] }),
+      ),
+      http.post('/api/workflows/purge', ({ request }) => {
+        capturedStore = new URL(request.url).searchParams.get('store')
+        return HttpResponse.json([{ instanceId: 'abc', mechanism: 'force', ok: true }])
+      }),
+    )
+    renderAt()
+    await screen.findByRole('link', { name: 'abc' })
+    const checkboxes = document.querySelectorAll('tbody .cbx:not(.on)')
+    await userEvent.click(checkboxes[0])
+    await waitFor(() => expect(screen.getByText('1 selected')).toBeInTheDocument())
+    await userEvent.click(document.querySelector('[data-cy="bulk-remove"]') as HTMLElement)
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+    await userEvent.click(document.querySelector('[data-cy="confirm-remove"]') as HTMLElement)
+    // The purge request must target the store the page is scoped to,
+    // not fall back to the server's active store.
+    await waitFor(() => expect(capturedStore).toBe('statestore-b'))
+  })
+
   it('collapses duplicate-path stores (same name+type+connection) into one option, showing the active one', async () => {
     const dupPaths = [
       { id: 'redis-p1', name: 'redis', type: 'state.redis', source: 'auto', path: '/c/redis-a.yaml', active: false, connection: 'localhost:6379' },

--- a/web/src/pages/Workflows.tsx
+++ b/web/src/pages/Workflows.tsx
@@ -277,7 +277,7 @@ export function Workflows() {
       return { appId, instanceId }
     })
     removeWorkflows(
-      { ids, force },
+      { ids, force, store: selectedStore ?? undefined },
       {
         onSuccess: (results) => {
           const ok = results.filter((r) => r.ok).length

--- a/web/src/pages/component-builder/reducer.test.ts
+++ b/web/src/pages/component-builder/reducer.test.ts
@@ -143,6 +143,48 @@ describe('SELECT_CATEGORY', () => {
   })
 })
 
+describe('SELECT_SCHEMA reset behavior', () => {
+  const memcached: ComponentMetadataSchema = {
+    type: 'state', name: 'memcached', version: 'v1', title: 'Memcached', status: 'stable',
+    metadata: [{ name: 'hosts', required: true }],
+  }
+  const redisWithAuth: ComponentMetadataSchema = {
+    ...redis,
+    authenticationProfiles: [{ title: 'Password', metadata: [{ name: 'redisPassword', required: true }] }],
+  }
+
+  function configured() {
+    let s = reducer(initialState(), { type: 'SELECT_SCHEMA', schema: redisWithAuth, version: 'v1' })
+    s = reducer(s, { type: 'SET_AUTH_PROFILE', profile: redisWithAuth.authenticationProfiles![0] })
+    s = reducer(s, { type: 'SET_VALUE', field: 'redisHost', value: 'localhost:6379' })
+    s = reducer(s, { type: 'ADD_OPTIONAL', field: 'enableTLS' })
+    s = reducer(s, { type: 'TOGGLE_SECRET', field: 'redisPassword', on: true })
+    s = reducer(s, { type: 'SET_SECRET', field: 'redisPassword', ref: { name: 'sec', key: 'pw' } })
+    return s
+  }
+
+  it('selecting a different schema in the same category clears auth profile + config', () => {
+    let s = configured()
+    s = reducer(s, { type: 'SELECT_SCHEMA', schema: memcached, version: 'v1' })
+    expect(s.schema?.name).toBe('memcached')
+    expect(s.authProfile).toBeUndefined()
+    expect(s.values).toEqual({})
+    expect(s.secretRefs).toEqual({})
+    expect(s.useSecret).toEqual({})
+    expect(s.optionalAdded).toEqual([])
+  })
+
+  it('re-selecting the same schema preserves auth profile + config', () => {
+    let s = configured()
+    s = reducer(s, { type: 'SELECT_SCHEMA', schema: redisWithAuth, version: 'v1' })
+    expect(s.authProfile?.title).toBe('Password')
+    expect(s.values).toEqual({ redisHost: 'localhost:6379' })
+    expect(s.secretRefs).toEqual({ redisPassword: { name: 'sec', key: 'pw' } })
+    expect(s.useSecret).toEqual({ redisPassword: true })
+    expect(s.optionalAdded).toEqual(['enableTLS'])
+  })
+})
+
 describe('REMOVE_OPTIONAL clears field state', () => {
   it('removes the field from optionalAdded and clears its value/secret/useSecret', () => {
     let s = initialState()

--- a/web/src/pages/component-builder/reducer.ts
+++ b/web/src/pages/component-builder/reducer.ts
@@ -50,6 +50,18 @@ export function reducer(state: ComponentBuilderState, action: Action): Component
   switch (action.type) {
     case 'SELECT_SCHEMA': {
       const hasAuthProfiles = (action.schema.authenticationProfiles?.length ?? 0) > 0
+      const sameSchema = action.schema.type === state.schema?.type && action.schema.name === state.schema?.name
+      if (sameSchema) {
+        return {
+          ...state,
+          category: action.schema.type,
+          schema: action.schema,
+          version: action.version,
+          hasAuthProfiles,
+          activeStep: 1,
+        }
+      }
+      // Switching component invalidates the auth profile + its config.
       return {
         ...state,
         category: action.schema.type,
@@ -57,6 +69,11 @@ export function reducer(state: ComponentBuilderState, action: Action): Component
         version: action.version,
         hasAuthProfiles,
         activeStep: 1,
+        authProfile: undefined,
+        values: {},
+        secretRefs: {},
+        useSecret: {},
+        optionalAdded: [],
       }
     }
     case 'SELECT_CATEGORY':

--- a/web/src/pages/resiliency-builder/StepPolicies.tsx
+++ b/web/src/pages/resiliency-builder/StepPolicies.tsx
@@ -14,8 +14,8 @@ export function StepPolicies({ state, dispatch }: { state: ResiliencyState; disp
   const pol = state.config.spec.policies
   const customRetryNames = Object.keys(pol.retries).filter((n) => !isDefaultPolicyName(n))
 
-  function renameThenUpsert<A extends Action>(editName: string | undefined, name: string, removeType: Action['type'], upsert: A) {
-    if (editName && editName !== name) dispatch({ type: removeType, name: editName } as Action)
+  function renameThenUpsert<A extends Action>(editName: string | undefined, name: string, renameType: 'RENAME_TIMEOUT' | 'RENAME_RETRY' | 'RENAME_CB', upsert: A) {
+    if (editName && editName !== name) dispatch({ type: renameType, from: editName, to: name })
     dispatch(upsert)
   }
 
@@ -66,21 +66,21 @@ export function StepPolicies({ state, dispatch }: { state: ResiliencyState; disp
           initialName={open.editName ?? nextName('timeout', pol.timeouts)}
           initialDuration={open.editName ? pol.timeouts[open.editName] : undefined}
           onClose={() => setOpen(null)}
-          onSave={(name, duration) => { renameThenUpsert(open.editName, name, 'REMOVE_TIMEOUT', { type: 'UPSERT_TIMEOUT', name, duration }); setOpen(null) }} />
+          onSave={(name, duration) => { renameThenUpsert(open.editName, name, 'RENAME_TIMEOUT', { type: 'UPSERT_TIMEOUT', name, duration }); setOpen(null) }} />
       )}
       {open?.kind === 'retry' && (
         <RetryDialog open editing={!!open.editName}
           initialName={open.editName ?? nextName('retry', pol.retries)}
           initialPolicy={open.editName ? pol.retries[open.editName] : undefined}
           onClose={() => setOpen(null)}
-          onSave={(name, policy) => { renameThenUpsert(open.editName, name, 'REMOVE_RETRY', { type: 'UPSERT_RETRY', name, policy }); setOpen(null) }} />
+          onSave={(name, policy) => { renameThenUpsert(open.editName, name, 'RENAME_RETRY', { type: 'UPSERT_RETRY', name, policy }); setOpen(null) }} />
       )}
       {open?.kind === 'cb' && (
         <CircuitBreakerDialog open editing={!!open.editName}
           initialName={open.editName ?? nextName('circuitBreaker', pol.circuitBreakers)}
           initialPolicy={open.editName ? pol.circuitBreakers[open.editName] : undefined}
           onClose={() => setOpen(null)}
-          onSave={(name, policy) => { renameThenUpsert(open.editName, name, 'REMOVE_CB', { type: 'UPSERT_CB', name, policy }); setOpen(null) }} />
+          onSave={(name, policy) => { renameThenUpsert(open.editName, name, 'RENAME_CB', { type: 'UPSERT_CB', name, policy }); setOpen(null) }} />
       )}
       {open?.kind === 'override' && (
         <RetryDialog open lockName keepDurationForExponential editing={open.editing}

--- a/web/src/pages/resiliency-builder/reducer.test.ts
+++ b/web/src/pages/resiliency-builder/reducer.test.ts
@@ -56,6 +56,83 @@ describe('reducer upserts/removes', () => {
   })
 })
 
+describe('policy remove/rename cascades to target references', () => {
+  function stateWithReferences() {
+    let s = reducer(initialState(), { type: 'UPSERT_TIMEOUT', name: 'timeout1', duration: '30s' })
+    s = reducer(s, { type: 'UPSERT_RETRY', name: 'retry1', policy: { policy: 'constant', duration: '5s', maxRetries: 3 } })
+    s = reducer(s, { type: 'UPSERT_CB', name: 'circuitBreaker1', policy: { maxRequests: 1, timeout: '30s' } })
+    s = reducer(s, { type: 'UPSERT_APP', name: 'orders', target: { timeout: 'timeout1', retry: 'retry1' } })
+    s = reducer(s, {
+      type: 'UPSERT_ACTOR', name: 'myactor',
+      target: { retry: 'retry1', circuitBreaker: 'circuitBreaker1', circuitBreakerScope: 'both', circuitBreakerCacheSize: 5000 },
+    })
+    s = reducer(s, {
+      type: 'UPSERT_COMPONENT', name: 'statestore',
+      target: { outbound: { timeout: 'timeout1', retry: 'retry1' }, inbound: { retry: 'retry1' } },
+    })
+    return s
+  }
+
+  it('removing a timeout clears its refs from targets but keeps other policy refs', () => {
+    const s = reducer(stateWithReferences(), { type: 'REMOVE_TIMEOUT', name: 'timeout1' })
+    expect(s.config.spec.targets.apps!.orders).toEqual({ retry: 'retry1' })
+    expect(s.config.spec.targets.components!.statestore.outbound).toEqual({ retry: 'retry1' })
+    expect(s.config.spec.targets.components!.statestore.inbound).toEqual({ retry: 'retry1' })
+  })
+
+  it('removing a retry clears its refs from every target that references it', () => {
+    const s = reducer(stateWithReferences(), { type: 'REMOVE_RETRY', name: 'retry1' })
+    expect(s.config.spec.targets.apps!.orders).toEqual({ timeout: 'timeout1' })
+    expect(s.config.spec.targets.actors!.myactor.retry).toBeUndefined()
+    expect(s.config.spec.targets.components!.statestore.outbound).toEqual({ timeout: 'timeout1' })
+    expect(s.config.spec.targets.components!.statestore.inbound).toEqual({})
+  })
+
+  it('removing a circuit breaker also clears actor scope and cache size', () => {
+    const s = reducer(stateWithReferences(), { type: 'REMOVE_CB', name: 'circuitBreaker1' })
+    expect(s.config.spec.targets.actors!.myactor).toEqual({ retry: 'retry1' })
+  })
+
+  it('removing a policy referenced by no target leaves targets untouched', () => {
+    let s = reducer(stateWithReferences(), { type: 'UPSERT_RETRY', name: 'retry2', policy: { policy: 'exponential', duration: '2s' } })
+    const before = s.config.spec.targets
+    s = reducer(s, { type: 'REMOVE_RETRY', name: 'retry2' })
+    expect(s.config.spec.policies.retries.retry2).toBeUndefined()
+    expect(s.config.spec.targets).toBe(before)
+  })
+
+  it('renaming a timeout rewrites refs in targets and renames the policy key', () => {
+    const s = reducer(stateWithReferences(), { type: 'RENAME_TIMEOUT', from: 'timeout1', to: 'fast-timeout' })
+    expect(s.config.spec.policies.timeouts).toEqual({ 'fast-timeout': '30s' })
+    expect(s.config.spec.targets.apps!.orders).toEqual({ timeout: 'fast-timeout', retry: 'retry1' })
+    expect(s.config.spec.targets.components!.statestore.outbound).toEqual({ timeout: 'fast-timeout', retry: 'retry1' })
+  })
+
+  it('renaming a retry rewrites refs in targets and preserves other refs', () => {
+    const s = reducer(stateWithReferences(), { type: 'RENAME_RETRY', from: 'retry1', to: 'important' })
+    expect(s.config.spec.policies.retries.important).toEqual({ policy: 'constant', duration: '5s', maxRetries: 3 })
+    expect(s.config.spec.policies.retries.retry1).toBeUndefined()
+    expect(s.config.spec.targets.apps!.orders).toEqual({ timeout: 'timeout1', retry: 'important' })
+    expect(s.config.spec.targets.actors!.myactor.retry).toBe('important')
+    expect(s.config.spec.targets.components!.statestore.inbound).toEqual({ retry: 'important' })
+  })
+
+  it('renaming a circuit breaker rewrites refs and keeps actor scope and cache size', () => {
+    const s = reducer(stateWithReferences(), { type: 'RENAME_CB', from: 'circuitBreaker1', to: 'cb-main' })
+    expect(s.config.spec.policies.circuitBreakers).toEqual({ 'cb-main': { maxRequests: 1, timeout: '30s' } })
+    expect(s.config.spec.targets.actors!.myactor).toEqual({
+      retry: 'retry1', circuitBreaker: 'cb-main', circuitBreakerScope: 'both', circuitBreakerCacheSize: 5000,
+    })
+  })
+
+  it('removing a DaprBuiltIn override leaves unrelated custom refs untouched', () => {
+    let s = reducer(stateWithReferences(), { type: 'UPSERT_RETRY', name: 'DaprBuiltInServiceRetries', policy: { policy: 'constant', duration: '1s', maxRetries: 3 } })
+    s = reducer(s, { type: 'REMOVE_RETRY', name: 'DaprBuiltInServiceRetries' })
+    expect(s.config.spec.policies.retries.DaprBuiltInServiceRetries).toBeUndefined()
+    expect(s.config.spec.targets.apps!.orders).toEqual({ timeout: 'timeout1', retry: 'retry1' })
+  })
+})
+
 describe('assembleResiliency', () => {
   it('keeps name + default namespace, cleans spec, omits empty scopes', () => {
     let s = reducer(initialState(), { type: 'SET_NAME', name: 'r' })

--- a/web/src/pages/resiliency-builder/reducer.ts
+++ b/web/src/pages/resiliency-builder/reducer.ts
@@ -1,6 +1,6 @@
 import {
   defaultResiliencyConfig, type DaprResiliency, type RetryPolicy, type CircuitBreakerPolicy,
-  type AppTarget, type ActorTarget, type ComponentTarget,
+  type AppTarget, type ActorTarget, type ComponentTarget, type Targets,
 } from '../../types/resiliency'
 import { validateResourceName } from '../../lib/validation'
 import { recursivelyRemoveEmptyValues } from '../../lib/yaml-emit'
@@ -16,10 +16,13 @@ export type Action =
   | { type: 'SET_NAMESPACE'; namespace: string }
   | { type: 'UPSERT_TIMEOUT'; name: string; duration: string }
   | { type: 'REMOVE_TIMEOUT'; name: string }
+  | { type: 'RENAME_TIMEOUT'; from: string; to: string }
   | { type: 'UPSERT_RETRY'; name: string; policy: RetryPolicy }
   | { type: 'REMOVE_RETRY'; name: string }
+  | { type: 'RENAME_RETRY'; from: string; to: string }
   | { type: 'UPSERT_CB'; name: string; policy: CircuitBreakerPolicy }
   | { type: 'REMOVE_CB'; name: string }
+  | { type: 'RENAME_CB'; from: string; to: string }
   | { type: 'UPSERT_APP'; name: string; target: AppTarget }
   | { type: 'REMOVE_APP'; name: string }
   | { type: 'UPSERT_ACTOR'; name: string; target: ActorTarget }
@@ -44,6 +47,58 @@ function withoutKey<T>(map: Record<string, T>, key: string): Record<string, T> {
   return next
 }
 
+function renamedKey<T>(map: Record<string, T>, from: string, to: string): Record<string, T> {
+  if (!(from in map)) return map
+  const next: Record<string, T> = {}
+  for (const [k, v] of Object.entries(map)) next[k === from ? to : k] = v
+  return next
+}
+
+type PolicyField = 'timeout' | 'retry' | 'circuitBreaker'
+type PolicyRefs = { timeout?: string; retry?: string; circuitBreaker?: string }
+
+/** Rewrite one target/leg's ref to policy `from`: point it at `to`, or clear it when `to` is undefined. */
+function remapRef<T extends PolicyRefs>(leg: T, field: PolicyField, from: string, to?: string): T {
+  if (leg[field] !== from) return leg
+  if (to !== undefined) return { ...leg, [field]: to }
+  const next = { ...leg }
+  delete next[field]
+  if (field === 'circuitBreaker') {
+    // Actor CB settings are meaningless without a circuit breaker (mirrors the dialog).
+    delete (next as ActorTarget).circuitBreakerScope
+    delete (next as ActorTarget).circuitBreakerCacheSize
+  }
+  return next
+}
+
+function mapValues<T>(map: Record<string, T> | undefined, fn: (v: T) => T): Record<string, T> | undefined {
+  if (!map) return map
+  let changed = false
+  const next: Record<string, T> = {}
+  for (const [k, v] of Object.entries(map)) {
+    next[k] = fn(v)
+    if (next[k] !== v) changed = true
+  }
+  return changed ? next : map
+}
+
+/** Cascade a policy rename (or removal, when `to` is undefined) into every target reference. */
+function remapPolicyRefs(targets: Targets, field: PolicyField, from: string, to?: string): Targets {
+  const apps = mapValues(targets.apps, (t) => remapRef(t, field, from, to))
+  const actors = mapValues(targets.actors, (t) => remapRef(t, field, from, to))
+  const components = mapValues(targets.components, (t) => {
+    const outbound = t.outbound && remapRef(t.outbound, field, from, to)
+    const inbound = t.inbound && remapRef(t.inbound, field, from, to)
+    if (outbound === t.outbound && inbound === t.inbound) return t
+    const next: ComponentTarget = {}
+    if (outbound) next.outbound = outbound
+    if (inbound) next.inbound = inbound
+    return next
+  })
+  if (apps === targets.apps && actors === targets.actors && components === targets.components) return targets
+  return { ...targets, apps, actors, components }
+}
+
 export function reducer(state: ResiliencyState, action: Action): ResiliencyState {
   const cfg = state.config
   const pol = cfg.spec.policies
@@ -60,15 +115,39 @@ export function reducer(state: ResiliencyState, action: Action): ResiliencyState
     case 'UPSERT_TIMEOUT':
       return set({ policies: { ...pol, timeouts: { ...pol.timeouts, [action.name]: action.duration } } })
     case 'REMOVE_TIMEOUT':
-      return set({ policies: { ...pol, timeouts: withoutKey(pol.timeouts, action.name) } })
+      return set({
+        policies: { ...pol, timeouts: withoutKey(pol.timeouts, action.name) },
+        targets: remapPolicyRefs(tgt, 'timeout', action.name),
+      })
+    case 'RENAME_TIMEOUT':
+      return set({
+        policies: { ...pol, timeouts: renamedKey(pol.timeouts, action.from, action.to) },
+        targets: remapPolicyRefs(tgt, 'timeout', action.from, action.to),
+      })
     case 'UPSERT_RETRY':
       return set({ policies: { ...pol, retries: { ...pol.retries, [action.name]: action.policy } } })
     case 'REMOVE_RETRY':
-      return set({ policies: { ...pol, retries: withoutKey(pol.retries, action.name) } })
+      return set({
+        policies: { ...pol, retries: withoutKey(pol.retries, action.name) },
+        targets: remapPolicyRefs(tgt, 'retry', action.name),
+      })
+    case 'RENAME_RETRY':
+      return set({
+        policies: { ...pol, retries: renamedKey(pol.retries, action.from, action.to) },
+        targets: remapPolicyRefs(tgt, 'retry', action.from, action.to),
+      })
     case 'UPSERT_CB':
       return set({ policies: { ...pol, circuitBreakers: { ...pol.circuitBreakers, [action.name]: action.policy } } })
     case 'REMOVE_CB':
-      return set({ policies: { ...pol, circuitBreakers: withoutKey(pol.circuitBreakers, action.name) } })
+      return set({
+        policies: { ...pol, circuitBreakers: withoutKey(pol.circuitBreakers, action.name) },
+        targets: remapPolicyRefs(tgt, 'circuitBreaker', action.name),
+      })
+    case 'RENAME_CB':
+      return set({
+        policies: { ...pol, circuitBreakers: renamedKey(pol.circuitBreakers, action.from, action.to) },
+        targets: remapPolicyRefs(tgt, 'circuitBreaker', action.from, action.to),
+      })
     case 'UPSERT_APP':
       return set({ targets: { ...tgt, apps: { ...(tgt.apps ?? {}), [action.name]: action.target } } })
     case 'REMOVE_APP':

--- a/web/src/pages/resiliency-builder/steps.test.tsx
+++ b/web/src/pages/resiliency-builder/steps.test.tsx
@@ -45,15 +45,16 @@ describe('StepPolicies', () => {
     fireEvent.click(screen.getByRole('button', { name: /remove retry1/i }))
     expect(dispatch).toHaveBeenCalledWith({ type: 'REMOVE_RETRY', name: 'retry1' })
   })
-  it('edits an existing timeout via chip click (rename dispatches remove + upsert)', () => {
+  it('edits an existing timeout via chip click (rename dispatches rename + upsert)', () => {
     const dispatch = vi.fn()
     const s = reducer(initialState(), { type: 'UPSERT_TIMEOUT', name: 'timeout1', duration: '30s' })
     render(<StepPolicies state={s} dispatch={dispatch} />)
     fireEvent.click(screen.getByRole('button', { name: /edit timeout1/i }))
     fireEvent.change(screen.getByLabelText(/timeout name/i), { target: { value: 'renamed' } })
     fireEvent.click(screen.getByRole('button', { name: /save/i }))
-    expect(dispatch).toHaveBeenCalledWith({ type: 'REMOVE_TIMEOUT', name: 'timeout1' })
+    expect(dispatch).toHaveBeenCalledWith({ type: 'RENAME_TIMEOUT', from: 'timeout1', to: 'renamed' })
     expect(dispatch).toHaveBeenCalledWith({ type: 'UPSERT_TIMEOUT', name: 'renamed', duration: '30s' })
+    expect(dispatch).not.toHaveBeenCalledWith({ type: 'REMOVE_TIMEOUT', name: 'timeout1' })
   })
   it('adds a DaprBuiltIn override with prefilled defaults', () => {
     const dispatch = vi.fn()


### PR DESCRIPTION
## Summary

First batch of fixes from a full-codebase review (Go backend + React 19 frontend). Five verified findings, each fixed TDD-style (failing test first) in an isolated worktree by a dedicated agent, then merged and verified together.

| Fix | Severity | Area |
|-----|----------|------|
| Bulk workflow purge ignored the selected state store — could purge same-ID instances from the **active** store instead | Critical | `web/src/pages/Workflows.tsx` |
| No CSRF/DNS-rebinding protection on the localhost API — any website could POST to `/api/workflows/purge` or stop control-plane containers | High | `pkg/server/middleware.go` (new) |
| Component builder kept stale `authProfile`/`values`/`secretRefs` when switching schemas within the same category — wrong profile fields leaked into the form and emitted YAML | High | `web/src/pages/component-builder/reducer.ts` |
| Resiliency builder left dangling policy references in targets after rename/remove — emitted YAML invalid for Dapr | High | `web/src/pages/resiliency-builder/` |
| Data race in `connPool.evict` — read `slot.store` without waiting on `slot.done`; racing an in-flight open could leak an unclosable connection | Medium | `cmd/connpool.go` |

## Details

- **Bulk purge**: `onConfirmRemove` now passes `store: selectedStore ?? undefined`, matching `WorkflowDetail`. Regression test asserts the MSW-captured purge request carries `?store=statestore-b`.
- **Host/Origin middleware**: all routes (API, SSE, SPA) reject non-loopback `Host` (403); POST/PUT/DELETE/PATCH reject present-but-foreign `Origin` (any localhost port allowed, so the Vite dev server keeps working; absent Origin, e.g. curl, allowed). 28 table-driven tests.
- **Schema switch**: `SELECT_SCHEMA` now resets `authProfile`, `values`, `secretRefs`, `useSecret`, `optionalAdded` when the schema actually changes; re-selecting the same schema preserves state (mirrors `SELECT_CATEGORY`).
- **Policy refs**: new per-type `RENAME_TIMEOUT`/`RENAME_RETRY`/`RENAME_CB` actions rename the policy key and rewrite target refs atomically; `REMOVE_*` cascades clear matching refs (including actor `circuitBreakerScope`/`circuitBreakerCacheSize`). `StepPolicies` rename now dispatches RENAME+UPSERT instead of remove+upsert.
- **Evict race**: `evict` waits `<-slot.done` after removing the slot from the map before closing the store, mirroring `Close()`. New `-race` stress test reproduced the race on every pre-fix run (`Read at connpool.go:118 / Previous write at connpool.go:103`).

## Verification

- `go test -tags unit -race ./...` — all 13 packages pass
- `npx vitest run` — 474/474 tests pass (70 files)
- `npx tsc -b` — clean
- `gofmt` / `go vet` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)