### PR TITLE
fix: second batch of code-review fixes (YAML multi-doc, stderr capture, news cache, UX feedback)

### DIFF
--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -161,13 +161,21 @@ func (r *ConnRegistry) Add(e ConnEntry) error {
 
 // Update replaces a manual entry matched by ID; errors if none exists. The id
 // is recomputed from the (possibly new) name so it stays deterministic, and the
-// new id is returned so callers can re-address the renamed entry.
+// new id is returned so callers can re-address the renamed entry. Renaming onto
+// another manual entry's name errors (ids are keyed by name, so allowing it
+// would produce two entries with the same id); renaming an entry to its own
+// current name is fine.
 func (r *ConnRegistry) Update(e ConnEntry) (string, error) {
 	e.Source = SourceManual
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for i := range r.entries {
 		if r.entries[i].Source == SourceManual && r.entries[i].ID == e.ID {
+			for j := range r.entries {
+				if j != i && r.entries[j].Source == SourceManual && r.entries[j].Name == e.Name {
+					return "", os.ErrExist
+				}
+			}
 			e.ID = entryID(SourceManual, e.Name)
 			r.entries[i] = e
 			if err := r.save(); err != nil {

--- a/cmd/registry_test.go
+++ b/cmd/registry_test.go
@@ -186,6 +186,54 @@ func TestRegistry_UpsertAutoNeverDuplicatesManualEmptyPath(t *testing.T) {
 	require.Len(t, reg.List(), before, "empty-path auto upsert must not duplicate around a manual entry")
 }
 
+func TestRegistry_UpdateRejectsRenameOntoExistingManualName(t *testing.T) {
+	home := t.TempDir()
+	r := LoadRegistry(home)
+	require.NoError(t, r.Add(ConnEntry{Name: "a", Type: "state.redis", Source: SourceManual,
+		Metadata: map[string]string{"redisHost": "hostA"}}))
+	require.NoError(t, r.Add(ConnEntry{Name: "b", Type: "state.postgresql", Source: SourceManual,
+		Metadata: map[string]string{"connectionString": "host=b"}}))
+
+	aID := entryID(SourceManual, "a")
+
+	// Renaming a onto b's name must fail like a duplicate Add does.
+	_, err := r.Update(ConnEntry{ID: aID, Name: "b", Type: "state.redis", Source: SourceManual,
+		Metadata: map[string]string{"redisHost": "hostA"}})
+	require.ErrorIs(t, err, os.ErrExist, "rename onto an existing manual name must be rejected")
+
+	// The registry is unchanged: both entries intact with distinct ids.
+	assertIntact := func(got []ConnEntry) {
+		require.Len(t, got, 2)
+		byName := map[string]ConnEntry{}
+		for _, e := range got {
+			byName[e.Name] = e
+		}
+		require.Equal(t, entryID(SourceManual, "a"), byName["a"].ID)
+		require.Equal(t, "hostA", byName["a"].Metadata["redisHost"])
+		require.Equal(t, entryID(SourceManual, "b"), byName["b"].ID)
+		require.Equal(t, "host=b", byName["b"].Metadata["connectionString"])
+	}
+	assertIntact(r.List())
+	// And the on-disk file is not corrupted either.
+	assertIntact(LoadRegistry(home).List())
+}
+
+func TestRegistry_UpdateRenameToOwnNameSucceeds(t *testing.T) {
+	r := LoadRegistry(t.TempDir())
+	require.NoError(t, r.Add(ConnEntry{Name: "pg", Type: "state.postgresql", Source: SourceManual,
+		Metadata: map[string]string{"connectionString": "host=a"}}))
+
+	pgID := entryID(SourceManual, "pg")
+	// A no-op rename (same name, new metadata) must still succeed.
+	newID, err := r.Update(ConnEntry{ID: pgID, Name: "pg", Type: "state.postgresql", Source: SourceManual,
+		Metadata: map[string]string{"connectionString": "host=b"}})
+	require.NoError(t, err)
+	require.Equal(t, pgID, newID)
+	got := r.List()
+	require.Len(t, got, 1)
+	require.Equal(t, "host=b", got[0].Metadata["connectionString"])
+}
+
 func TestUpdateReturnsNewID(t *testing.T) {
 	r := LoadRegistry(t.TempDir())
 	require.NoError(t, r.Add(ConnEntry{Name: "old", Type: "state.redis", Metadata: map[string]string{"redisHost": "h"}}))

--- a/pkg/controlplane/runtime.go
+++ b/pkg/controlplane/runtime.go
@@ -74,8 +74,22 @@ func (r *execRunner) stream(ctx context.Context, args ...string) (<-chan string,
 	// scanner sees EOF once the child exits.
 	pw.Close()
 	ch := make(chan string)
+	// Cancellation kills only the direct child, but shells fork non-tail
+	// commands: a surviving descendant keeps a duplicate of the write end,
+	// so waiting for EOF alone would block the scanner forever. Close the
+	// read end on cancel to unblock it regardless of surviving writers.
+	// (Double-closing pr with the scanner goroutine's deferred Close is safe.)
+	scanDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			pr.Close()
+		case <-scanDone:
+		}
+	}()
 	go func() {
 		defer close(ch)
+		defer close(scanDone)
 		defer func() { _ = cmd.Wait() }()
 		// Closing the read end before Wait unblocks a child stuck writing
 		// (e.g. after a scanner error mid-line), so Wait cannot deadlock.

--- a/pkg/controlplane/runtime.go
+++ b/pkg/controlplane/runtime.go
@@ -3,7 +3,11 @@ package controlplane
 import (
 	"bufio"
 	"context"
+	"errors"
+	"fmt"
+	"os"
 	"os/exec"
+	"strings"
 )
 
 // runner executes runtime subcommands: run returns stdout; stream emits lines.
@@ -37,23 +41,46 @@ type execRunner struct{ bin string }
 func newExecRunner(kind RuntimeKind) *execRunner { return &execRunner{bin: string(kind)} }
 
 func (r *execRunner) run(ctx context.Context, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, r.bin, args...).Output()
+	out, err := exec.CommandContext(ctx, r.bin, args...).Output()
+	// Output() stashes stderr in ExitError.Stderr; fold it into the error so
+	// the API reports why the command failed, not just "exit status 1".
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		if detail := strings.TrimSpace(string(ee.Stderr)); detail != "" {
+			return out, fmt.Errorf("%w: %s", err, detail)
+		}
+	}
+	return out, err
 }
 
 func (r *execRunner) stream(ctx context.Context, args ...string) (<-chan string, error) {
 	cmd := exec.CommandContext(ctx, r.bin, args...)
-	stdout, err := cmd.StdoutPipe()
+	// The runtime CLI demultiplexes container output: container stdout goes
+	// to the CLI's stdout, container stderr to the CLI's stderr. Attach one
+	// pipe to both so error output (and CLI errors like "no such container")
+	// reaches the stream, interleaved like a terminal.
+	pr, pw, err := os.Pipe()
 	if err != nil {
 		return nil, err
 	}
+	cmd.Stdout = pw
+	cmd.Stderr = pw
 	if err := cmd.Start(); err != nil {
+		pr.Close()
+		pw.Close()
 		return nil, err
 	}
+	// The child holds its own copy of the write end; close ours so the
+	// scanner sees EOF once the child exits.
+	pw.Close()
 	ch := make(chan string)
 	go func() {
 		defer close(ch)
 		defer func() { _ = cmd.Wait() }()
-		sc := bufio.NewScanner(stdout)
+		// Closing the read end before Wait unblocks a child stuck writing
+		// (e.g. after a scanner error mid-line), so Wait cannot deadlock.
+		defer pr.Close()
+		sc := bufio.NewScanner(pr)
 		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		for sc.Scan() {
 			select {
@@ -61,6 +88,14 @@ func (r *execRunner) stream(ctx context.Context, args ...string) (<-chan string,
 			case <-ctx.Done():
 				_ = cmd.Process.Kill()
 				return
+			}
+		}
+		// A scanner error (e.g. a line over the buffer cap) would otherwise
+		// look like a normal EOF; surface it as a final marker line.
+		if err := sc.Err(); err != nil {
+			select {
+			case ch <- fmt.Sprintf("[stream error: %v]", err):
+			case <-ctx.Done():
 			}
 		}
 	}()

--- a/pkg/controlplane/runtime_test.go
+++ b/pkg/controlplane/runtime_test.go
@@ -102,6 +102,29 @@ func TestExecRunnerStreamCancelEndsStream(t *testing.T) {
 	collect(t, ch, 5*time.Second) // fails if the channel never closes
 }
 
+// Shells fork rather than exec non-tail commands, and cancellation kills only
+// the direct child: a surviving descendant still holds a duplicate of the pipe
+// write end, so EOF alone would never come. `sleep 30 & wait` forces that fork
+// on every platform; the stream must still close promptly after cancel.
+func TestExecRunnerStreamCancelWithSurvivingGrandchild(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &execRunner{bin: "sh"}
+	ch, err := r.stream(ctx, "-c", "echo first; sleep 30 & wait")
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	select {
+	case line := <-ch:
+		if line != "first" {
+			t.Fatalf("first line = %q, want %q", line, "first")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no line before cancel")
+	}
+	cancel()
+	collect(t, ch, 5*time.Second) // fails if the channel never closes
+}
+
 // A scanner error (e.g. a line exceeding the buffer cap) must not look like a
 // normal EOF; it is surfaced as a final marker line.
 func TestExecRunnerStreamSurfacesScannerError(t *testing.T) {

--- a/pkg/controlplane/runtime_test.go
+++ b/pkg/controlplane/runtime_test.go
@@ -3,8 +3,12 @@
 package controlplane
 
 import (
+	"context"
 	"errors"
+	"os/exec"
+	"strings"
 	"testing"
+	"time"
 )
 
 func fakeLook(present map[string]bool) lookPathFunc {
@@ -37,5 +41,107 @@ func TestResolveRuntime(t *testing.T) {
 	// Invalid env override is ignored and falls back to PATH probing.
 	if got := resolveRuntime("nerdctl", both); got != RuntimeDocker {
 		t.Errorf("invalid env override: got %q, want docker", got)
+	}
+}
+
+// collect drains ch until it closes or the timeout elapses.
+func collect(t *testing.T, ch <-chan string, timeout time.Duration) []string {
+	t.Helper()
+	var got []string
+	deadline := time.After(timeout)
+	for {
+		select {
+		case line, open := <-ch:
+			if !open {
+				return got
+			}
+			got = append(got, line)
+		case <-deadline:
+			t.Fatalf("stream did not close within %v; got %v", timeout, got)
+		}
+	}
+}
+
+// The runtime CLI demultiplexes container output: container stdout goes to the
+// CLI's stdout, container stderr to the CLI's stderr. Both must reach the log
+// stream, along with CLI errors like "no such container".
+func TestExecRunnerStreamCapturesStderr(t *testing.T) {
+	r := &execRunner{bin: "sh"}
+	ch, err := r.stream(context.Background(), "-c", "echo out; echo err 1>&2")
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	got := collect(t, ch, 5*time.Second)
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, "out") {
+		t.Errorf("stream lines = %v, want stdout line %q", got, "out")
+	}
+	if !strings.Contains(joined, "err") {
+		t.Errorf("stream lines = %v, want stderr line %q", got, "err")
+	}
+}
+
+// Cancelling the handler context must kill the child and close the channel,
+// even while the child is still producing (or sleeping).
+func TestExecRunnerStreamCancelEndsStream(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &execRunner{bin: "sh"}
+	ch, err := r.stream(ctx, "-c", "echo first; sleep 30")
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	select {
+	case line := <-ch:
+		if line != "first" {
+			t.Fatalf("first line = %q, want %q", line, "first")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no line before cancel")
+	}
+	cancel()
+	collect(t, ch, 5*time.Second) // fails if the channel never closes
+}
+
+// A scanner error (e.g. a line exceeding the buffer cap) must not look like a
+// normal EOF; it is surfaced as a final marker line.
+func TestExecRunnerStreamSurfacesScannerError(t *testing.T) {
+	r := &execRunner{bin: "sh"}
+	// Print a single line larger than the 1 MiB scanner cap.
+	ch, err := r.stream(context.Background(), "-c", `head -c 2097152 /dev/zero | tr '\0' 'a'; echo`)
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	got := collect(t, ch, 10*time.Second)
+	if len(got) == 0 || !strings.HasPrefix(got[len(got)-1], "[stream error:") {
+		t.Errorf("stream lines = %v, want final \"[stream error: ...]\" line", got)
+	}
+}
+
+// run must include the command's stderr in the returned error, not just
+// "exit status 1", so the API surfaces why an action failed.
+func TestExecRunnerRunErrorIncludesStderr(t *testing.T) {
+	r := &execRunner{bin: "sh"}
+	_, err := r.run(context.Background(), "-c", "echo boom 1>&2; exit 1")
+	if err == nil {
+		t.Fatal("run: got nil error, want failure")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("error = %q, want stderr detail %q included", err, "boom")
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Errorf("error = %v, want *exec.ExitError still reachable via errors.As", err)
+	}
+}
+
+// run without stderr output keeps the plain error.
+func TestExecRunnerRunErrorNoStderr(t *testing.T) {
+	r := &execRunner{bin: "sh"}
+	_, err := r.run(context.Background(), "-c", "exit 3")
+	if err == nil {
+		t.Fatal("run: got nil error, want failure")
+	}
+	if got := err.Error(); got != "exit status 3" {
+		t.Errorf("error = %q, want %q", got, "exit status 3")
 	}
 }

--- a/pkg/news/news.go
+++ b/pkg/news/news.go
@@ -41,45 +41,114 @@ type feedPayload struct {
 	UpcomingEvents   []Item `json:"upcomingEvents"`
 }
 
+// maxNegativeTTL caps how long a failed refresh suppresses retries.
+const maxNegativeTTL = 30 * time.Second
+
 type service struct {
-	client    *http.Client
-	url       string
-	ttl       time.Duration
+	client *http.Client
+	url    string
+	ttl    time.Duration
+	negTTL time.Duration
+
 	mu        sync.Mutex
 	cached    Response
-	fetchedAt time.Time
-	hasGood   bool
+	fetchedAt time.Time     // time of the last successful fetch
+	failedAt  time.Time     // time of the last failed fetch (zero after a success)
+	hasGood   bool          // whether cached holds a real (last-good) response
+	inflight  chan struct{} // non-nil while a fetch is in progress; closed when it completes
 }
 
 // New builds a caching news service. url is the upstream product feed URL; ttl is the cache lifetime.
+// Failed fetches are negatively cached for half the ttl, capped at 30s, so an
+// upstream outage is not re-probed on every request.
 func New(client *http.Client, url string, ttl time.Duration) Service {
+	negTTL := ttl / 2
+	if negTTL > maxNegativeTTL {
+		negTTL = maxNegativeTTL
+	}
 	return &service{
 		client: client,
 		url:    url,
 		ttl:    ttl,
+		negTTL: negTTL,
 	}
 }
 
-// Get returns a Response with up to four content slots. It serves from cache when fresh,
-// refetches when stale, and falls back to the last-good response on fetch/parse failure.
+// Get returns a Response with up to four content slots. It serves from cache when
+// fresh. When stale, at most one fetch is in flight at a time: callers with a
+// last-good response get it immediately (the refresh runs in the background),
+// while callers with no last-good wait for the single in-flight fetch. A failed
+// fetch is negatively cached and never evicts the last-good response.
 func (s *service) Get(ctx context.Context) Response {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if s.hasGood && time.Since(s.fetchedAt) < s.ttl {
-		return s.cached
+		r := s.cached
+		s.mu.Unlock()
+		return r
 	}
 
-	resp, err := s.fetch(ctx)
+	// Negative cache: a recent failed fetch is not retried yet.
+	if s.inflight == nil && !s.failedAt.IsZero() && time.Since(s.failedAt) < s.negTTL {
+		r := s.cached // last-good (zero Response{} if none)
+		s.mu.Unlock()
+		return r
+	}
+
+	if ch := s.inflight; ch != nil {
+		// A fetch is already in progress.
+		if s.hasGood {
+			r := s.cached
+			s.mu.Unlock()
+			return r // serve stale immediately rather than blocking
+		}
+		s.mu.Unlock()
+		select {
+		case <-ch: // share the single in-flight fetch's outcome
+			s.mu.Lock()
+			r := s.cached
+			s.mu.Unlock()
+			return r
+		case <-ctx.Done():
+			return Response{}
+		}
+	}
+
+	// Become the refresher.
+	ch := make(chan struct{})
+	s.inflight = ch
+	if s.hasGood {
+		r := s.cached
+		s.mu.Unlock()
+		// Stale-while-revalidate: refresh in the background, detached from the
+		// caller's context so a canceled request doesn't abort the refresh.
+		go s.refresh(context.Background(), ch)
+		return r
+	}
+	s.mu.Unlock()
+	return s.refresh(ctx, ch)
+}
+
+// refresh performs one upstream fetch (without holding the lock), records the
+// outcome, and wakes any callers waiting on ch. On failure the last-good
+// response is preserved and the failure time is recorded for negative caching.
+func (s *service) refresh(ctx context.Context, ch chan struct{}) Response {
+	payload, err := s.fetch(ctx)
+
+	s.mu.Lock()
 	if err != nil {
-		return s.cached // last-good (zero Response{} if none)
+		s.failedAt = time.Now()
+	} else {
+		s.cached = derive(payload)
+		s.fetchedAt = time.Now()
+		s.failedAt = time.Time{}
+		s.hasGood = true
 	}
-
-	derived := derive(resp)
-	s.cached = derived
-	s.fetchedAt = time.Now()
-	s.hasGood = true
-	return derived
+	r := s.cached
+	s.inflight = nil
+	s.mu.Unlock()
+	close(ch)
+	return r
 }
 
 // fetch performs the HTTP request and parses the feed payload.

--- a/pkg/news/news_test.go
+++ b/pkg/news/news_test.go
@@ -63,6 +63,127 @@ func TestNewsLastGoodOnFailure(t *testing.T) {
 	require.Equal(t, "Blog A", r2.Blog.Title)
 }
 
+// TestNewsStaleServedDuringSlowRefresh verifies that when the cache is stale
+// but a last-good response exists, concurrent Gets return the stale data
+// promptly (without blocking on the in-flight upstream fetch) and the
+// upstream receives exactly one refresh request.
+func TestNewsStaleServedDuringSlowRefresh(t *testing.T) {
+	var calls int32
+	release := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n > 1 {
+			<-release // hold every refresh request until the test releases it
+		}
+		_, _ = w.Write([]byte(feedJSON))
+	}))
+	defer ts.Close()
+	defer close(release)
+
+	svc := New(&http.Client{Timeout: 5 * time.Second}, ts.URL, 30*time.Millisecond)
+	r := svc.Get(context.Background()) // prime last-good
+	require.NotNil(t, r.Blog)
+	time.Sleep(50 * time.Millisecond) // let the cache go stale
+
+	const n = 10
+	results := make(chan Response, n)
+	start := time.Now()
+	for i := 0; i < n; i++ {
+		go func() {
+			results <- svc.Get(context.Background())
+		}()
+	}
+	for i := 0; i < n; i++ {
+		select {
+		case got := <-results:
+			require.NotNil(t, got.Blog)
+			require.Equal(t, "Blog A", got.Blog.Title)
+		case <-time.After(2 * time.Second):
+			t.Fatal("Get blocked behind the in-flight refresh instead of serving stale data")
+		}
+	}
+	// Generous bound: callers must not have waited on the (still-blocked) upstream.
+	require.Less(t, time.Since(start), 1*time.Second, "stale callers should return promptly")
+
+	// Wait for the (single, background) refresh request to reach upstream,
+	// then confirm no further requests were issued: it is still parked on the
+	// handler, so exactly one refresh is in flight.
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadInt32(&calls) < 2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	time.Sleep(50 * time.Millisecond) // grace period for any extra (buggy) refreshes
+	require.Equal(t, int32(2), atomic.LoadInt32(&calls), "expected exactly 1 refresh request (plus the priming request)")
+}
+
+// TestNewsSingleflightNoLastGood verifies that when there is no last-good
+// response and upstream is failing, N concurrent Gets share a single upstream
+// request, and a follow-up Get within the negative TTL does not hit upstream.
+func TestNewsSingleflightNoLastGood(t *testing.T) {
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		time.Sleep(200 * time.Millisecond) // ensure concurrent callers overlap the fetch
+		w.WriteHeader(500)
+	}))
+	defer ts.Close()
+
+	svc := New(&http.Client{Timeout: 5 * time.Second}, ts.URL, time.Hour)
+
+	const n = 10
+	done := make(chan Response, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			done <- svc.Get(context.Background())
+		}()
+	}
+	for i := 0; i < n; i++ {
+		got := <-done
+		require.Nil(t, got.Blog) // no last-good: zero response
+	}
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "concurrent Gets must share one upstream fetch")
+
+	// Within the negative TTL a failed refresh must not be retried.
+	_ = svc.Get(context.Background())
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "Get within negative TTL must not hit upstream")
+}
+
+// TestNewsFailureNeverEvictsLastGood verifies that a failed refresh never
+// clears the last-good response.
+func TestNewsFailureNeverEvictsLastGood(t *testing.T) {
+	var calls int32
+	var fail atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		if fail.Load() {
+			w.WriteHeader(500)
+			return
+		}
+		_, _ = w.Write([]byte(feedJSON))
+	}))
+	defer ts.Close()
+
+	svc := New(&http.Client{Timeout: 5 * time.Second}, ts.URL, 20*time.Millisecond)
+	r := svc.Get(context.Background()) // prime last-good
+	require.NotNil(t, r.Blog)
+
+	fail.Store(true)
+	time.Sleep(30 * time.Millisecond) // stale
+
+	_ = svc.Get(context.Background()) // triggers a refresh that fails
+
+	// Wait until the failed refresh has actually completed.
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadInt32(&calls) < 2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(2), "refresh attempt should have reached upstream")
+
+	got := svc.Get(context.Background())
+	require.NotNil(t, got.Blog, "failed refresh must not evict last-good")
+	require.Equal(t, "Blog A", got.Blog.Title)
+}
+
 func TestWithUTM(t *testing.T) {
 	cases := []struct {
 		name string

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -5,11 +5,28 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
 	"sigs.k8s.io/yaml"
 )
+
+// yamlDocSeparator matches a YAML document separator line ("---").
+var yamlDocSeparator = regexp.MustCompile(`(?m)^---\s*$`)
+
+// splitYAMLDocs splits multi-document YAML content on document separator
+// lines, dropping empty or whitespace-only documents.
+func splitYAMLDocs(data []byte) [][]byte {
+	var docs [][]byte
+	for _, doc := range yamlDocSeparator.Split(string(data), -1) {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		docs = append(docs, []byte(doc))
+	}
+	return docs
+}
 
 // Kind identifies the Dapr resource type.
 type Kind string
@@ -93,14 +110,6 @@ func (s *service) scan(kind Kind) ([]Resource, error) {
 			if err != nil {
 				return nil
 			}
-			var rr rawResource
-			if err := yaml.Unmarshal(data, &rr); err != nil {
-				return nil
-			}
-			k, ok := kindFromString(rr.Kind)
-			if !ok || k != kind {
-				return nil
-			}
 			absPath, err := filepath.Abs(path)
 			if err != nil {
 				absPath = path
@@ -109,13 +118,23 @@ func (s *service) scan(kind Kind) ([]Resource, error) {
 				return nil
 			}
 			seen[absPath] = true
-			out = append(out, Resource{
-				Name:    rr.Metadata.Name,
-				Kind:    k,
-				Type:    rr.Spec.Type,
-				Version: rr.Spec.Version,
-				Path:    absPath,
-			})
+			for _, doc := range splitYAMLDocs(data) {
+				var rr rawResource
+				if err := yaml.Unmarshal(doc, &rr); err != nil {
+					continue
+				}
+				k, ok := kindFromString(rr.Kind)
+				if !ok || k != kind {
+					continue
+				}
+				out = append(out, Resource{
+					Name:    rr.Metadata.Name,
+					Kind:    k,
+					Type:    rr.Spec.Type,
+					Version: rr.Spec.Version,
+					Path:    absPath,
+				})
+			}
 			return nil
 		})
 	}

--- a/pkg/resources/resources_test.go
+++ b/pkg/resources/resources_test.go
@@ -41,3 +41,29 @@ func TestResourcesListAndGet(t *testing.T) {
 	_, err = svc.Get(context.Background(), KindComponent, "missing")
 	require.ErrorIs(t, err, ErrNotFound)
 }
+
+const comp2YAML = "apiVersion: dapr.io/v1alpha1\nkind: Component\nmetadata:\n  name: pubsub\nspec:\n  type: pubsub.redis\n  version: v1\n"
+
+func TestResourcesMultiDocFile(t *testing.T) {
+	dir := t.TempDir()
+	multi := comp2YAML + "---\n" + cfgYAML + "---\n" + compYAML
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "resources.yaml"), []byte(multi), 0o600))
+	svc := New(func() []string { return []string{dir} })
+
+	comps, err := svc.List(context.Background(), KindComponent)
+	require.NoError(t, err)
+	require.Len(t, comps, 2)
+	require.Equal(t, "pubsub", comps[0].Name)
+	require.Equal(t, "pubsub.redis", comps[0].Type)
+	require.Equal(t, "statestore", comps[1].Name)
+	require.Equal(t, "state.redis", comps[1].Type)
+
+	cfgs, err := svc.List(context.Background(), KindConfiguration)
+	require.NoError(t, err)
+	require.Len(t, cfgs, 1)
+	require.Equal(t, "appconfig", cfgs[0].Name)
+
+	got, err := svc.Get(context.Background(), KindComponent, "statestore")
+	require.NoError(t, err)
+	require.Contains(t, got.Raw, "state.redis")
+}

--- a/pkg/server/workflows.go
+++ b/pkg/server/workflows.go
@@ -164,7 +164,10 @@ func workflowsRouter(backend WorkflowBackend, stores StoreRegistry) http.Handler
 			return
 		}
 		var body removeBody
-		_ = json.NewDecoder(req.Body).Decode(&body)
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
 		var tgts []workflow.RemoveTarget
 		var failed []workflow.RemoveResult
 		for _, ref := range body.IDs {

--- a/pkg/server/workflows_test.go
+++ b/pkg/server/workflows_test.go
@@ -163,6 +163,31 @@ func TestWorkflowBulkPurgeReconcilesFailed(t *testing.T) {
 	require.Contains(t, body, `"error":"could not resolve target"`)
 }
 
+func TestWorkflowBulkPurgeMalformedBody(t *testing.T) {
+	rem := &fakeRemover{}
+	backend := &fakeBackend{svc: fakeWF{}, rem: rem, targets: fakeResolver{}}
+	h := workflowsRouter(backend, nil)
+
+	// Malformed JSON → 400, nothing purged.
+	res, body := postJSON(t, h, "/purge", `{"ids": [`)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Contains(t, body, `"error":"invalid JSON body"`)
+	require.Empty(t, rem.calls)
+
+	// Mis-typed field (ids must be an array) → 400, nothing purged.
+	res, body = postJSON(t, h, "/purge", `{"ids":"x"}`)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Contains(t, body, `"error":"invalid JSON body"`)
+	require.Empty(t, rem.calls)
+
+	// Empty body → 400: the frontend always sends a JSON body, so an empty
+	// body is a client bug, not a valid "purge nothing" request.
+	res, body = postJSON(t, h, "/purge", ``)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Contains(t, body, `"error":"invalid JSON body"`)
+	require.Empty(t, rem.calls)
+}
+
 func TestWorkflowUnknownStore(t *testing.T) {
 	h := workflowsRouter(newFakeBackend(fakeWF{}), nil)
 

--- a/pkg/statestore/detect.go
+++ b/pkg/statestore/detect.go
@@ -3,10 +3,27 @@ package statestore
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"sigs.k8s.io/yaml"
 )
+
+// yamlDocSeparator matches a YAML document separator line ("---").
+var yamlDocSeparator = regexp.MustCompile(`(?m)^---\s*$`)
+
+// splitYAMLDocs splits multi-document YAML content on document separator
+// lines, dropping empty or whitespace-only documents.
+func splitYAMLDocs(data []byte) [][]byte {
+	var docs [][]byte
+	for _, doc := range yamlDocSeparator.Split(string(data), -1) {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		docs = append(docs, []byte(doc))
+	}
+	return docs
+}
 
 type rawComponent struct {
 	Kind     string `json:"kind"`
@@ -47,25 +64,6 @@ func Detect(paths []string) ([]Component, error) {
 			if err != nil {
 				return nil
 			}
-			var rc rawComponent
-			if err := yaml.Unmarshal(data, &rc); err != nil {
-				return nil
-			}
-			if rc.Kind != "Component" || !strings.HasPrefix(rc.Spec.Type, "state.") {
-				return nil
-			}
-			md := make(map[string]string, len(rc.Spec.Metadata))
-			var refs map[string]SecretRef
-			for _, m := range rc.Spec.Metadata {
-				if m.SecretKeyRef.Name != "" {
-					if refs == nil {
-						refs = make(map[string]SecretRef)
-					}
-					refs[m.Name] = SecretRef{Name: m.SecretKeyRef.Name, Key: m.SecretKeyRef.Key}
-					continue
-				}
-				md[m.Name] = m.Value
-			}
 			absPath, err := filepath.Abs(path)
 			if err != nil {
 				absPath = path
@@ -74,10 +72,31 @@ func Detect(paths []string) ([]Component, error) {
 				return nil
 			}
 			seen[absPath] = true
-			out = append(out, Component{
-				Name: rc.Metadata.Name, Type: rc.Spec.Type, Version: rc.Spec.Version,
-				Metadata: md, SecretRefs: refs, SecretStore: rc.Auth.SecretStore, Path: absPath,
-			})
+			for _, doc := range splitYAMLDocs(data) {
+				var rc rawComponent
+				if err := yaml.Unmarshal(doc, &rc); err != nil {
+					continue
+				}
+				if rc.Kind != "Component" || !strings.HasPrefix(rc.Spec.Type, "state.") {
+					continue
+				}
+				md := make(map[string]string, len(rc.Spec.Metadata))
+				var refs map[string]SecretRef
+				for _, m := range rc.Spec.Metadata {
+					if m.SecretKeyRef.Name != "" {
+						if refs == nil {
+							refs = make(map[string]SecretRef)
+						}
+						refs[m.Name] = SecretRef{Name: m.SecretKeyRef.Name, Key: m.SecretKeyRef.Key}
+						continue
+					}
+					md[m.Name] = m.Value
+				}
+				out = append(out, Component{
+					Name: rc.Metadata.Name, Type: rc.Spec.Type, Version: rc.Spec.Version,
+					Metadata: md, SecretRefs: refs, SecretStore: rc.Auth.SecretStore, Path: absPath,
+				})
+			}
 			return nil
 		})
 	}

--- a/pkg/statestore/detect_test.go
+++ b/pkg/statestore/detect_test.go
@@ -54,6 +54,16 @@ auth:
   secretStore: local-secrets
 `
 
+const secondStateComponent = `
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore2
+spec:
+  type: state.in-memory
+  version: v1
+`
+
 func TestDetect(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "redis.yaml"), []byte(redisComponent), 0o600))
@@ -67,6 +77,38 @@ func TestDetect(t *testing.T) {
 	require.Equal(t, "state.redis", got[0].Type)
 	require.Equal(t, "localhost:6379", got[0].Metadata["redisHost"])
 	require.Equal(t, "true", got[0].Metadata["actorStateStore"])
+}
+
+func TestDetectMultiDoc_StateStoreAfterOtherComponent(t *testing.T) {
+	dir := t.TempDir()
+	multi := pubsubComponent + "\n---\n" + redisComponent
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "resources.yaml"), []byte(multi), 0o600))
+
+	got, err := Detect([]string{dir})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "statestore", got[0].Name)
+	require.Equal(t, "state.redis", got[0].Type)
+	require.Equal(t, "localhost:6379", got[0].Metadata["redisHost"])
+}
+
+func TestDetectMultiDoc_TwoStateStoresInOneFile(t *testing.T) {
+	dir := t.TempDir()
+	multi := redisComponent + "\n---\n" + secondStateComponent
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "resources.yaml"), []byte(multi), 0o600))
+
+	got, err := Detect([]string{dir})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	byName := map[string]Component{}
+	for _, c := range got {
+		byName[c.Name] = c
+	}
+	require.Contains(t, byName, "statestore")
+	require.Equal(t, "state.redis", byName["statestore"].Type)
+	require.Contains(t, byName, "statestore2")
+	require.Equal(t, "state.in-memory", byName["statestore2"].Type)
 }
 
 func TestDetectParsesSecretKeyRef(t *testing.T) {

--- a/pkg/statestore/secrets.go
+++ b/pkg/statestore/secrets.go
@@ -51,13 +51,6 @@ func DetectSecretStores(paths []string) ([]SecretStore, error) {
 			if err != nil {
 				return nil
 			}
-			var rc rawSecretStore
-			if err := yaml.Unmarshal(data, &rc); err != nil {
-				return nil
-			}
-			if rc.Kind != "Component" || !strings.HasPrefix(rc.Spec.Type, "secretstores.local.") {
-				return nil
-			}
 			absPath, err := filepath.Abs(path)
 			if err != nil {
 				absPath = path
@@ -66,23 +59,32 @@ func DetectSecretStores(paths []string) ([]SecretStore, error) {
 				return nil
 			}
 			seen[absPath] = true
+			for _, doc := range splitYAMLDocs(data) {
+				var rc rawSecretStore
+				if err := yaml.Unmarshal(doc, &rc); err != nil {
+					continue
+				}
+				if rc.Kind != "Component" || !strings.HasPrefix(rc.Spec.Type, "secretstores.local.") {
+					continue
+				}
 
-			s := SecretStore{Name: rc.Metadata.Name, Type: rc.Spec.Type, NestedSeparator: ":"}
-			for _, m := range rc.Spec.Metadata {
-				switch m.Name {
-				case "secretsFile":
-					sf := m.Value
-					if sf != "" && !filepath.IsAbs(sf) {
-						sf = filepath.Join(filepath.Dir(absPath), sf)
-					}
-					s.SecretsFile = sf
-				case "nestedSeparator":
-					if m.Value != "" {
-						s.NestedSeparator = m.Value
+				s := SecretStore{Name: rc.Metadata.Name, Type: rc.Spec.Type, NestedSeparator: ":"}
+				for _, m := range rc.Spec.Metadata {
+					switch m.Name {
+					case "secretsFile":
+						sf := m.Value
+						if sf != "" && !filepath.IsAbs(sf) {
+							sf = filepath.Join(filepath.Dir(absPath), sf)
+						}
+						s.SecretsFile = sf
+					case "nestedSeparator":
+						if m.Value != "" {
+							s.NestedSeparator = m.Value
+						}
 					}
 				}
+				out = append(out, s)
 			}
-			out = append(out, s)
 			return nil
 		})
 	}

--- a/pkg/statestore/secrets_test.go
+++ b/pkg/statestore/secrets_test.go
@@ -66,6 +66,27 @@ func TestDetectSecretStores(t *testing.T) {
 	require.Equal(t, ":", fs.NestedSeparator)
 }
 
+func TestDetectSecretStoresMultiDoc_StoreAfterOtherComponent(t *testing.T) {
+	dir := t.TempDir()
+	multi := k8sSecretStore + "\n---\n" + localFileSecretStore + "\n---\n" + localEnvSecretStore
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "resources.yaml"), []byte(multi), 0o600))
+
+	stores, err := DetectSecretStores([]string{dir})
+	require.NoError(t, err)
+
+	byName := map[string]SecretStore{}
+	for _, s := range stores {
+		byName[s.Name] = s
+	}
+	require.Contains(t, byName, "local-secrets")
+	require.Contains(t, byName, "env-secrets")
+	require.NotContains(t, byName, "k8s-secrets")
+
+	fs := byName["local-secrets"]
+	require.Equal(t, "secretstores.local.file", fs.Type)
+	require.Equal(t, filepath.Join(dir, "secrets.json"), fs.SecretsFile)
+}
+
 func TestResolveSecrets_LocalFileNested(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "secrets.json"),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,15 +4,12 @@ import { SmallScreenGuard } from './components/SmallScreenGuard'
 import { TopNav } from './components/TopNav'
 import { ResourcesSidebar } from './components/ResourcesSidebar'
 import { getTheme, type Theme } from './lib/prefs'
+import { safeGet } from './lib/safeStorage'
 
 const SIDEBAR_COLLAPSED_KEY = 'devdash.sidebarCollapsed'
 
 function getInitialCollapsed(): boolean {
-  try {
-    return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true'
-  } catch {
-    return false
-  }
+  return safeGet(SIDEBAR_COLLAPSED_KEY) === 'true'
 }
 
 export function App() {

--- a/web/src/components/RouteError.test.tsx
+++ b/web/src/components/RouteError.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
+import { createMemoryRouter, RouterProvider, type RouteObject } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
+import { server } from '../test/setup'
+import { routes } from '../router'
+import { QueryProvider, makeQueryClient } from '../lib/query'
+import { RefreshProvider } from '../lib/refresh'
+
+// jsdom does not implement matchMedia; stub it so SmallScreenGuard works
+beforeAll(() => {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: true,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+})
+
+// Register MSW handlers so App-shell fetches (sidebar, news, version) don't error
+beforeEach(() => {
+  server.use(
+    http.get('/api/version', () => HttpResponse.json({ version: '9.9.9', commit: 'abc1234', date: '2026-01-01' })),
+    http.get('/api/health', () => HttpResponse.json({ status: 'ok' })),
+    http.get('/api/workflows', () => HttpResponse.json({ items: [] })),
+    http.get('/api/statestores', () => HttpResponse.json([])),
+    http.get('/api/news', () =>
+      HttpResponse.json({ blog: null, report: null, webinar: null, event: null }),
+    ),
+  )
+})
+
+function Bomb(): never {
+  throw new Error('kaboom: render exploded')
+}
+
+/** Replace the element of every index route in the real route tree with a throwing component. */
+function withBombAtIndex(route: RouteObject): RouteObject {
+  if (route.index) return { ...route, element: <Bomb /> }
+  if (route.children) return { ...route, children: route.children.map(withBombAtIndex) }
+  return route
+}
+
+function renderBombed() {
+  const client = makeQueryClient()
+  const router = createMemoryRouter(routes.map(withBombAtIndex), {
+    initialEntries: ['/'],
+    future: { v7_relativeSplatPath: true },
+  })
+  return render(
+    <QueryProvider client={client}>
+      <RefreshProvider>
+        <RouterProvider router={router} future={{ v7_startTransition: true }} />
+      </RefreshProvider>
+    </QueryProvider>,
+  )
+}
+
+describe('route error boundary', () => {
+  let errSpy: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    // React logs caught render errors; keep test output quiet
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    errSpy.mockRestore()
+  })
+
+  it('renders the error boundary with a Reload button instead of the raw router error screen', () => {
+    renderBombed()
+    expect(screen.getByRole('button', { name: /reload/i })).toBeInTheDocument()
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument()
+  })
+
+  it('shows the error text', () => {
+    renderBombed()
+    expect(screen.getByText(/kaboom: render exploded/)).toBeInTheDocument()
+  })
+
+  it('keeps the app shell (TopNav) usable', () => {
+    renderBombed()
+    expect(screen.getByRole('navigation', { name: 'Primary navigation' })).toBeInTheDocument()
+  })
+
+  it('offers a link back to the home route', () => {
+    renderBombed()
+    const back = screen.getByRole('link', { name: /back to applications/i })
+    expect(back).toHaveAttribute('href', '/')
+  })
+})

--- a/web/src/components/RouteError.tsx
+++ b/web/src/components/RouteError.tsx
@@ -1,0 +1,39 @@
+import { Link, isRouteErrorResponse, useRouteError } from 'react-router-dom'
+
+/**
+ * Route-level error boundary. Rendered by react-router (via `errorElement`)
+ * when a route element throws during render, so users get a recoverable page
+ * instead of the raw "Unexpected Application Error" screen.
+ */
+export function RouteError() {
+  const error = useRouteError()
+  const message = isRouteErrorResponse(error)
+    ? `${error.status} ${error.statusText}`
+    : error instanceof Error
+      ? error.message
+      : String(error)
+
+  return (
+    <div className="page">
+      <div className="phead">
+        <div>
+          <h1>Something went wrong</h1>
+          <div className="sub">The page hit an unexpected error while rendering</div>
+        </div>
+      </div>
+      <div className="panel">
+        <div className="ph">Error</div>
+        <p className="err">{message}</p>
+        <p className="muted">Reload the page, or go back to the applications list.</p>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button className="btn primary" onClick={() => window.location.reload()}>
+            Reload
+          </button>
+          <Link className="btn ghost" to="/">
+            Back to Applications
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/StateStoreConnectionDialog.test.tsx
+++ b/web/src/components/StateStoreConnectionDialog.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { http, HttpResponse } from 'msw'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { server } from '../test/setup'
 import { QueryProvider } from '../lib/query'
 import { StateStoreConnectionDialog } from './StateStoreConnectionDialog'
@@ -25,7 +25,7 @@ describe('StateStoreConnectionDialog', () => {
       return HttpResponse.json({ name: 'orders' }, { status: 201 })
     }))
 
-    setup(<StateStoreConnectionDialog open onClose={() => {}} />)
+    setup(<StateStoreConnectionDialog open onClose={() => {}} onSaved={() => {}} />)
 
     // Wait for catalog → required field present.
     await waitFor(() => expect(screen.getByLabelText('redisHost')).toBeInTheDocument())
@@ -44,5 +44,24 @@ describe('StateStoreConnectionDialog', () => {
       type: 'state.redis',
       metadata: { redisHost: 'localhost:6379', actorStateStore: 'true' },
     })
+  })
+
+  it('calls onSaved with the connection name after a successful save', async () => {
+    server.use(http.get('/api/metadata/components', () => HttpResponse.json(catalog)))
+    server.use(http.post('/api/statestores', () => HttpResponse.json({ name: 'orders' }, { status: 201 })))
+
+    const onSaved = vi.fn()
+    const onClose = vi.fn()
+    setup(<StateStoreConnectionDialog open onClose={onClose} onSaved={onSaved} />)
+
+    await waitFor(() => expect(screen.getByLabelText('redisHost')).toBeInTheDocument())
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'orders' } })
+    fireEvent.change(screen.getByLabelText('redisHost'), { target: { value: 'localhost:6379' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith('orders'))
+    // Closing is the owner's job (it shows the toast, then closes) — the dialog must not
+    // race it with its own onClose.
+    expect(onClose).not.toHaveBeenCalled()
   })
 })

--- a/web/src/components/StateStoreConnectionDialog.tsx
+++ b/web/src/components/StateStoreConnectionDialog.tsx
@@ -4,17 +4,19 @@ import { MetadataFieldInput } from './MetadataFieldInput'
 import { useComponentCatalog } from '../hooks/useComponentCatalog'
 import { useStoreMutations } from '../hooks/useStoreMutations'
 import { SUPPORTED_STORE_TYPES, storeTypeLabel } from '../lib/storeTypes'
-import { useToast } from '../lib/toast'
 
 interface Props {
   open: boolean
   onClose: () => void
+  /** Called after a successful save. The owner is responsible for closing the
+   * dialog and showing the confirmation toast — this component unmounts on
+   * close, so a toast rendered here would never be seen. */
+  onSaved: (name: string) => void
 }
 
-export function StateStoreConnectionDialog({ open, onClose }: Props) {
+export function StateStoreConnectionDialog({ open, onClose, onSaved }: Props) {
   const { fieldsFor, isError } = useComponentCatalog()
   const { addStore } = useStoreMutations()
-  const { toast, toastNode } = useToast()
 
   const [name, setName] = useState('')
   const [type, setType] = useState<string>(SUPPORTED_STORE_TYPES[0])
@@ -61,8 +63,7 @@ export function StateStoreConnectionDialog({ open, onClose }: Props) {
 
     try {
       await addStore.mutateAsync({ name: name.trim(), type, metadata })
-      toast.show(`Added ${name.trim()}`)
-      onClose()
+      onSaved(name.trim())
     } catch (e) {
       setError((e as Error).message)
     }
@@ -72,7 +73,6 @@ export function StateStoreConnectionDialog({ open, onClose }: Props) {
 
   return (
     <Modal open={open} title="Add state store connection" onClose={onClose}>
-      {toastNode}
       {isError && <p className="field-err">Couldn't load the component catalog; try reloading.</p>}
 
       <div className="field">

--- a/web/src/components/StateStoreConnectionsPanel.test.tsx
+++ b/web/src/components/StateStoreConnectionsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { http, HttpResponse } from 'msw'
 import { describe, it, expect } from 'vitest'
 import { server } from '../test/setup'
@@ -9,6 +9,13 @@ const stores = [
   { id: 'a1', name: 'statestore', type: 'state.redis', source: 'auto', path: '/x/a.yaml', active: true, connection: 'localhost:6379' },
   { id: 'm1', name: 'orders-pg', type: 'state.postgresql', source: 'manual', path: '', active: false, connection: 'host=db' },
 ]
+
+const catalog = {
+  schemaVersion: 'v1', date: '2026', components: [
+    { type: 'state', name: 'redis', version: 'v1', title: 'Redis', status: 'stable',
+      metadata: [{ name: 'redisHost', required: true, type: 'string' }] },
+  ],
+}
 
 describe('StateStoreConnectionsPanel', () => {
   it('shows auto rows read-only and manual rows with actions', async () => {
@@ -25,5 +32,63 @@ describe('StateStoreConnectionsPanel', () => {
     expect(screen.queryByRole('button', { name: /edit statestore/i })).not.toBeInTheDocument()
     // Add button present.
     expect(screen.getByRole('button', { name: /add connection/i })).toBeInTheDocument()
+  })
+
+  it('shows a success toast after a successful add, even though the dialog unmounts', async () => {
+    server.use(
+      http.get('/api/statestores', () => HttpResponse.json(stores)),
+      http.get('/api/metadata/components', () => HttpResponse.json(catalog)),
+      http.post('/api/statestores', () => HttpResponse.json({ name: 'orders' }, { status: 201 })),
+    )
+    render(<QueryProvider><StateStoreConnectionsPanel /></QueryProvider>)
+
+    fireEvent.click(screen.getByRole('button', { name: /add connection/i }))
+    await waitFor(() => expect(screen.getByLabelText('redisHost')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'orders' } })
+    fireEvent.change(screen.getByLabelText('redisHost'), { target: { value: 'localhost:6379' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    // Dialog closes…
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: /add state store connection/i })).not.toBeInTheDocument(),
+    )
+    // …and the confirmation toast is still visible (rendered by the panel, not the dialog).
+    expect(screen.getByText('Added orders')).toBeInTheDocument()
+  })
+
+  it('shows error feedback and keeps the confirm modal open when delete fails', async () => {
+    server.use(
+      http.get('/api/statestores', () => HttpResponse.json(stores)),
+      http.delete('/api/statestores/m1', () =>
+        HttpResponse.json({ error: 'store is in use' }, { status: 500 }),
+      ),
+    )
+    render(<QueryProvider><StateStoreConnectionsPanel /></QueryProvider>)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /delete orders-pg/i })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /delete orders-pg/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    // Error surfaced to the user, modal still open, no crash / unhandled rejection.
+    await waitFor(() => expect(screen.getByText('store is in use')).toBeInTheDocument())
+    expect(screen.getByRole('dialog', { name: /delete connection/i })).toBeInTheDocument()
+  })
+
+  it('closes the confirm modal and shows a toast on successful delete', async () => {
+    server.use(
+      http.get('/api/statestores', () => HttpResponse.json(stores)),
+      http.delete('/api/statestores/m1', () => new HttpResponse(null, { status: 204 })),
+    )
+    render(<QueryProvider><StateStoreConnectionsPanel /></QueryProvider>)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /delete orders-pg/i })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /delete orders-pg/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: /delete connection/i })).not.toBeInTheDocument(),
+    )
+    expect(screen.getByText('Removed orders-pg')).toBeInTheDocument()
   })
 })

--- a/web/src/components/StateStoreConnectionsPanel.tsx
+++ b/web/src/components/StateStoreConnectionsPanel.tsx
@@ -4,14 +4,41 @@ import { useStoreMutations } from '../hooks/useStoreMutations'
 import { StateStoreConnectionDialog } from './StateStoreConnectionDialog'
 import { Modal } from './Modal'
 import { storeTypeLabel } from '../lib/storeTypes'
+import { useToast } from '../lib/toast'
 import type { StateStore } from '../types/workflow'
 
 export function StateStoreConnectionsPanel() {
   const { data: stores } = useStateStores()
   const { deleteStore } = useStoreMutations()
+  // The panel owns the toast: the add dialog unmounts on close, so any toast
+  // rendered inside it would disappear before the user could see it.
+  const { toast, toastNode } = useToast()
 
   const [addOpen, setAddOpen] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<StateStore | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  const openDeleteConfirm = (s: StateStore) => {
+    setDeleteError(null)
+    setPendingDelete(s)
+  }
+  const closeDeleteConfirm = () => {
+    setDeleteError(null)
+    setPendingDelete(null)
+  }
+
+  async function handleConfirmDelete() {
+    if (!pendingDelete) return
+    setDeleteError(null)
+    try {
+      await deleteStore.mutateAsync(pendingDelete.id)
+      toast.show(`Removed ${pendingDelete.name}`)
+      closeDeleteConfirm()
+    } catch (e) {
+      // Keep the modal open so the user sees what failed and can retry/cancel.
+      setDeleteError((e as Error).message)
+    }
+  }
 
   return (
     <div className="card" style={{ padding: '14px 16px', marginBottom: 16 }}>
@@ -37,7 +64,7 @@ export function StateStoreConnectionsPanel() {
           </span>
           {s.source === 'manual' && (
             <span style={{ display: 'flex', gap: 6 }}>
-              <button className="btn danger" aria-label={`delete ${s.name}`} onClick={() => setPendingDelete(s)}>Delete</button>
+              <button className="btn danger" aria-label={`delete ${s.name}`} onClick={() => openDeleteConfirm(s)}>Delete</button>
             </span>
           )}
         </div>
@@ -45,23 +72,29 @@ export function StateStoreConnectionsPanel() {
 
       {/* Mount the dialog only while open, so the component catalog isn't
           fetched on every Components-page load — only when Add is used. */}
-      {addOpen && <StateStoreConnectionDialog open onClose={() => setAddOpen(false)} />}
+      {addOpen && (
+        <StateStoreConnectionDialog
+          open
+          onClose={() => setAddOpen(false)}
+          onSaved={(name) => {
+            setAddOpen(false)
+            toast.show(`Added ${name}`)
+          }}
+        />
+      )}
 
-      <Modal open={pendingDelete !== null} title="Delete connection?" onClose={() => setPendingDelete(null)}>
+      <Modal open={pendingDelete !== null} title="Delete connection?" onClose={closeDeleteConfirm}>
         <p style={{ margin: '0 0 8px', color: 'var(--muted)', fontSize: 14 }}>
           Remove the connection <b>{pendingDelete?.name}</b>? This only removes it from the dashboard registry.
         </p>
+        {deleteError && <p className="field-err">{deleteError}</p>}
         <div className="modal-actions">
-          <button className="btn ghost" onClick={() => setPendingDelete(null)}>Cancel</button>
-          <button
-            className="btn danger"
-            onClick={async () => {
-              if (pendingDelete) await deleteStore.mutateAsync(pendingDelete.id)
-              setPendingDelete(null)
-            }}
-          >Delete</button>
+          <button className="btn ghost" onClick={closeDeleteConfirm}>Cancel</button>
+          <button className="btn danger" onClick={handleConfirmDelete}>Delete</button>
         </div>
       </Modal>
+
+      {toastNode}
     </div>
   )
 }

--- a/web/src/lib/newsSeen.ts
+++ b/web/src/lib/newsSeen.ts
@@ -1,4 +1,5 @@
 import type { NewsResponse } from '../types/logs'
+import { safeGet, safeSet } from './safeStorage'
 
 const STORAGE_KEY = 'devdash.newsSeen'
 
@@ -15,9 +16,9 @@ export function newsUrls(n: NewsResponse): string[] {
  * Returns the set of URLs that have been marked as seen (from localStorage).
  */
 export function getSeen(): Set<string> {
+  const raw = safeGet(STORAGE_KEY)
+  if (!raw) return new Set()
   try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return new Set()
     const parsed = JSON.parse(raw)
     if (Array.isArray(parsed)) return new Set<string>(parsed)
   } catch {
@@ -35,7 +36,7 @@ export function markSeen(urls: string[]): void {
   for (const url of urls) {
     existing.add(url)
   }
-  localStorage.setItem(STORAGE_KEY, JSON.stringify([...existing]))
+  safeSet(STORAGE_KEY, JSON.stringify([...existing]))
 }
 
 /**

--- a/web/src/lib/prefs.ts
+++ b/web/src/lib/prefs.ts
@@ -1,17 +1,18 @@
 export type Theme = 'light' | 'dark'
 
 import type { HistoryOrder } from './eventOrder'
+import { safeGet, safeSet } from './safeStorage'
 
 const THEME_KEY = 'devdash.theme'
 
 export function getTheme(): Theme {
-  const v = localStorage.getItem(THEME_KEY)
+  const v = safeGet(THEME_KEY)
   if (v === 'light' || v === 'dark') return v
   return 'light' // default light
 }
 
 export function setTheme(t: Theme) {
-  localStorage.setItem(THEME_KEY, t)
+  safeSet(THEME_KEY, t)
 }
 
 export function applyPrefs() {
@@ -22,19 +23,11 @@ export function applyPrefs() {
 const HISTORY_ORDER_KEY = 'devdash.workflowHistoryOrder'
 
 export function getHistoryOrder(): HistoryOrder {
-  try {
-    const v = localStorage.getItem(HISTORY_ORDER_KEY)
-    if (v === 'asc' || v === 'desc') return v
-  } catch {
-    // localStorage may be unavailable (private mode / restricted context)
-  }
+  const v = safeGet(HISTORY_ORDER_KEY)
+  if (v === 'asc' || v === 'desc') return v
   return 'asc'
 }
 
 export function setHistoryOrder(order: HistoryOrder) {
-  try {
-    localStorage.setItem(HISTORY_ORDER_KEY, order)
-  } catch {
-    // ignore persistence failures
-  }
+  safeSet(HISTORY_ORDER_KEY, order)
 }

--- a/web/src/lib/refresh.tsx
+++ b/web/src/lib/refresh.tsx
@@ -1,4 +1,5 @@
 import { createContext, use, useState, type ReactNode } from 'react'
+import { safeGet, safeSet } from './safeStorage'
 
 const REFRESH_MS_KEY = 'devdash.refreshMs'
 const REFRESH_PAUSED_KEY = 'devdash.refreshPaused'
@@ -12,7 +13,7 @@ export interface RefreshCtx {
 }
 
 function readIntervalMs(): number {
-  const raw = localStorage.getItem(REFRESH_MS_KEY)
+  const raw = safeGet(REFRESH_MS_KEY)
   if (raw !== null) {
     const parsed = parseInt(raw, 10)
     if (!isNaN(parsed)) return parsed
@@ -21,7 +22,7 @@ function readIntervalMs(): number {
 }
 
 function readPaused(): boolean {
-  return localStorage.getItem(REFRESH_PAUSED_KEY) === 'true'
+  return safeGet(REFRESH_PAUSED_KEY) === 'true'
 }
 
 export const RefreshContext = createContext<RefreshCtx | null>(null)
@@ -31,12 +32,12 @@ export function RefreshProvider({ children }: { children: ReactNode }) {
   const [paused, setPausedState] = useState<boolean>(readPaused)
 
   function setInterval(ms: number) {
-    localStorage.setItem(REFRESH_MS_KEY, String(ms))
+    safeSet(REFRESH_MS_KEY, String(ms))
     setIntervalMs(ms)
   }
 
   function setPaused(value: boolean) {
-    localStorage.setItem(REFRESH_PAUSED_KEY, String(value))
+    safeSet(REFRESH_PAUSED_KEY, String(value))
     setPausedState(value)
   }
 

--- a/web/src/lib/safeStorage.test.tsx
+++ b/web/src/lib/safeStorage.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import React from 'react'
+import { getTheme, setTheme, getHistoryOrder, setHistoryOrder } from './prefs'
+import { RefreshProvider, useRefreshInterval } from './refresh'
+import { markSeen, getSeen } from './newsSeen'
+import { safeGet, safeSet } from './safeStorage'
+
+/**
+ * Simulates a restricted context (private mode / blocked storage) where any
+ * localStorage access throws.
+ */
+function throwingStorage(): Storage {
+  const deny = () => {
+    throw new Error('storage disabled')
+  }
+  return {
+    get length(): number {
+      throw new Error('storage disabled')
+    },
+    clear: deny,
+    getItem: deny,
+    setItem: deny,
+    removeItem: deny,
+    key: deny,
+  } as unknown as Storage
+}
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <RefreshProvider>{children}</RefreshProvider>
+)
+
+describe('storage accessors under a throwing localStorage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', throwingStorage())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('getTheme returns the default instead of throwing', () => {
+    expect(getTheme()).toBe('light')
+  })
+
+  it('setTheme does not throw', () => {
+    expect(() => setTheme('dark')).not.toThrow()
+  })
+
+  it('getHistoryOrder returns the default instead of throwing', () => {
+    expect(getHistoryOrder()).toBe('asc')
+  })
+
+  it('setHistoryOrder does not throw', () => {
+    expect(() => setHistoryOrder('desc')).not.toThrow()
+  })
+
+  it('RefreshProvider mounts with defaults (readIntervalMs / readPaused)', () => {
+    const { result } = renderHook(() => useRefreshInterval(), { wrapper })
+    expect(result.current.intervalMs).toBe(3000)
+    expect(result.current.paused).toBe(false)
+  })
+
+  it('setInterval / setPaused still update state without throwing', () => {
+    const { result } = renderHook(() => useRefreshInterval(), { wrapper })
+    act(() => {
+      result.current.setInterval(5000)
+    })
+    expect(result.current.intervalMs).toBe(5000)
+    act(() => {
+      result.current.setPaused(true)
+    })
+    expect(result.current.paused).toBe(true)
+  })
+
+  it('getSeen returns an empty set instead of throwing', () => {
+    expect(getSeen()).toEqual(new Set())
+  })
+
+  it('markSeen does not throw', () => {
+    expect(() => markSeen(['https://example.com/post'])).not.toThrow()
+  })
+})
+
+describe('safeStorage helper', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('safeGet/safeSet round-trip through localStorage when it works', () => {
+    safeSet('devdash.safeStorageTest', 'v1')
+    expect(safeGet('devdash.safeStorageTest')).toBe('v1')
+  })
+
+  it('safeGet returns null for a missing key', () => {
+    expect(safeGet('devdash.safeStorageTest.missing')).toBeNull()
+  })
+
+  it('safeGet returns null when localStorage throws', () => {
+    vi.stubGlobal('localStorage', throwingStorage())
+    expect(safeGet('devdash.safeStorageTest')).toBeNull()
+  })
+
+  it('safeSet swallows errors when localStorage throws', () => {
+    vi.stubGlobal('localStorage', throwingStorage())
+    expect(() => safeSet('devdash.safeStorageTest', 'v2')).not.toThrow()
+  })
+})

--- a/web/src/lib/safeStorage.ts
+++ b/web/src/lib/safeStorage.ts
@@ -1,0 +1,24 @@
+/**
+ * Guarded localStorage access.
+ *
+ * In restricted contexts (private browsing, blocked third-party storage,
+ * sandboxed iframes) any access to `localStorage` can throw. These helpers
+ * swallow those errors so reading/writing preferences never crashes the app.
+ */
+
+export function safeGet(key: string): string | null {
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    // localStorage may be unavailable (private mode / restricted context)
+    return null
+  }
+}
+
+export function safeSet(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value)
+  } catch {
+    // ignore persistence failures
+  }
+}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -12,27 +12,37 @@ import { ComponentBuilder } from './pages/component-builder/ComponentBuilder'
 import { Resiliency } from './pages/Resiliency'
 import { ResiliencyBuilder } from './pages/resiliency-builder/ResiliencyBuilder'
 import { ControlPlane } from './pages/ControlPlane'
+import { RouteError } from './components/RouteError'
 
 export const routes: RouteObject[] = [
   {
     path: '/',
     element: <App />,
+    // Fallback if the App shell itself fails to render: standalone error page.
+    errorElement: <RouteError />,
     children: [
-      { index: true, element: <Applications /> },
-      { path: 'apps/:appId', element: <AppDetail /> },
-      { path: 'workflows', element: <Workflows /> },
-      { path: 'workflows/:appId/:instanceId', element: <WorkflowDetail /> },
-      { path: 'actors', element: <Actors /> },
-      { path: 'subscriptions', element: <Subscriptions /> },
-      { path: 'components/new', element: <ComponentBuilder /> },
-      { path: 'components', element: <ResourceList kind="component" /> },
-      { path: 'components/:name', element: <ResourceList kind="component" /> },
-      { path: 'configurations', element: <ResourceList kind="configuration" /> },
-      { path: 'configurations/:name', element: <ResourceList kind="configuration" /> },
-      { path: 'resiliency', element: <Resiliency /> },
-      { path: 'resiliency/new', element: <ResiliencyBuilder /> },
-      { path: 'control-plane', element: <ControlPlane /> },
-      { path: 'logs', element: <Logs /> },
+      {
+        // Pathless layout route: page render errors are caught here, so the
+        // error renders inside the App shell (TopNav/sidebar stay usable).
+        errorElement: <RouteError />,
+        children: [
+          { index: true, element: <Applications /> },
+          { path: 'apps/:appId', element: <AppDetail /> },
+          { path: 'workflows', element: <Workflows /> },
+          { path: 'workflows/:appId/:instanceId', element: <WorkflowDetail /> },
+          { path: 'actors', element: <Actors /> },
+          { path: 'subscriptions', element: <Subscriptions /> },
+          { path: 'components/new', element: <ComponentBuilder /> },
+          { path: 'components', element: <ResourceList kind="component" /> },
+          { path: 'components/:name', element: <ResourceList kind="component" /> },
+          { path: 'configurations', element: <ResourceList kind="configuration" /> },
+          { path: 'configurations/:name', element: <ResourceList kind="configuration" /> },
+          { path: 'resiliency', element: <Resiliency /> },
+          { path: 'resiliency/new', element: <ResiliencyBuilder /> },
+          { path: 'control-plane', element: <ControlPlane /> },
+          { path: 'logs', element: <Logs /> },
+        ],
+      },
     ],
   },
 ]


### PR DESCRIPTION
## Summary

Second batch of fixes from the full-codebase review (follows #29). Seven verified findings, each fixed TDD-style (failing test first) in an isolated worktree by a dedicated agent, then merged and verified together.

| Fix | Severity | Area |
|-----|----------|------|
| Multi-document YAML resource files were truncated to their first document in all three scanners — later components/state stores were never detected, elected, or listed | Medium | `pkg/statestore`, `pkg/resources` |
| `docker logs` stderr was dropped from control-plane log streams; failed runtime commands surfaced as bare `exit status 1` | Medium | `pkg/controlplane/runtime.go` |
| `/api/workflows/purge` ignored JSON decode errors — malformed body returned `200 OK` with nothing purged | Medium | `pkg/server/workflows.go` |
| News cache held its mutex across the upstream HTTP fetch — requests serialized behind a 5s network timeout during outages, with no negative caching | Medium | `pkg/news` |
| Registry `Update` allowed renaming onto an existing manual connection name → duplicate IDs, cross-entry deletion | Medium | `cmd/registry.go` |
| "Added X" success toast rendered inside the dialog that `onClose` immediately unmounted — never visible; failed deletes were silent unhandled rejections | Medium | `web/src/components/StateStoreConnection*` |
| Five unguarded `localStorage` accessors ran at startup (crash in blocked-storage contexts); no route `errorElement` anywhere | Medium | `web/src/lib`, `router.tsx` |

## Details

- **Multi-doc YAML**: scanners split on `(?m)^---\s*$` and run per-doc matching on every document; per-file dedupe moved so one file can contribute multiple resources.
- **Controlplane stderr**: single `os.Pipe` shared by `cmd.Stdout`/`cmd.Stderr` (terminal-style interleaving, signatures unchanged). TDD also surfaced that an oversized line didn't just end the stream — it deadlocked `cmd.Wait`; now the pipe read end closes before `Wait` and a final `[stream error: …]` line is emitted. `run()` errors now append trimmed `ExitError.Stderr` (still `errors.As`-compatible).
- **Purge decode**: 400 with the same error shape as the statestores handlers; empty body is also 400 (the frontend always sends JSON — documented in the commit).
- **News cache**: stale-while-revalidate — fresh path unchanged; first stale caller refreshes in the background while everyone gets last-good immediately; no-last-good callers share a single in-flight fetch (hand-rolled singleflight; avoided promoting `golang.org/x/sync` to a direct dep); failures are cached for `min(ttl/2, 30s)` and never evict last-good.
- **Registry rename**: `Update` now rejects a rename onto another manual entry's name with `os.ErrExist` (self-rename still works), mirroring `Add`. Follow-up noted: the API surfaces this as `"file already exists"` — wrapping it like `AddStore` does would be friendlier.
- **Connection UX**: toast ownership lifted to the panel (`onSaved(name)` callback; the dialog no longer closes itself), delete failures render inline in the confirm modal and keep it open for retry; successful delete shows a "Removed X" toast.
- **Storage guards + error boundary**: new `lib/safeStorage.ts` (`safeGet`/`safeSet`) now backs every `localStorage` touchpoint in `prefs.ts`, `refresh.tsx`, `newsSeen.ts`, and `App.tsx`. New `RouteError` component wired as `errorElement` on a pathless layout route (errors render inside the app shell with TopNav intact) plus a root-level standalone fallback; uses existing styleguide classes only.

## Verification

- `go test -tags unit -race ./...` — all 13 packages pass
- `npx vitest run` — 494/494 tests pass (72 files)
- `npx tsc -b` — clean
- `gofmt` / `go vet` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)