### PR TITLE
fix: follow-scroll stops pinning once the log buffer cap is reached

### DIFF
--- a/web/src/hooks/useFollowScroll.ts
+++ b/web/src/hooks/useFollowScroll.ts
@@ -10,17 +10,20 @@ const SCROLL_THRESHOLD = 24
  * Shared follow/auto-scroll mechanics for log viewers.
  *
  * While `following` is true, pins the scroll container to the bottom whenever
- * `itemCount` changes (new lines arrived) or follow is re-engaged. Returns a
- * scroll handler to attach via `onScroll`: when the user scrolls more than
- * SCROLL_THRESHOLD px away from the bottom while following, `onDisengage`
- * fires so the caller can turn follow off.
+ * `revision` changes (new lines arrived) or follow is re-engaged. Pass a
+ * monotonic arrival counter (`useLogStream().revision`), NOT the buffer
+ * length: at the buffer cap, drop-one-append-one keeps the length constant
+ * and pinning would silently stop. Returns a scroll handler to attach via
+ * `onScroll`: when the user scrolls more than SCROLL_THRESHOLD px away from
+ * the bottom while following, `onDisengage` fires so the caller can turn
+ * follow off.
  *
  * Zero-height (unlaid-out) elements are ignored in both directions so hidden
  * panes neither jump nor disengage follow.
  */
 export function useFollowScroll(
   ref: RefObject<HTMLElement | null>,
-  itemCount: number,
+  revision: number,
   following: boolean,
   onDisengage: () => void,
 ): () => void {
@@ -32,7 +35,7 @@ export function useFollowScroll(
     if (el.scrollHeight > 0) {
       el.scrollTop = el.scrollHeight
     }
-  }, [ref, itemCount, following])
+  }, [ref, revision, following])
 
   function handleScroll() {
     const el = ref.current

--- a/web/src/hooks/useLogStream.test.tsx
+++ b/web/src/hooks/useLogStream.test.tsx
@@ -40,6 +40,22 @@ describe('useLogStream', () => {
     expect(result.current.lines[1].text).toBe('line3')
   })
 
+  it('revision keeps counting past the buffer cap while lines stay capped', () => {
+    const { result } = renderHook(() => useLogStream('order', 'daprd', { max: 3 }))
+    const es = FakeES.instances[0]
+    act(() => {
+      for (let i = 1; i <= 5; i++) es.onmessage?.({ data: `line${i}` })
+    })
+    // The buffer is capped...
+    expect(result.current.lines).toHaveLength(3)
+    // ...but revision reflects every line ever received, so consumers keying
+    // effects on it (e.g. follow-scroll) still fire after the cap is reached.
+    expect(result.current.revision).toBe(5)
+    act(() => { es.onmessage?.({ data: 'line6' }) })
+    expect(result.current.lines).toHaveLength(3)
+    expect(result.current.revision).toBe(6)
+  })
+
   it('status transitions: connecting → open → error', () => {
     const { result } = renderHook(() => useLogStream('order', 'daprd'))
     expect(result.current.status).toBe('connecting')

--- a/web/src/hooks/useLogStream.ts
+++ b/web/src/hooks/useLogStream.ts
@@ -12,6 +12,12 @@ export type LogStreamStatus = 'idle' | 'connecting' | 'open' | 'error' | 'closed
 
 interface UseLogStreamResult {
   lines: LogLine[]
+  /**
+   * Total lines ever received on this stream — monotonic, unaffected by the
+   * buffer cap. Key follow-scroll effects on this, not lines.length: at the
+   * cap, drop-one-append-one keeps the length constant forever.
+   */
+  revision: number
   status: LogStreamStatus
   clear: () => void
 }
@@ -29,6 +35,7 @@ export function usePathLogStream(
   opts?: { max?: number },
 ): UseLogStreamResult {
   const [lines, setLines] = useState<LogLine[]>([])
+  const [revision, setRevision] = useState(0)
   const [status, setStatus] = useState<LogStreamStatus>('idle')
   const seqRef = useRef(0)
   // Keep max current via a ref so changes don't tear down the EventSource connection
@@ -65,6 +72,7 @@ export function usePathLogStream(
         const next = [...prev, line]
         return next.length > cap ? next.slice(next.length - cap) : next
       })
+      setRevision(r => r + 1)
     }
 
     es.onerror = () => {
@@ -78,7 +86,7 @@ export function usePathLogStream(
     }
   }, [path])
 
-  return { lines, status, clear }
+  return { lines, revision, status, clear }
 }
 
 /**

--- a/web/src/pages/Logs.test.tsx
+++ b/web/src/pages/Logs.test.tsx
@@ -543,6 +543,37 @@ describe('Logs', () => {
     expect(screen.getByRole('button', { name: /^Follow$/i })).toHaveAttribute('aria-pressed', 'false')
   })
 
+  // Follow must keep pinning at the line cap: once the buffer is full, each
+  // new line drops the oldest so lines.length stops changing — an effect keyed
+  // on length alone silently stops scrolling while "Following" stays lit.
+  it('F4 — follow still pins to bottom after the 2000-line cap is reached', async () => {
+    server.use(
+      http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+      http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+    )
+
+    renderAt('/logs?app=order&source=daprd')
+    await waitFor(() => expect(FakeES.instances.length).toBeGreaterThanOrEqual(1))
+    expect(screen.getByRole('button', { name: /Following/i })).toHaveClass('on')
+
+    const logwin = document.querySelector('.logwin') as HTMLDivElement
+    Object.defineProperty(logwin, 'scrollHeight', { value: 500, configurable: true })
+    Object.defineProperty(logwin, 'scrollTop', { value: 0, configurable: true, writable: true })
+    Object.defineProperty(logwin, 'clientHeight', { value: 200, configurable: true })
+
+    // Fill exactly to the cap (one batched render), then reset the pin marker.
+    act(() => {
+      for (let i = 0; i < 2000; i++) {
+        FakeES.instances[0].onmessage?.({ data: `level=info line-${i}` })
+      }
+    })
+    logwin.scrollTop = 0
+
+    // One more line while at the cap: length stays 2000, but follow must re-pin.
+    act(() => { FakeES.instances[0].onmessage?.({ data: 'level=info past-cap' }) })
+    expect(logwin.scrollTop).toBe(500)
+  })
+
   // New F2: single-source mode opens exactly ONE EventSource
   it('F2-new — source=daprd opens exactly ONE EventSource (daprd only)', async () => {
     server.use(

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -247,7 +247,14 @@ function LogViewerCore({
     return all
   }, [source, daprdResult.lines, appResult.lines])
 
-  const handleScroll = useFollowScroll(scrollRef, merged.length, following, onFollowDisengage)
+  // Key on the streams' revisions, not merged.length: at the line cap the
+  // length stops changing (drop-one-append-one) and follow would silently die.
+  const handleScroll = useFollowScroll(
+    scrollRef,
+    daprdResult.revision + appResult.revision,
+    following,
+    onFollowDisengage,
+  )
 
   const filtered = merged.filter(({ line }) => lineMatches(line, activeLevels, search))
 
@@ -306,10 +313,11 @@ function CpLogViewer({
   following,
   onFollowDisengage,
 }: CpLogViewerProps) {
-  const { lines, status } = usePathLogStream(`/controlplane/${cp}/logs`)
+  const { lines, revision, status } = usePathLogStream(`/controlplane/${cp}/logs`)
   const scrollRef = useRef<HTMLDivElement>(null)
 
-  const handleScroll = useFollowScroll(scrollRef, lines.length, following, onFollowDisengage)
+  // revision, not lines.length — see LogViewerCore's note on the line cap.
+  const handleScroll = useFollowScroll(scrollRef, revision, following, onFollowDisengage)
 
   const filtered = lines.filter(line => lineMatches(line, activeLevels, search))
   const matchCount = countMatches(lines, search)


### PR DESCRIPTION
## Summary

Fixes the log-viewer quirk deferred from the review series (#29–#32): with Follow engaged, once a stream accumulates 2000 lines (the buffer cap), each new line drops the oldest — `lines.length` stays constant, so the pin-to-bottom effect keyed on it never fires again. New lines keep rendering while the viewport silently stops following, with the Follow button still lit.

## Fix

- `useLogStream`/`usePathLogStream` now expose **`revision`** — a monotonic count of lines ever received, unaffected by the cap
- Both viewers key `useFollowScroll` on it (`daprd + app` revisions summed for the merged view)
- `useFollowScroll`'s parameter renamed `itemCount` → `revision` with the cap caveat documented, so the next caller doesn't reintroduce the bug with a length

## Tests (TDD)

- **Hook**: `revision` keeps counting past the cap while `lines` stays capped — failed pre-fix (`expected undefined to be 5`)
- **Page**: fill to exactly 2000 lines, send one more, assert the pane re-pins — failed pre-fix (`expected +0 to be 500`), reproducing the user-visible bug

`npx vitest run` — 578/578 (76 files) · `npx tsc -b` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)