### PR TITLE
UI polish: nav order, footer feedback link, 768px min width

### DIFF
--- a/docs/superpowers/plans/2026-07-06-ui-polish-nav-footer-minwidth.md
+++ b/docs/superpowers/plans/2026-07-06-ui-polish-nav-footer-minwidth.md
@@ -1,0 +1,298 @@
+# UI Polish (nav order, footer feedback link, 768px min width) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Swap the Configurations/Resiliency top-nav order, add an "Issues & feedback" GitHub link to the sidebar footer, and lower the small-screen warning threshold from 1024px to 768px.
+
+**Architecture:** Three independent, single-file UI tweaks in the React web dashboard (`web/`). Each change is pinned by a Vitest unit test. No new components, routes, or dependencies.
+
+**Tech Stack:** React 19 + TypeScript, Vitest + Testing Library, plain CSS (`web/src/styles/theme.css`).
+
+**Spec:** `docs/superpowers/specs/2026-07-06-ui-polish-nav-footer-minwidth-design.md`
+
+## Global Constraints
+
+- All commands run from `web/` (`npm test`, `npm run build`).
+- Footer link text is exactly `Issues & feedback`; href is exactly `https://github.com/diagridio/dev-dashboard` (repo root, NOT `/issues`).
+- New small-screen threshold is exactly `768` (75% of 1024). Width-only; no height guard.
+- External links use `target="_blank" rel="noopener noreferrer"`, matching the existing Diagrid link.
+- No other nav labels/routes change; only the order of two items moves.
+
+---
+
+### Task 1: Swap Configurations and Resiliency in the top nav
+
+**Files:**
+- Modify: `web/src/components/TopNav.tsx:12-22` (the `NAV_ITEMS` array)
+- Test: `web/src/components/TopNav.test.tsx:9-43`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: `NAV_ITEMS: NavItem[]` export keeps the same shape (`{ label: string, to: string }[]`); only element order changes (Resiliency now index 5, Configurations index 6).
+
+- [ ] **Step 1: Update the order-asserting tests to expect the new order**
+
+In `web/src/components/TopNav.test.tsx`, in the `describe('NAV_ITEMS')` block, swap the two entries in both assertions so they read:
+
+```tsx
+  it('has exactly 9 items in the correct order', () => {
+    const labels = NAV_ITEMS.map((i) => i.label)
+    expect(labels).toEqual([
+      'Applications',
+      'Workflows',
+      'Actors',
+      'Subscriptions',
+      'Components',
+      'Resiliency',
+      'Configurations',
+      'Control Plane',
+      'Logs',
+    ])
+  })
+
+  it('has correct paths', () => {
+    const paths = NAV_ITEMS.map((i) => i.to)
+    expect(paths).toEqual([
+      '/',
+      '/workflows',
+      '/actors',
+      '/subscriptions',
+      '/components',
+      '/resiliency',
+      '/configurations',
+      '/control-plane',
+      '/logs',
+    ])
+  })
+```
+
+(Leave the `includes a Control Plane nav item` test and everything else untouched.)
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run (from `web/`): `npm test -- src/components/TopNav.test.tsx`
+Expected: FAIL — both order tests report the array mismatch (Configurations/Resiliency swapped).
+
+- [ ] **Step 3: Swap the two entries in NAV_ITEMS**
+
+In `web/src/components/TopNav.tsx`, change the `NAV_ITEMS` array to:
+
+```tsx
+export const NAV_ITEMS: NavItem[] = [
+  { label: 'Applications', to: '/' },
+  { label: 'Workflows', to: '/workflows' },
+  { label: 'Actors', to: '/actors' },
+  { label: 'Subscriptions', to: '/subscriptions' },
+  { label: 'Components', to: '/components' },
+  { label: 'Resiliency', to: '/resiliency' },
+  { label: 'Configurations', to: '/configurations' },
+  { label: 'Control Plane', to: '/control-plane' },
+  { label: 'Logs', to: '/logs' },
+]
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run (from `web/`): `npm test -- src/components/TopNav.test.tsx`
+Expected: PASS (all tests in the file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/components/TopNav.tsx web/src/components/TopNav.test.tsx
+git commit -m "feat(web): move Resiliency before Configurations in top nav"
+```
+
+---
+
+### Task 2: Add "Issues & feedback" link to the sidebar footer
+
+**Files:**
+- Modify: `web/src/components/ResourcesSidebar.tsx:245-257` (the `.sbfoot` block)
+- Modify: `web/src/styles/theme.css:98` (the `.sbfoot` rule)
+- Test: `web/src/components/ResourcesSidebar.test.tsx:317-335` (the `ResourcesSidebar footer` describe block)
+
+**Interfaces:**
+- Consumes: nothing from other tasks. Uses the file's existing `renderSidebar()` helper (defined at the top of the test file) and the existing `screen` import.
+- Produces: nothing consumed by other tasks.
+
+- [ ] **Step 1: Write the failing test**
+
+In `web/src/components/ResourcesSidebar.test.tsx`, add a second `it` inside the existing `describe('ResourcesSidebar footer', ...)` block (after the `renders Powered by Diagrid link and version in sbfoot` test):
+
+```tsx
+  it('renders Issues & feedback link to the GitHub repo', async () => {
+    renderSidebar()
+    const link = await screen.findByRole('link', { name: 'Issues & feedback' })
+    expect(link).toHaveAttribute('href', 'https://github.com/diagridio/dev-dashboard')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    // Lives inside the footer, below the Powered by line
+    expect(link.closest('.sbfoot')).not.toBeNull()
+  })
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (from `web/`): `npm test -- src/components/ResourcesSidebar.test.tsx`
+Expected: FAIL — `Unable to find role="link" and name "Issues & feedback"`.
+
+- [ ] **Step 3: Add the link to the footer**
+
+In `web/src/components/ResourcesSidebar.tsx`, extend the `.sbfoot` div so it reads:
+
+```tsx
+      <div className="sbfoot">
+        <span className="pw">
+          Powered by{' '}
+          <a
+            href="https://diagrid.io/?utm_source=dev-dashboard&utm_medium=footer"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Diagrid
+          </a>
+          {' · '}v{version}
+        </span>
+        <span className="pw">
+          <a
+            href="https://github.com/diagridio/dev-dashboard"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Issues &amp; feedback
+          </a>
+        </span>
+      </div>
+```
+
+- [ ] **Step 4: Stack the two footer lines in CSS**
+
+In `web/src/styles/theme.css`, change the `.sbfoot` rule (line 98) from:
+
+```css
+.sbfoot { padding: 10px 14px; border-top: 1px solid var(--line-soft); }
+```
+
+to:
+
+```css
+.sbfoot { padding: 10px 14px; border-top: 1px solid var(--line-soft); display: grid; gap: 2px; }
+```
+
+(Leave `.sbfoot .pw`, `.pw a`, and the collapsed/media-query rules untouched — they already hide the whole footer when collapsed or narrow, which covers the new link too.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run (from `web/`): `npm test -- src/components/ResourcesSidebar.test.tsx`
+Expected: PASS (all tests in the file, including the pre-existing footer test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/components/ResourcesSidebar.tsx web/src/components/ResourcesSidebar.test.tsx web/src/styles/theme.css
+git commit -m "feat(web): add Issues & feedback link to sidebar footer"
+```
+
+---
+
+### Task 3: Lower the small-screen warning threshold to 768px
+
+**Files:**
+- Modify: `web/src/components/SmallScreenGuard.tsx:4` (the `MIN_WIDTH` constant)
+- Test: `web/src/components/SmallScreenGuard.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: nothing consumed by other tasks. `SmallScreenGuard` keeps its `{ children: ReactNode }` props.
+
+- [ ] **Step 1: Write the failing test**
+
+The existing tests mock `matchMedia` with a fixed boolean and never inspect the query string, so the threshold is currently untested. Add a test that captures the query. In `web/src/components/SmallScreenGuard.test.tsx`, add inside the `describe('SmallScreenGuard')` block:
+
+```tsx
+  it('uses a 768px minimum width media query', () => {
+    const queries: string[] = []
+    vi.stubGlobal('matchMedia', (query: string) => {
+      queries.push(query)
+      return {
+        matches: true, media: query, onchange: null,
+        addEventListener: vi.fn(), removeEventListener: vi.fn(),
+        addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+      }
+    })
+    render(<SmallScreenGuard><div>content</div></SmallScreenGuard>)
+    expect(queries).toContain('(min-width: 768px)')
+  })
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (from `web/`): `npm test -- src/components/SmallScreenGuard.test.tsx`
+Expected: FAIL — the new test reports `queries` containing `'(min-width: 1024px)'`, not `'(min-width: 768px)'`. The two pre-existing tests still pass.
+
+- [ ] **Step 3: Change the constant**
+
+In `web/src/components/SmallScreenGuard.tsx`, change line 4 from:
+
+```tsx
+const MIN_WIDTH = 1024
+```
+
+to:
+
+```tsx
+const MIN_WIDTH = 768
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run (from `web/`): `npm test -- src/components/SmallScreenGuard.test.tsx`
+Expected: PASS (all 3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/components/SmallScreenGuard.tsx web/src/components/SmallScreenGuard.test.tsx
+git commit -m "feat(web): allow windows down to 768px before small-screen warning"
+```
+
+---
+
+### Task 4: Full-suite verification and manual spot-check
+
+**Files:**
+- No file changes expected (fix regressions if any appear).
+
+**Interfaces:**
+- Consumes: the three completed tasks above.
+- Produces: a verified, buildable main-ready branch.
+
+- [ ] **Step 1: Run the full web test suite**
+
+Run (from `web/`): `npm test`
+Expected: PASS — no failures anywhere (other suites reference nav items and the sidebar; confirm nothing else pinned the old order or footer text).
+
+- [ ] **Step 2: Run the production build**
+
+Run (from `web/`): `npm run build`
+Expected: `tsc -b` and `vite build` both succeed with no errors.
+
+- [ ] **Step 3: Manual verification in the running app**
+
+Start the dashboard (from `web/`): `npm run dev`, open the printed URL, then confirm:
+
+1. Top nav reads: Applications, Workflows, Actors, Subscriptions, Components, **Resiliency, Configurations**, Control Plane, Logs.
+2. The sidebar footer shows "Powered by Diagrid · v…" with "Issues & feedback" beneath it; the link opens `https://github.com/diagridio/dev-dashboard` in a new tab. Collapse the sidebar: the footer (including the new link) disappears.
+3. Resize the window to ~800px wide: the dashboard stays usable (no overlay); pages render acceptably (sidebar/media-query layout kicks in below 760px). Resize to ~700px: the "designed for a wider screen" overlay appears; widening past 768px dismisses it.
+
+Expected: all three behaviors confirmed; no console errors.
+
+- [ ] **Step 4: Commit (only if fixes were needed)**
+
+If Steps 1-3 forced any changes, re-run the affected tests, then:
+
+```bash
+git add -A
+git commit -m "fix(web): regressions found during ui-polish verification"
+```

--- a/docs/superpowers/specs/2026-07-06-ui-polish-nav-footer-minwidth-design.md
+++ b/docs/superpowers/specs/2026-07-06-ui-polish-nav-footer-minwidth-design.md
@@ -1,0 +1,52 @@
+# UI polish: nav order, footer feedback link, lower min width — Design
+
+**Date:** 2026-07-06
+**Status:** Approved for planning
+
+Three small, independent UI changes to the web dashboard.
+
+## 1. Top menu: swap Configurations and Resiliency
+
+`NAV_ITEMS` in `web/src/components/TopNav.tsx` currently orders the tabs:
+
+> Applications, Workflows, Actors, Subscriptions, Components, **Configurations, Resiliency**, Control Plane, Logs
+
+Swap the two so Resiliency comes before Configurations:
+
+> Applications, Workflows, Actors, Subscriptions, Components, **Resiliency, Configurations**, Control Plane, Logs
+
+Routes and labels are unchanged; only array order moves. `TopNav.test.tsx` ("has exactly 9 items in the correct order") is updated to the new order.
+
+## 2. Sidebar footer: "Issues & feedback" link
+
+The Resources sidebar footer (`.sbfoot` in `web/src/components/ResourcesSidebar.tsx`) currently renders one line:
+
+> Powered by [Diagrid] · v{version}
+
+Add a second line below it:
+
+> [Issues & feedback]
+
+- Link target: `https://github.com/diagridio/dev-dashboard` (as requested — repo root, not `/issues`).
+- Opens in a new tab (`target="_blank" rel="noopener noreferrer"`), matching the Diagrid link.
+- Markup: a new element inside `.sbfoot` after the `.pw` span (e.g. `<span className="pw"><a …>Issues &amp; feedback</a></span>` on its own line, or a sibling class if spacing needs it). Styling follows the existing `.pw` mono/muted look; at most a small `theme.css` addition for line spacing.
+- Behavior in collapsed sidebar is unchanged: `.app.collapsed .sbfoot { display: none }` already hides the whole footer.
+
+`ResourcesSidebar.test.tsx` footer describe-block gets an assertion for the new link's name and href.
+
+## 3. Lower the small-screen warning threshold to 768px
+
+`web/src/components/SmallScreenGuard.tsx` shows a full-screen "designed for a wider screen" overlay below `MIN_WIDTH = 1024`. Change the constant to **768** (75% of 1024).
+
+- The guard only checks width, so "75% of current size" maps to width only.
+- Existing responsive CSS already adapts below 1024px (sidebar collapse media query at 760px, two-column collapses at 820/760/720px), so no additional layout work is required for the newly-allowed 768–1023px range. Spot-check the main pages at ~800px width during verification.
+- `SmallScreenGuard.test.tsx` mocks `matchMedia` boolean-only; add a small assertion that the media query string uses `768px` so the threshold is pinned by a test.
+
+## Out of scope
+
+- Any layout redesign for narrow widths beyond what existing CSS provides.
+- Height-based guarding.
+
+## Testing
+
+Unit tests as noted per change (Vitest). Full `web` test suite + lint + build must pass. Manual verification: run the dashboard, confirm nav order, footer link, and that resizing to ~800px width no longer triggers the overlay while ~700px does.

--- a/web/src/components/ResourcesSidebar.test.tsx
+++ b/web/src/components/ResourcesSidebar.test.tsx
@@ -331,6 +331,16 @@ describe('ResourcesSidebar footer', () => {
       expect(sbfoot?.textContent).toContain('Powered by Diagrid · v1.2.3')
     })
   })
+
+  it('renders Issues & feedback link to the GitHub repo', async () => {
+    renderSidebar()
+    const link = await screen.findByRole('link', { name: 'Issues & feedback' })
+    expect(link).toHaveAttribute('href', 'https://github.com/diagridio/dev-dashboard')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    // Lives inside the footer, below the Powered by line
+    expect(link.closest('.sbfoot')).not.toBeNull()
+  })
 })
 
 describe('ResourcesSidebar onHasNewChange contract', () => {

--- a/web/src/components/ResourcesSidebar.tsx
+++ b/web/src/components/ResourcesSidebar.tsx
@@ -254,6 +254,15 @@ export function ResourcesSidebar({ collapsed, onCollapsedChange, onHasNewChange 
           </a>
           {' · '}v{version}
         </span>
+        <span className="pw">
+          <a
+            href="https://github.com/diagridio/dev-dashboard"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Issues &amp; feedback
+          </a>
+        </span>
       </div>
     </aside>
   )

--- a/web/src/components/SmallScreenGuard.test.tsx
+++ b/web/src/components/SmallScreenGuard.test.tsx
@@ -24,4 +24,18 @@ describe('SmallScreenGuard', () => {
     expect(screen.getByText(/wider screen/i)).toBeInTheDocument()
     expect(screen.queryByText('content')).toBeNull()
   })
+
+  it('uses a 768px minimum width media query', () => {
+    const queries: string[] = []
+    vi.stubGlobal('matchMedia', (query: string) => {
+      queries.push(query)
+      return {
+        matches: true, media: query, onchange: null,
+        addEventListener: vi.fn(), removeEventListener: vi.fn(),
+        addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+      }
+    })
+    render(<SmallScreenGuard><div>content</div></SmallScreenGuard>)
+    expect(queries).toContain('(min-width: 768px)')
+  })
 })

--- a/web/src/components/SmallScreenGuard.tsx
+++ b/web/src/components/SmallScreenGuard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import { getTheme } from '../lib/prefs'
 
-const MIN_WIDTH = 1024
+const MIN_WIDTH = 768
 
 export function SmallScreenGuard({ children }: { children: ReactNode }) {
   const [wide, setWide] = useState(

--- a/web/src/components/TopNav.test.tsx
+++ b/web/src/components/TopNav.test.tsx
@@ -15,8 +15,8 @@ describe('NAV_ITEMS', () => {
       'Actors',
       'Subscriptions',
       'Components',
-      'Configurations',
       'Resiliency',
+      'Configurations',
       'Control Plane',
       'Logs',
     ])
@@ -30,8 +30,8 @@ describe('NAV_ITEMS', () => {
       '/actors',
       '/subscriptions',
       '/components',
-      '/configurations',
       '/resiliency',
+      '/configurations',
       '/control-plane',
       '/logs',
     ])

--- a/web/src/components/TopNav.test.tsx
+++ b/web/src/components/TopNav.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { TopNav, NAV_ITEMS } from './TopNav'
 import { RefreshProvider } from '../lib/refresh'
@@ -91,5 +91,53 @@ describe('TopNav', () => {
     renderNav()
     const link = screen.getByRole('link', { name: 'Logs' })
     expect(link).toHaveAttribute('href', '/logs')
+  })
+
+  describe('topbar height tracking', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals()
+      document.documentElement.style.removeProperty('--topbar-h')
+    })
+
+    it('publishes the topbar height as --topbar-h so the sidebar can start below it', () => {
+      let onResize: (() => void) | undefined
+      const observed: Element[] = []
+      vi.stubGlobal(
+        'ResizeObserver',
+        class {
+          constructor(cb: () => void) {
+            onResize = cb
+          }
+          observe(el: Element) {
+            observed.push(el)
+          }
+          unobserve() {}
+          disconnect() {}
+        },
+      )
+      renderNav()
+      const header = document.querySelector('header.topbar')
+      expect(header).not.toBeNull()
+      expect(observed).toContain(header)
+      // Simulate the topbar wrapping to multiple rows (e.g. zoom / narrow window)
+      Object.defineProperty(header, 'offsetHeight', { value: 82, configurable: true })
+      onResize?.()
+      expect(document.documentElement.style.getPropertyValue('--topbar-h')).toBe('82px')
+    })
+
+    it('removes --topbar-h on unmount', () => {
+      vi.stubGlobal(
+        'ResizeObserver',
+        class {
+          observe() {}
+          unobserve() {}
+          disconnect() {}
+        },
+      )
+      const { unmount } = renderNav()
+      expect(document.documentElement.style.getPropertyValue('--topbar-h')).not.toBe('')
+      unmount()
+      expect(document.documentElement.style.getPropertyValue('--topbar-h')).toBe('')
+    })
   })
 })

--- a/web/src/components/TopNav.tsx
+++ b/web/src/components/TopNav.tsx
@@ -15,8 +15,8 @@ export const NAV_ITEMS: NavItem[] = [
   { label: 'Actors', to: '/actors' },
   { label: 'Subscriptions', to: '/subscriptions' },
   { label: 'Components', to: '/components' },
-  { label: 'Configurations', to: '/configurations' },
   { label: 'Resiliency', to: '/resiliency' },
+  { label: 'Configurations', to: '/configurations' },
   { label: 'Control Plane', to: '/control-plane' },
   { label: 'Logs', to: '/logs' },
 ]

--- a/web/src/components/TopNav.tsx
+++ b/web/src/components/TopNav.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import { NavLink } from 'react-router-dom'
 import { Logo } from './Logo'
 import { ThemeToggle } from './ThemeToggle'
@@ -27,8 +28,27 @@ interface TopNavProps {
 }
 
 export function TopNav({ theme, onThemeChange }: TopNavProps) {
+  const headerRef = useRef<HTMLElement>(null)
+
+  // The nav can wrap onto extra rows on narrow/zoomed windows; the fixed
+  // sidebar reads --topbar-h to start below the topbar's real height.
+  useEffect(() => {
+    const el = headerRef.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+    const update = () => {
+      document.documentElement.style.setProperty('--topbar-h', `${el.offsetHeight}px`)
+    }
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => {
+      ro.disconnect()
+      document.documentElement.style.removeProperty('--topbar-h')
+    }
+  }, [])
+
   return (
-    <header className="topbar">
+    <header className="topbar" ref={headerRef}>
       <span className="brand">
         <Logo height={21} />
         <span className="dot">/</span>

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -69,7 +69,7 @@ body {
 .app[data-theme="dark"] .dglogo { color: #FFFFFF; }
 
 /* ---- Left resources sidebar ---- */
-.sidebar { position: fixed; left: 0; top: 46px; bottom: 0; width: var(--sbw); background: var(--surface); border-right: 1px solid var(--line); z-index: 9; transition: width .18s ease; display: flex; flex-direction: column; overflow: hidden; }
+.sidebar { position: fixed; left: 0; top: var(--topbar-h, 46px); bottom: 0; width: var(--sbw); background: var(--surface); border-right: 1px solid var(--line); z-index: 9; transition: width .18s ease; display: flex; flex-direction: column; overflow: hidden; }
 .sbhead { display: flex; align-items: center; gap: 8px; padding: 12px 12px 6px; color: var(--muted); }
 .sbhead .lbl { font-family: var(--mono); font-size: 10px; letter-spacing: .14em; text-transform: uppercase; white-space: nowrap; }
 .sbtoggle { margin-left: auto; background: transparent; border: 1px solid var(--line); color: var(--muted); border-radius: 7px; width: 26px; height: 26px; cursor: pointer; flex: none; display: grid; place-items: center; font-size: 13px; }

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -95,7 +95,7 @@ body {
 .sblink .col { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
 .sblink .col .txt { white-space: normal; font-size: 12.5px; line-height: 1.25; }
 .sblink .col .sub { font-family: var(--mono); font-size: 10px; color: var(--muted); white-space: nowrap; }
-.sbfoot { padding: 10px 14px; border-top: 1px solid var(--line-soft); }
+.sbfoot { padding: 10px 14px; border-top: 1px solid var(--line-soft); display: grid; gap: 2px; }
 .sbfoot .pw { font-family: var(--mono); font-size: 11px; color: var(--muted); line-height: 1.4; white-space: nowrap; }
 .pw a { color: inherit; text-decoration: none; }
 .pw a:hover { text-decoration: underline; }


### PR DESCRIPTION
## Summary

Three small UI changes to the web dashboard (spec and plan in `docs/superpowers/`), plus a layout fix they exposed:

- **Top nav:** Resiliency now comes before Configurations in `NAV_ITEMS`.
- **Sidebar footer:** new "Issues & feedback" link to https://github.com/diagridio/dev-dashboard on a second line under "Powered by Diagrid · v…". Hidden when the sidebar is collapsed, same as the rest of the footer.
- **Minimum window width:** the small-screen overlay threshold drops from 1024px to 768px (75%), so moderately narrow windows can use the dashboard. The previously-untested threshold is now pinned by a test asserting the `(min-width: 768px)` media query.
- **Sidebar/topbar overlap fix:** the sidebar was pinned at `top: 46px` (the topbar's single-row height), so when the nav wrapped onto extra rows (zoomed or narrow windows) the topbar covered the Resources label and collapse toggle. The topbar now publishes its measured height as `--topbar-h` via ResizeObserver and the sidebar anchors to it, so the drawer always starts beneath the topbar.

## Testing

- Full web suite: 599/599 passing (4 new tests); `tsc -b && vite build` clean.
- Runtime-verified with headless Chrome against `npm run dev`: nav order correct at 1280px; footer link renders with correct href/target/rel; app renders at 800px and exactly 768px; overlay shows at 767px and below; with the topbar wrapped to three rows (800px and 1.5× zoom simulation) the sidebar head and toggle are fully visible below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
