### PR TITLE
Remove Kubernetes-only control-plane placeholder cards

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -323,8 +323,7 @@ components-contrib `state.Store` (+ `KeysLiker`) interface.
 `New()` resolves a container runtime — `DASH_CONTAINER_RUNTIME` override, else `docker`,
 else `podman`, else none. `List()` probes reachability, then `docker inspect` +
 `docker stats` each known container: `dapr_scheduler` and `dapr_placement` are the
-**actionable** self-hosted containers (`LiveServiceNames`); `dapr_sentry` and
-`dapr_injector` are surfaced as **kubernetes-only** (not actionable). It returns status,
+**actionable** self-hosted containers (`LiveServiceNames`). It returns status,
 health, port bindings, memory, and log path per service. `List()` additionally detects
 compose containers whose command is `placement`/`scheduler`, surfaces them with a
 `composeProject`, and `Do`/`LogStream` accept the compose names discovered by the most

--- a/README.md
+++ b/README.md
@@ -437,8 +437,8 @@ sidecars and state store.
   extended metadata, then streamed to the SPA over SSE.
 - **Control plane** is inspected through the resolved container runtime (`docker`, else
   `podman`): `dapr_scheduler` / `dapr_placement` are the self-hosted containers the dashboard
-  can start/restart/stop (allowlisted to those names), while `dapr_sentry` / `dapr_injector`
-  are shown as kubernetes-only. Container logs stream over SSE via `docker logs -f`.
+  can start/restart/stop (allowlisted to those names). Container logs stream over SSE via
+  `docker logs -f`.
 - **News** (optional) — the Resources sidebar pulls the Diagrid product feed, proxied and
   cached behind the backend's own `GET /api/news` endpoint so the SPA only ever talks to its
   own origin.

--- a/pkg/controlplane/service.go
+++ b/pkg/controlplane/service.go
@@ -60,7 +60,7 @@ func (m *manager) List(ctx context.Context) (ListResult, error) {
 	composeSvcs := m.composeControlPlane(ctx)
 	statNames := append(append([]string{}, LiveServiceNames...), serviceNames(composeSvcs)...)
 	mem := m.memory(ctx, statNames)
-	services := make([]Service, 0, len(LiveServiceNames)+len(K8sOnlyServiceNames)+len(composeSvcs))
+	services := make([]Service, 0, len(LiveServiceNames)+len(composeSvcs))
 	present := false
 	for _, name := range LiveServiceNames {
 		svc := Service{Name: name, Status: StatusStopped, Actionable: true}
@@ -85,9 +85,6 @@ func (m *manager) List(ctx context.Context) (ListResult, error) {
 			svc.Ports = []string{}
 		}
 		services = append(services, svc)
-	}
-	for _, name := range K8sOnlyServiceNames {
-		services = append(services, Service{Name: name, Status: StatusK8sOnly, Actionable: false})
 	}
 	for i := range composeSvcs {
 		if ms, ok := mem[composeSvcs[i].Name]; ok {

--- a/pkg/controlplane/service_test.go
+++ b/pkg/controlplane/service_test.go
@@ -74,9 +74,8 @@ func TestListRunningService(t *testing.T) {
 	if !res.ControlPlanePresent {
 		t.Error("ControlPlanePresent = false, want true (containers found)")
 	}
-	// 2 live + 2 k8s-only placeholders
-	if len(res.Services) != 4 {
-		t.Fatalf("len(Services) = %d, want 4", len(res.Services))
+	if len(res.Services) != 2 {
+		t.Fatalf("len(Services) = %d, want 2", len(res.Services))
 	}
 	sched := res.Services[0]
 	if sched.Name != "dapr_scheduler" || sched.Status != StatusRunning || !sched.Healthy {
@@ -84,11 +83,6 @@ func TestListRunningService(t *testing.T) {
 	}
 	if sched.MemoryBytes == 0 {
 		t.Error("scheduler MemoryBytes = 0, want > 0")
-	}
-	// last two are k8s-only, non-actionable
-	k8s := res.Services[3]
-	if k8s.Status != StatusK8sOnly || k8s.Actionable {
-		t.Errorf("k8s placeholder = %+v, want kubernetes-only + non-actionable", k8s)
 	}
 }
 
@@ -171,9 +165,8 @@ func TestListReachableButNoContainers(t *testing.T) {
 	if res.ControlPlanePresent {
 		t.Error("ControlPlanePresent = true, want false (no containers)")
 	}
-	// still returns 4 services (2 live + 2 k8s placeholders)
-	if len(res.Services) != 4 {
-		t.Fatalf("len(Services) = %d, want 4", len(res.Services))
+	if len(res.Services) != 2 {
+		t.Fatalf("len(Services) = %d, want 2", len(res.Services))
 	}
 	// A stopped/absent container has no port bindings; Ports must be a non-nil
 	// empty slice so it marshals to JSON [] (not null) and never breaks the

--- a/pkg/controlplane/types.go
+++ b/pkg/controlplane/types.go
@@ -17,7 +17,6 @@ type ServiceStatus string
 const (
 	StatusRunning ServiceStatus = "running"
 	StatusStopped ServiceStatus = "stopped"
-	StatusK8sOnly ServiceStatus = "kubernetes-only"
 	StatusUnknown ServiceStatus = "unknown"
 )
 
@@ -36,13 +35,6 @@ type Service struct {
 
 // LiveServiceNames are the self-hosted control-plane containers this dashboard manages.
 var LiveServiceNames = []string{"dapr_scheduler", "dapr_placement"}
-
-// K8sOnlyServiceNames exist only on Kubernetes; shown as disabled placeholders.
-var K8sOnlyServiceNames = []string{"dapr_sentry", "dapr_injector"}
-
-func IsControlPlaneName(name string) bool {
-	return IsLiveName(name) || contains(K8sOnlyServiceNames, name)
-}
 
 func IsLiveName(name string) bool {
 	return contains(LiveServiceNames, name)

--- a/pkg/controlplane/types_test.go
+++ b/pkg/controlplane/types_test.go
@@ -4,29 +4,12 @@ package controlplane
 
 import "testing"
 
-func TestIsControlPlaneName(t *testing.T) {
-	cases := map[string]bool{
-		"dapr_scheduler": true,
-		"dapr_placement": true,
-		"dapr_sentry":    true,
-		"dapr_injector":  true,
-		"dapr_redis":     false,
-		"":               false,
-		"scheduler":      false,
-	}
-	for name, want := range cases {
-		if got := IsControlPlaneName(name); got != want {
-			t.Errorf("IsControlPlaneName(%q) = %v, want %v", name, got, want)
-		}
-	}
-}
-
 func TestIsLiveName(t *testing.T) {
 	if !IsLiveName("dapr_scheduler") {
 		t.Error("scheduler should be live")
 	}
 	if IsLiveName("dapr_sentry") {
-		t.Error("sentry is k8s-only, not live")
+		t.Error("sentry is not a self-hosted control-plane container")
 	}
 }
 

--- a/web/src/pages/ControlPlane.test.tsx
+++ b/web/src/pages/ControlPlane.test.tsx
@@ -67,17 +67,6 @@ describe('ControlPlane', () => {
     expect(screen.getByRole('button', { name: /^start$/i })).toBeInTheDocument()
   })
 
-  it('renders k8s-only services without actions', async () => {
-    mockList({
-      runtime: 'docker', available: true, reachable: true, controlPlanePresent: true,
-      services: [{ name: 'dapr_sentry', status: 'kubernetes-only', healthy: false, ports: [], memoryBytes: 0, memoryHuman: '', logPath: '', actionable: false }],
-    })
-    renderPage()
-    expect(await screen.findByText('dapr_sentry')).toBeInTheDocument()
-    expect(screen.getByText(/kubernetes only/i)).toBeInTheDocument()
-    expect(screen.queryByRole('button')).not.toBeInTheDocument()
-  })
-
   it('groups compose-run control-plane services under their project', async () => {
     mockList({
       runtime: 'docker',

--- a/web/src/pages/ControlPlane.tsx
+++ b/web/src/pages/ControlPlane.tsx
@@ -100,58 +100,51 @@ function ServiceCard({
   svc: ControlPlaneService
   onAction: (name: string, act: ControlPlaneAction) => void
 }) {
-  const isK8s = svc.status === 'kubernetes-only'
   return (
-    <div className={isK8s ? 'card faint cp-card' : 'card cp-card'}>
+    <div className="card cp-card">
       <div className="b">{svc.name}</div>
-      {isK8s ? (
-        <div className="sub">Kubernetes only</div>
-      ) : (
-        <>
-          <div className="cp-field">
-            <div className="cp-label">Status</div>
-            <span className="health">
-              <span className={svc.healthy ? 'led ok' : 'led bad'} />
-              {svc.status}
-            </span>
-          </div>
-          <div className="cp-field">
-            <div className="cp-label">Ports</div>
-            <div className="cp-value mono faint">
-              {svc.ports && svc.ports.length ? svc.ports.join(', ') : '—'}
-            </div>
-          </div>
-          <div className="cp-field">
-            <div className="cp-label">Memory</div>
-            <div className="cp-value mono">
-              {svc.memoryHuman || '—'}
-            </div>
-          </div>
-          <div className="cp-field">
-            <div className="cp-label">Log</div>
-            <div className="cp-value mono faint cp-logpath">
-              {svc.logPath || '—'}
-            </div>
-          </div>
-          <div className="cp-field">
-            <Link className="chip k" to={`/logs?cp=${encodeURIComponent(svc.name)}`}>
-              View logs
-            </Link>
-          </div>
-          {svc.actionable && (
-            <div className="actions">
-              {svc.status === 'stopped' && (
-                <button className="btn ghost" onClick={() => onAction(svc.name, 'start')}>Start</button>
-              )}
-              {svc.status === 'running' && (
-                <>
-                  <button className="btn ghost" onClick={() => onAction(svc.name, 'restart')}>Restart</button>
-                  <button className="btn danger" onClick={() => onAction(svc.name, 'stop')}>Stop</button>
-                </>
-              )}
-            </div>
+      <div className="cp-field">
+        <div className="cp-label">Status</div>
+        <span className="health">
+          <span className={svc.healthy ? 'led ok' : 'led bad'} />
+          {svc.status}
+        </span>
+      </div>
+      <div className="cp-field">
+        <div className="cp-label">Ports</div>
+        <div className="cp-value mono faint">
+          {svc.ports && svc.ports.length ? svc.ports.join(', ') : '—'}
+        </div>
+      </div>
+      <div className="cp-field">
+        <div className="cp-label">Memory</div>
+        <div className="cp-value mono">
+          {svc.memoryHuman || '—'}
+        </div>
+      </div>
+      <div className="cp-field">
+        <div className="cp-label">Log</div>
+        <div className="cp-value mono faint cp-logpath">
+          {svc.logPath || '—'}
+        </div>
+      </div>
+      <div className="cp-field">
+        <Link className="chip k" to={`/logs?cp=${encodeURIComponent(svc.name)}`}>
+          View logs
+        </Link>
+      </div>
+      {svc.actionable && (
+        <div className="actions">
+          {svc.status === 'stopped' && (
+            <button className="btn ghost" onClick={() => onAction(svc.name, 'start')}>Start</button>
           )}
-        </>
+          {svc.status === 'running' && (
+            <>
+              <button className="btn ghost" onClick={() => onAction(svc.name, 'restart')}>Restart</button>
+              <button className="btn danger" onClick={() => onAction(svc.name, 'stop')}>Stop</button>
+            </>
+          )}
+        </div>
       )}
     </div>
   )

--- a/web/src/pages/Logs.test.tsx
+++ b/web/src/pages/Logs.test.tsx
@@ -97,8 +97,6 @@ const CP_LIST_BASE = {
   services: [
     { name: 'dapr_scheduler', status: 'running', healthy: true, ports: [], memoryBytes: 0, memoryHuman: '', logPath: '', actionable: true },
     { name: 'dapr_placement', status: 'running', healthy: true, ports: [], memoryBytes: 0, memoryHuman: '', logPath: '', actionable: true },
-    { name: 'dapr_sentry', status: 'kubernetes-only', healthy: false, ports: [], memoryBytes: 0, memoryHuman: '', logPath: '', actionable: false },
-    { name: 'dapr_injector', status: 'kubernetes-only', healthy: false, ports: [], memoryBytes: 0, memoryHuman: '', logPath: '', actionable: false },
   ],
 }
 

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -15,7 +15,7 @@ type LogSource = (typeof LOG_SOURCES)[number]
 
 // Static fallback so the selector renders before /api/controlplane answers;
 // compose-managed placement/scheduler containers are merged in from the API.
-const CP_SERVICES = ['dapr_scheduler', 'dapr_placement', 'dapr_sentry', 'dapr_injector'] as const
+const CP_SERVICES = ['dapr_scheduler', 'dapr_placement'] as const
 
 /** A merged row carries the original LogLine plus its tagged source. */
 interface MergedLine {

--- a/web/src/types/controlplane.ts
+++ b/web/src/types/controlplane.ts
@@ -1,4 +1,4 @@
-export type ServiceStatus = 'running' | 'stopped' | 'kubernetes-only' | 'unknown'
+export type ServiceStatus = 'running' | 'stopped' | 'unknown'
 
 export interface ControlPlaneService {
   name: string


### PR DESCRIPTION
## Summary
- The dashboard currently has no Kubernetes support (self-hosted Docker/Podman only), so the `dapr_sentry` and `dapr_injector` cards on the Control Plane page were hardcoded, unactionable placeholders that could never show real data.
- Removes the backend placeholder entries (`K8sOnlyServiceNames`, `StatusK8sOnly`) and the frontend's faint "Kubernetes only" card branch, plus the dead `dapr_sentry`/`dapr_injector` entries in the Logs page's control-plane source dropdown.
- This is scaffolding that can be reintroduced later if/when real Kubernetes cluster introspection is added.

## Test plan
- [x] `go build ./...`
- [x] `go test -tags=unit ./pkg/controlplane/...`
- [x] `npx vitest run src/pages/ControlPlane.test.tsx src/pages/Logs.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)