### PR TITLE
feat: add Rust detection and Java/Rust runtime swatch colors

### DIFF
--- a/pkg/discovery/infer.go
+++ b/pkg/discovery/infer.go
@@ -6,6 +6,8 @@ import "strings"
 func InferRuntime(appCommand string) string {
 	c := strings.ToLower(appCommand)
 	switch {
+	case strings.Contains(c, "cargo"), strings.Contains(c, "target/release"), strings.Contains(c, "target/debug"):
+		return "rust"
 	case strings.Contains(c, "go run"), strings.HasPrefix(c, "go "):
 		return "go"
 	case strings.Contains(c, "python"):
@@ -39,6 +41,8 @@ func InferRuntimeFromImage(image string) string {
 	case strings.Contains(c, "openjdk"), strings.Contains(c, "temurin"),
 		strings.Contains(c, "java"), strings.Contains(c, "jre"), strings.Contains(c, "jdk"):
 		return "java"
+	case strings.Contains(c, "rust"):
+		return "rust"
 	default:
 		return "unknown"
 	}

--- a/pkg/discovery/infer_test.go
+++ b/pkg/discovery/infer_test.go
@@ -14,7 +14,9 @@ func TestInferRuntime(t *testing.T) {
 		"npm run start":           "node",
 		"dotnet run":              "dotnet",
 		"java -jar app.jar":       "java",
-		"./target/release/app":    "unknown",
+		"cargo run":               "rust",
+		"./target/release/app":    "rust",
+		"./target/debug/app":      "rust",
 		"":                        "unknown",
 	}
 	for cmd, want := range cases {
@@ -30,6 +32,7 @@ func TestInferRuntimeFromImage(t *testing.T) {
 		"mcr.microsoft.com/dotnet/aspnet:9.0": "dotnet",
 		"eclipse-temurin:21":                  "java",
 		"openjdk:21":                          "java",
+		"rust:1.75-slim":                      "rust",
 		"saga-primes-go":                      "unknown",
 		"":                                    "unknown",
 	}

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -14,7 +14,7 @@ const (
 type Instance struct {
 	AppID              string         `json:"appId"`
 	Health             Health         `json:"health"`
-	Runtime            string         `json:"runtime"`            // e.g. "go", "python", "node", "dotnet", "java", "unknown"
+	Runtime            string         `json:"runtime"`            // e.g. "go", "python", "node", "dotnet", "java", "rust", "unknown"
 	IsAspire           bool           `json:"isAspire,omitempty"` // true when the app is .NET Aspire-managed
 	Source             string         `json:"source"`             // "standalone" | "compose"
 	ComposeProject     string         `json:"composeProject,omitempty"`

--- a/web/src/lib/runtimeSwatch.test.ts
+++ b/web/src/lib/runtimeSwatch.test.ts
@@ -38,8 +38,16 @@ describe('runtimeSwatch', () => {
     expect(runtimeSwatch('dotnet')).toBe('#8330FF')
   })
 
+  it('maps java runtimes to the Java orange', () => {
+    expect(runtimeSwatch('java 21')).toBe('#ED8B00')
+  })
+
+  it('maps rust runtimes to the Rust orange', () => {
+    expect(runtimeSwatch('rust')).toBe('#CE422B')
+  })
+
   it('falls back to the faint CSS variable for unknown runtimes', () => {
-    expect(runtimeSwatch('rust')).toBe('var(--faint)')
+    expect(runtimeSwatch('unknown')).toBe('var(--faint)')
   })
 
   it('is case-insensitive', () => {

--- a/web/src/lib/runtimeSwatch.ts
+++ b/web/src/lib/runtimeSwatch.ts
@@ -22,5 +22,7 @@ export function runtimeSwatch(runtime: string): string {
   if (r.includes('python') || r.includes('py')) return '#3776AB'
   if (r.includes('node') || r.includes('js')) return '#539E43'
   if (r.includes('.net') || r.includes('dotnet')) return '#8330FF'
+  if (r.includes('java')) return '#ED8B00'
+  if (r.includes('rust')) return '#CE422B'
   return 'var(--faint)'
 }


### PR DESCRIPTION
Rust apps were never detected by InferRuntime/InferRuntimeFromImage, and Java had no distinct swatch color, so both looked identical to "unknown" on the Applications page.