### PR TITLE
Workflows page graceful degradation on store errors + Disconnect rename

### DIFF
--- a/docs/superpowers/plans/2026-07-06-workflow-store-graceful-degradation.md
+++ b/docs/superpowers/plans/2026-07-06-workflow-store-graceful-degradation.md
@@ -1,0 +1,304 @@
+# Workflow Store Graceful Degradation + Disconnect Rename Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the Workflows page usable (header, store selector, filters) when the selected state store fails to load, showing an error banner instead of replacing the page; rename the connections panel's "Delete" action to "Disconnect".
+
+**Architecture:** Frontend-only change. `Workflows.tsx` currently early-returns on `isError`, replacing the whole page; the fix derives a `loadError` string and renders it as a banner between the page header and the filters, leaving all page chrome interactive. `StateStoreConnectionsPanel.tsx` gets a pure wording/styling change. No API or server changes.
+
+**Tech Stack:** React 19 + TypeScript, TanStack Query, Vitest + Testing Library + MSW. Tests run from `web/` with `npm test` (vitest run).
+
+**Spec:** `docs/superpowers/specs/2026-07-06-workflow-store-graceful-degradation-design.md`
+
+## Global Constraints
+
+- Frontend only: no changes under `pkg/`, `cmd/`, or to any API route.
+- The full-page "No state store detected" guidance for an **empty store list** (`noStores`) stays exactly as-is.
+- `WorkflowDetail.tsx` is out of scope.
+- Banner copy: the extracted server message followed by `Select another state store or check the connection.`
+- Degraded table placeholder copy: `Couldn't load workflows from this store.`
+- Modal reassurance copy: `The component YAML file on disk is not deleted.`
+- Row Disconnect button: `btn ghost`. Modal confirm Disconnect button: `btn primary`. Toast: `Disconnected <name>`.
+
+---
+
+### Task 1: Workflows page — graceful degradation on load errors
+
+**Files:**
+- Modify: `web/src/pages/Workflows.tsx` (error block at lines 311–348; banner insertion after the `phead` div ~line 397; table placeholder ~line 534)
+- Test: `web/src/pages/Workflows.test.tsx`
+
+**Interfaces:**
+- Consumes: existing `useWorkflows` hook result (`{ data, isLoading, isError, error }`) — unchanged.
+- Produces: no exports change. Behavior contract for tests: on any `/api/workflows` error the page renders (a) the store selector (`data-testid="store-select"`), (b) a banner `data-testid="load-error-banner"` containing the server message, (c) the filters, and (d) the placeholder text `Couldn't load workflows from this store.` in the table area.
+
+**Background for the implementer:** Today `Workflows.tsx` has three early returns: `noStores` (keep), a 503 branch, and a generic error branch (both replaced by the banner). The 503 branch parses the server message out of `String(error)`, which looks like `API error 503: could not connect to state store "x" (host) for /api/workflows...`. That parsing moves into a `loadError` variable. Note: the old code special-cased a 503 whose message contains `no state store detected` to show the full-page guidance; under the new design that case only occurs with a non-empty store list (empty list is caught by `noStores` first), so it now shows the banner like any other error.
+
+- [ ] **Step 1: Update the two existing 503 tests to expect the degraded page**
+
+In `web/src/pages/Workflows.test.tsx`, replace the test `'shows the no-store message on 503'` (currently ~line 73) with:
+
+```tsx
+  it('degrades gracefully on a no-store 503: banner + chrome, no full-page guidance', async () => {
+    server.use(
+      http.get('/api/workflows', () =>
+        HttpResponse.json({ error: 'no state store detected' }, { status: 503 }),
+      ),
+    )
+    renderAt()
+    const banner = await screen.findByTestId('load-error-banner')
+    expect(banner).toHaveTextContent(/no state store detected/i)
+    expect(banner).toHaveTextContent(/select another state store or check the connection/i)
+    // Page chrome still rendered: store selector and filters are usable.
+    expect(screen.getByTestId('store-select')).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: 'Status filter' })).toBeInTheDocument()
+    // The --statestore full-page guidance is only for an empty store list.
+    expect(screen.queryByText(/--statestore/)).toBeNull()
+  })
+```
+
+And in the `'Workflows page — store selector'` describe block, replace the test `'shows the server "could not connect…" message on an unreachable 503 (not the no-store guidance)'` (~line 773) with:
+
+```tsx
+  it('shows a banner with the server "could not connect…" message and keeps the store selector usable', async () => {
+    server.use(
+      http.get('/api/statestores', () => HttpResponse.json(twoStores)),
+      http.get('/api/workflows', () =>
+        HttpResponse.json({ error: 'could not connect to state store "statestore" (localhost:16379)' }, { status: 503 }),
+      ),
+      http.get('/api/apps', () => HttpResponse.json([])),
+    )
+    renderAt()
+    const banner = await screen.findByTestId('load-error-banner')
+    expect(banner).toHaveTextContent(/could not connect to state store/i)
+    expect(banner).toHaveTextContent(/localhost:16379/)
+    // The --statestore guidance is only for the genuine no-store case.
+    expect(screen.queryByText(/--statestore/)).toBeNull()
+    // Chrome stays interactive and the table shows the degraded placeholder.
+    expect(screen.getByTestId('store-select')).toBeInTheDocument()
+    expect(screen.getByText(/couldn't load workflows from this store/i)).toBeInTheDocument()
+  })
+```
+
+- [ ] **Step 2: Add a recovery test — switching stores from the degraded state loads rows**
+
+Append inside the same `'Workflows page — store selector'` describe block:
+
+```tsx
+  it('recovers when the user switches to a reachable store from the degraded state', async () => {
+    // Store b (persisted selection) is unreachable; store a works.
+    window.localStorage.setItem('devdash.workflowStore', 'statestore-b')
+    server.use(
+      http.get('/api/statestores', () => HttpResponse.json(twoStores)),
+      http.get('/api/workflows', ({ request }) => {
+        const url = new URL(request.url)
+        if (url.searchParams.get('store') === 'statestore-b') {
+          return HttpResponse.json(
+            { error: 'could not connect to state store "statestore" (localhost:16379)' },
+            { status: 503 },
+          )
+        }
+        return HttpResponse.json({
+          items: [{ appId: 'order', instanceId: 'a1', name: 'OrderWorkflow', status: 'Running', createdAt: '2026-06-29T10:00:00Z' }],
+        })
+      }),
+      http.get('/api/apps', () => HttpResponse.json([])),
+    )
+    renderAt()
+    await screen.findByTestId('load-error-banner')
+    const storeSelect = screen.getByTestId('store-select') as HTMLSelectElement
+    await userEvent.selectOptions(storeSelect, 'statestore-a')
+    // Rows from the reachable store render and the banner clears.
+    expect(await screen.findByRole('link', { name: 'a1' })).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByTestId('load-error-banner')).toBeNull())
+  })
+```
+
+- [ ] **Step 3: Run the Workflows tests to verify the new/updated tests fail**
+
+Run: `cd web && npx vitest run src/pages/Workflows.test.tsx`
+Expected: the three tests above FAIL (no element with testid `load-error-banner`; old full-page error still rendered). All other tests in the file still pass.
+
+- [ ] **Step 4: Implement the degraded state in `Workflows.tsx`**
+
+Replace the whole error-states section (from the `// --- Error states ---` comment through the end of the `if (isError) { … }` block, currently lines 311–348) with:
+
+```tsx
+  // --- Error states ---
+
+  // No-store guidance block — full-page, only when the store list itself is empty
+  // (there is no selector to degrade to in that case).
+  const noStoreGuidance = (
+    <div className="page">
+      <p className="err b">No state store detected</p>
+      <p className="muted" style={{ marginTop: 8 }}>
+        Dapr requires a state store to persist workflow state. Configure one with the{' '}
+        <span className="mono">--statestore</span> flag or add a state store component.
+      </p>
+    </div>
+  )
+
+  if (noStores) return noStoreGuidance
+
+  // Any workflow-list load error degrades gracefully: the page chrome (store
+  // selector, filters) stays rendered and usable; the error is shown as a
+  // banner above the filters so the user can switch to a reachable store.
+  let loadError: string | null = null
+  if (isError) {
+    const errStr = String(error)
+    if (errStr.includes('503')) {
+      // The server message follows the "API error 503: <message> for <path>" shape.
+      // Fall back to a generic message if the separator isn't present.
+      const extracted = errStr.replace(/^.*?503[:\s]+/, '').replace(/\s*for\s+\/\S*$/, '').trim()
+      loadError = extracted && extracted !== errStr ? extracted : 'state store unavailable'
+    } else {
+      loadError = `Error loading workflows: ${errStr}`
+    }
+  }
+```
+
+Then insert the banner right after the closing `</div>` of the `phead` header block (before the `{/* Remove status banner */}` comment):
+
+```tsx
+      {/* Load-error banner — page stays usable so the user can switch stores */}
+      {loadError && (
+        <div
+          data-testid="load-error-banner"
+          style={{
+            marginBottom: 12,
+            padding: '8px 12px',
+            borderRadius: 8,
+            border: '1px solid var(--line)',
+            background: 'var(--surface)',
+            color: 'var(--fail-fg)',
+            fontSize: 13,
+          }}
+        >
+          {loadError} — Select another state store or check the connection.
+        </div>
+      )}
+```
+
+Finally, make the table area show a degraded placeholder instead of "No workflows found" when errored. Replace the tablewrap ternary's first two branches (currently ~line 534):
+
+```tsx
+          {(isLoading || (!noStores && selectedStore === null)) ? (
+            <p className="muted" style={{ padding: 20 }}>Loading…</p>
+          ) : isError ? (
+            <p className="muted" style={{ padding: 20 }}>Couldn't load workflows from this store.</p>
+          ) : items.length === 0 ? (
+            <p className="muted" style={{ padding: 20 }}>No workflows found</p>
+          ) : (
+```
+
+(The final `<table>` branch and everything after are unchanged.)
+
+- [ ] **Step 5: Run the Workflows tests to verify they pass**
+
+Run: `cd web && npx vitest run src/pages/Workflows.test.tsx`
+Expected: PASS, all tests.
+
+- [ ] **Step 6: Run the full web suite and typecheck**
+
+Run: `cd web && npm test && npx tsc -b`
+Expected: PASS, no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/pages/Workflows.tsx web/src/pages/Workflows.test.tsx
+git commit -m "feat(web): degrade Workflows page gracefully on state-store load errors"
+```
+
+---
+
+### Task 2: Connections panel — rename Delete to Disconnect
+
+**Files:**
+- Modify: `web/src/components/StateStoreConnectionsPanel.tsx`
+- Test: `web/src/components/StateStoreConnectionsPanel.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (independent task).
+- Produces: no exports change. Behavior contract: row button accessible name `disconnect <name>` with class `btn ghost`; modal dialog name `Disconnect state store?`; confirm button text `Disconnect` with class `btn primary`; success toast `Disconnected <name>`; modal body contains `The component YAML file on disk is not deleted.`
+
+- [ ] **Step 1: Update the panel tests for the new wording**
+
+In `web/src/components/StateStoreConnectionsPanel.test.tsx` apply these replacements:
+
+- Every `{ name: /delete orders-pg/i }` → `{ name: /disconnect orders-pg/i }` (all occurrences: lines ~31, 69, 70, 85, 86, 105).
+- Every `{ name: /delete statestore/i }` → `{ name: /disconnect statestore/i }` (~line 104).
+- Every `{ name: /delete projstore/i }` → `{ name: /disconnect projstore/i }` (~lines 115, 116).
+- Both `fireEvent.click(screen.getByRole('button', { name: 'Delete' }))` → `fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }))` (~lines 71, 87).
+- Both `{ name: /delete connection/i }` dialog queries → `{ name: /disconnect state store/i }` (~lines 75, 90).
+- `expect(screen.getByText('Removed orders-pg')).toBeInTheDocument()` → `expect(screen.getByText('Disconnected orders-pg')).toBeInTheDocument()` (~line 92).
+- In the test `'shows auto rows read-only and manual rows with actions'`, after the existing disconnect-button assertion, add the styling check:
+
+```tsx
+    // Disconnect is non-destructive: ghost styling, not danger.
+    const btn = screen.getByRole('button', { name: /disconnect orders-pg/i })
+    expect(btn.className).toContain('ghost')
+    expect(btn.className).not.toContain('danger')
+```
+
+- In the test `'explains durable dismissal when removing an auto-discovered connection'`, add after the existing assertion:
+
+```tsx
+    expect(screen.getByText(/the component yaml file on disk is not deleted/i)).toBeInTheDocument()
+```
+
+- [ ] **Step 2: Run the panel tests to verify they fail**
+
+Run: `cd web && npx vitest run src/components/StateStoreConnectionsPanel.test.tsx`
+Expected: FAIL — buttons named `disconnect …` not found (still labeled Delete).
+
+- [ ] **Step 3: Implement the rename in `StateStoreConnectionsPanel.tsx`**
+
+Row button (line ~64):
+
+```tsx
+                <button className="btn ghost" aria-label={`disconnect ${s.name}`} onClick={() => openDeleteConfirm(s)}>Disconnect</button>
+```
+
+Toast in `handleConfirmDelete` (line ~35):
+
+```tsx
+      toast.show(`Disconnected ${pendingDelete.name}`)
+```
+
+Confirm modal (lines ~93–105):
+
+```tsx
+      <Modal open={pendingDelete !== null} title="Disconnect state store?" onClose={closeDeleteConfirm}>
+        <p style={{ margin: '0 0 8px', color: 'var(--muted)', fontSize: 14 }}>
+          Disconnect <b>{pendingDelete?.name}</b>? The component YAML file on disk is not deleted.{' '}
+          {pendingDelete?.source === 'auto'
+            ? 'It will stay hidden unless it becomes the active workflow state store again.'
+            : 'This only removes it from the dashboard registry.'}
+        </p>
+        {deleteError && <p className="field-err">{deleteError}</p>}
+        <div className="modal-actions">
+          <button className="btn ghost" onClick={closeDeleteConfirm}>Cancel</button>
+          <button className="btn primary" onClick={handleConfirmDelete}>Disconnect</button>
+        </div>
+      </Modal>
+```
+
+Internal identifiers (`pendingDelete`, `openDeleteConfirm`, `deleteStore`, etc.) stay as they are — the API call is still a DELETE; only user-facing copy changes.
+
+- [ ] **Step 4: Run the panel tests to verify they pass**
+
+Run: `cd web && npx vitest run src/components/StateStoreConnectionsPanel.test.tsx`
+Expected: PASS, all tests.
+
+- [ ] **Step 5: Run the full web suite and typecheck**
+
+Run: `cd web && npm test && npx tsc -b`
+Expected: PASS, no type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/components/StateStoreConnectionsPanel.tsx web/src/components/StateStoreConnectionsPanel.test.tsx
+git commit -m "feat(web): rename state-store connection Delete to Disconnect"
+```

--- a/docs/superpowers/specs/2026-07-06-workflow-store-graceful-degradation-design.md
+++ b/docs/superpowers/specs/2026-07-06-workflow-store-graceful-degradation-design.md
@@ -1,0 +1,85 @@
+# Workflow store graceful degradation + Disconnect rename — design
+
+Date: 2026-07-06
+Status: approved
+
+## Problem
+
+1. **Workflows page blocks on store errors.** When the selected workflow state
+   store cannot be reached (e.g. a docker-compose project was brought down but
+   its auto-persisted registry entry — and the user's persisted selection in
+   `localStorage` — still point at it), `Workflows.tsx` returns early on
+   `isError` and replaces the entire page with the error text. The page header
+   (which contains the store selector), filters, and table never render, so
+   the user cannot switch to a reachable store from the page itself.
+
+2. **"Delete" mislabels disconnecting.** On the Components page, the
+   connections panel's per-row button and confirm dialog say "Delete", which
+   suggests the component YAML file is deleted. It only removes the entry from
+   the dashboard's connection registry (`connections.yaml`); the YAML file on
+   disk is untouched.
+
+## Decisions (from brainstorming)
+
+- Graceful degradation applies to **all** workflow-list load errors (store
+  unreachable, server error, network failure) — one consistent degraded state.
+- The full-page "No state store detected" guidance stays as-is: with zero
+  stores there is no selector to degrade to.
+- **List page only.** `WorkflowDetail.tsx`'s error path is out of scope; the
+  list page (now recoverable) is how users reach it.
+- No auto-fallback to the active store and no server-side health filtering —
+  the user keeps their selection and switches manually, guided by a banner.
+- The row's Disconnect button uses the **ghost** style (not `danger`): the
+  action is non-destructive, and the red styling was part of what implied
+  deletion. The confirm modal's Disconnect button uses `primary`.
+
+## Design
+
+### 1. Workflows page graceful degradation (`web/src/pages/Workflows.tsx`)
+
+- Keep the `noStores` early return (full-page guidance) unchanged.
+- Remove the `if (isError) return …` block. Instead derive a `loadError`
+  message from `error`, reusing the existing 503-message extraction:
+  - 503 with a server message → the extracted message (e.g.
+    `could not connect to state store "statestore" (postgres://…)`);
+  - 503 without a parsable message → `state store unavailable`;
+  - any other error → `Error loading workflows: <error>`.
+- Render an error banner between the page header and the filters row when
+  `loadError` is set — same visual pattern as the existing remove-status
+  banner, error-colored. Content: the message, followed by the hint
+  "Select another state store or check the connection."
+- Table area: when `isError`, show a muted placeholder
+  "Couldn't load workflows from this store." instead of "No workflows found".
+- Everything else renders as normal: store selector, app filter, search,
+  child-workflow toggle, stats segments (they show 0 — their query fails
+  independently and already defaults to 0), and pager ("No results").
+- Switching stores in the degraded state works exactly as today
+  (`onStoreChange` resets filters/paging and the queries refetch).
+
+### 2. Rename Delete → Disconnect (`web/src/components/StateStoreConnectionsPanel.tsx`)
+
+- Row button: label `Delete` → `Disconnect`; aria-label `delete ${name}` →
+  `disconnect ${name}`; class `btn danger` → `btn ghost`.
+- Confirm modal: title `Delete connection?` → `Disconnect state store?`;
+  confirm button `Delete` → `Disconnect`, styled `btn primary` (a clear,
+  non-danger primary action; Cancel stays `btn ghost`, order unchanged).
+  Body text keeps the existing auto/manual nuance and adds the reassurance:
+  "The component YAML file on disk is not deleted."
+- Toast: `Removed ${name}` → `Disconnected ${name}`.
+- No API changes: `DELETE /statestores/:id` and registry semantics untouched.
+
+## Error handling
+
+- The banner reflects whatever `useWorkflows` reports; a store that recovers
+  (compose brought back up) clears the banner on the next successful refetch.
+- Disconnect failures keep today's behavior: the modal stays open and shows
+  the error inline.
+
+## Testing
+
+- `Workflows.test.tsx`: update the 503 tests — assert the store selector and
+  filters remain rendered alongside the banner text; assert the table shows
+  the degraded placeholder; add a case where switching stores from the
+  degraded state triggers a refetch and renders rows from the second store.
+- Connections panel tests: update for the new labels (`Disconnect`, modal
+  title, toast text, aria-labels) and ghost styling class.

--- a/web/src/components/StateStoreConnectionsPanel.test.tsx
+++ b/web/src/components/StateStoreConnectionsPanel.test.tsx
@@ -26,10 +26,14 @@ describe('StateStoreConnectionsPanel', () => {
     expect(screen.getByText('orders-pg')).toBeInTheDocument()
     // ACTIVE badge on the active auto store.
     expect(screen.getByText(/active/i)).toBeInTheDocument()
-    // Manual row has delete only (no edit); the active row has neither.
+    // Manual row has disconnect only (no edit); the active row has neither.
     expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /delete orders-pg/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /disconnect orders-pg/i })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /edit statestore/i })).not.toBeInTheDocument()
+    // Disconnect is non-destructive: ghost styling, not danger.
+    const btn = screen.getByRole('button', { name: /disconnect orders-pg/i })
+    expect(btn.className).toContain('ghost')
+    expect(btn.className).not.toContain('danger')
     // Add button present.
     expect(screen.getByRole('button', { name: /add connection/i })).toBeInTheDocument()
   })
@@ -57,7 +61,7 @@ describe('StateStoreConnectionsPanel', () => {
     expect(screen.getByText('Added orders')).toBeInTheDocument()
   })
 
-  it('shows error feedback and keeps the confirm modal open when delete fails', async () => {
+  it('shows error feedback and keeps the confirm modal open when disconnect fails', async () => {
     server.use(
       http.get('/api/statestores', () => HttpResponse.json(stores)),
       http.delete('/api/statestores/m1', () =>
@@ -66,33 +70,33 @@ describe('StateStoreConnectionsPanel', () => {
     )
     render(<QueryProvider><StateStoreConnectionsPanel /></QueryProvider>)
 
-    await waitFor(() => expect(screen.getByRole('button', { name: /delete orders-pg/i })).toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: /delete orders-pg/i }))
-    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: /disconnect orders-pg/i })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /disconnect orders-pg/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }))
 
     // Error surfaced to the user, modal still open, no crash / unhandled rejection.
     await waitFor(() => expect(screen.getByText('store is in use')).toBeInTheDocument())
-    expect(screen.getByRole('dialog', { name: /delete connection/i })).toBeInTheDocument()
+    expect(screen.getByRole('dialog', { name: /disconnect state store/i })).toBeInTheDocument()
   })
 
-  it('closes the confirm modal and shows a toast on successful delete', async () => {
+  it('closes the confirm modal and shows a toast on successful disconnect', async () => {
     server.use(
       http.get('/api/statestores', () => HttpResponse.json(stores)),
       http.delete('/api/statestores/m1', () => new HttpResponse(null, { status: 204 })),
     )
     render(<QueryProvider><StateStoreConnectionsPanel /></QueryProvider>)
 
-    await waitFor(() => expect(screen.getByRole('button', { name: /delete orders-pg/i })).toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: /delete orders-pg/i }))
-    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: /disconnect orders-pg/i })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /disconnect orders-pg/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }))
 
     await waitFor(() =>
-      expect(screen.queryByRole('dialog', { name: /delete connection/i })).not.toBeInTheDocument(),
+      expect(screen.queryByRole('dialog', { name: /disconnect state store/i })).not.toBeInTheDocument(),
     )
-    expect(screen.getByText('Removed orders-pg')).toBeInTheDocument()
+    expect(screen.getByText('Disconnected orders-pg')).toBeInTheDocument()
   })
 
-  it('renames the panel, shows paths, and offers delete on non-active rows only', async () => {
+  it('renames the panel, shows paths, and offers disconnect on non-active rows only', async () => {
     server.use(http.get('/api/statestores', () => HttpResponse.json(stores)))
     render(<QueryProvider client={makeQueryClient()}><StateStoreConnectionsPanel /></QueryProvider>)
 
@@ -100,9 +104,9 @@ describe('StateStoreConnectionsPanel', () => {
     expect(screen.getByText('Recent workflow state store connections')).toBeInTheDocument()
     // Path shown for the auto (file-backed) row; the manual row has none.
     expect(screen.getByText('/x/a.yaml')).toBeInTheDocument()
-    // The active row has no delete button; the non-active row does.
-    expect(screen.queryByRole('button', { name: /delete statestore/i })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /delete orders-pg/i })).toBeInTheDocument()
+    // The active row has no disconnect button; the non-active row does.
+    expect(screen.queryByRole('button', { name: /disconnect statestore/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /disconnect orders-pg/i })).toBeInTheDocument()
   })
 
   it('explains durable dismissal when removing an auto-discovered connection', async () => {
@@ -112,10 +116,11 @@ describe('StateStoreConnectionsPanel', () => {
     server.use(http.get('/api/statestores', () => HttpResponse.json(autoInactive)))
     render(<QueryProvider client={makeQueryClient()}><StateStoreConnectionsPanel /></QueryProvider>)
 
-    await waitFor(() => expect(screen.getByRole('button', { name: /delete projstore/i })).toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: /delete projstore/i }))
+    await waitFor(() => expect(screen.getByRole('button', { name: /disconnect projstore/i })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /disconnect projstore/i }))
     expect(
       screen.getByText(/stay hidden unless it becomes the active workflow state store again/i),
     ).toBeInTheDocument()
+    expect(screen.getByText(/the component yaml file on disk is not deleted/i)).toBeInTheDocument()
   })
 })

--- a/web/src/components/StateStoreConnectionsPanel.tsx
+++ b/web/src/components/StateStoreConnectionsPanel.tsx
@@ -32,7 +32,7 @@ export function StateStoreConnectionsPanel() {
     setDeleteError(null)
     try {
       await deleteStore.mutateAsync(pendingDelete.id)
-      toast.show(`Removed ${pendingDelete.name}`)
+      toast.show(`Disconnected ${pendingDelete.name}`)
       closeDeleteConfirm()
     } catch (e) {
       // Keep the modal open so the user sees what failed and can retry/cancel.
@@ -61,7 +61,7 @@ export function StateStoreConnectionsPanel() {
             </span>
             {!s.active && (
               <span style={{ display: 'flex', gap: 6 }}>
-                <button className="btn danger" aria-label={`delete ${s.name}`} onClick={() => openDeleteConfirm(s)}>Delete</button>
+                <button className="btn ghost" aria-label={`disconnect ${s.name}`} onClick={() => openDeleteConfirm(s)}>Disconnect</button>
               </span>
             )}
           </div>
@@ -90,9 +90,9 @@ export function StateStoreConnectionsPanel() {
         />
       )}
 
-      <Modal open={pendingDelete !== null} title="Delete connection?" onClose={closeDeleteConfirm}>
+      <Modal open={pendingDelete !== null} title="Disconnect state store?" onClose={closeDeleteConfirm}>
         <p style={{ margin: '0 0 8px', color: 'var(--muted)', fontSize: 14 }}>
-          Remove the connection <b>{pendingDelete?.name}</b>?{' '}
+          Disconnect <b>{pendingDelete?.name}</b>? The component YAML file on disk is not deleted.{' '}
           {pendingDelete?.source === 'auto'
             ? 'It will stay hidden unless it becomes the active workflow state store again.'
             : 'This only removes it from the dashboard registry.'}
@@ -100,7 +100,7 @@ export function StateStoreConnectionsPanel() {
         {deleteError && <p className="field-err">{deleteError}</p>}
         <div className="modal-actions">
           <button className="btn ghost" onClick={closeDeleteConfirm}>Cancel</button>
-          <button className="btn danger" onClick={handleConfirmDelete}>Delete</button>
+          <button className="btn primary" onClick={handleConfirmDelete}>Disconnect</button>
         </div>
       </Modal>
 

--- a/web/src/pages/Workflows.test.tsx
+++ b/web/src/pages/Workflows.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createMemoryRouter, RouterProvider, MemoryRouter } from 'react-router-dom'
 import { http, HttpResponse } from 'msw'
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { QueryClient, focusManager } from '@tanstack/react-query'
 import { server } from '../test/setup'
 import { QueryProvider } from '../lib/query'
@@ -888,6 +888,12 @@ describe('Workflows page — store selector', () => {
 describe('Workflows page — stale-data error-state gating', () => {
   beforeEach(() => {
     window.localStorage.clear()
+  })
+
+  // setFocused(true) forces the manager for the process lifetime; restore
+  // auto-detection so later tests don't inherit a forced-focused state.
+  afterEach(() => {
+    focusManager.setFocused(undefined)
   })
 
   it('hides stale rows, selection bar, and stale nextToken when a background refetch errors', async () => {

--- a/web/src/pages/Workflows.test.tsx
+++ b/web/src/pages/Workflows.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { createMemoryRouter, RouterProvider, MemoryRouter } from 'react-router-dom'
 import { http, HttpResponse } from 'msw'
 import { describe, it, expect, beforeEach } from 'vitest'
-import { QueryClient } from '@tanstack/react-query'
+import { QueryClient, focusManager } from '@tanstack/react-query'
 import { server } from '../test/setup'
 import { QueryProvider } from '../lib/query'
 import { RefreshProvider } from '../lib/refresh'
@@ -882,5 +882,60 @@ describe('Workflows page — store selector', () => {
     expect(opt.value).toBe('redis-p2')
     expect(opt.textContent).toMatch(/redis — redis · localhost:6379 \(active\)/)
     await waitFor(() => expect(storeSelect.value).toBe('redis-p2'))
+  })
+})
+
+describe('Workflows page — stale-data error-state gating', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('hides stale rows, selection bar, and stale nextToken when a background refetch errors', async () => {
+    // First call: returns one row + nextToken so pager shows "1–1 loaded" and Next is enabled.
+    // Subsequent calls: return 503 (simulates store going down while page is open).
+    let callCount = 0
+    server.use(
+      http.get('/api/workflows', () => {
+        callCount++
+        if (callCount === 1) {
+          return HttpResponse.json({
+            items: [{ appId: 'order', instanceId: 'abc', name: 'OrderWorkflow', status: 'Running', createdAt: '2026-06-26T10:00:00Z' }],
+            nextToken: 'tok-stale',
+          })
+        }
+        return HttpResponse.json(
+          { error: 'could not connect to state store "statestore" (localhost:16379)' },
+          { status: 503 },
+        )
+      }),
+    )
+
+    renderAt()
+
+    // Wait for the initial successful load: row + enabled Next button.
+    await screen.findByRole('link', { name: 'abc' })
+    expect(screen.getByRole('button', { name: 'Next →' })).not.toBeDisabled()
+
+    // Select the row so we have an active selection before the error hits.
+    const checkboxes = document.querySelectorAll('tbody .cbx:not(.on)')
+    await userEvent.click(checkboxes[0])
+    await waitFor(() => expect(screen.getByText('1 selected')).toBeInTheDocument())
+
+    // Trigger a background refetch via TanStack Query's focusManager
+    // (refetchOnWindowFocus is on by default; setFocused(true) fires the same path
+    // as a real window-focus/visibilitychange event without needing DOM hacks).
+    focusManager.setFocused(true)
+
+    // After the refetch errors the page must gate all stale-data-derived UI:
+    await screen.findByTestId('load-error-banner')
+    // Placeholder replaces the table.
+    expect(screen.getByText(/couldn't load workflows from this store/i)).toBeInTheDocument()
+    // Pager shows "No results" (not "1–1 loaded").
+    await waitFor(() => expect(screen.getByText('No results')).toBeInTheDocument())
+    expect(screen.queryByText(/1–1 loaded/)).toBeNull()
+    // Selection bar is hidden even though selected state was non-empty.
+    expect(screen.queryByText('1 selected')).toBeNull()
+    // Next button is disabled (stale nextToken must not enable it).
+    expect(screen.getByRole('button', { name: 'Next →' })).toBeDisabled()
   })
 })

--- a/web/src/pages/Workflows.test.tsx
+++ b/web/src/pages/Workflows.test.tsx
@@ -70,15 +70,21 @@ describe('Workflows', () => {
     expect(screen.getByText('RUNNING')).toBeInTheDocument()
   })
 
-  it('shows the no-store message on 503', async () => {
+  it('degrades gracefully on a no-store 503: banner + chrome, no full-page guidance', async () => {
     server.use(
       http.get('/api/workflows', () =>
         HttpResponse.json({ error: 'no state store detected' }, { status: 503 }),
       ),
     )
     renderAt()
-    await waitFor(() => expect(screen.getByText(/no state store detected/i)).toBeInTheDocument())
-    expect(screen.getByText(/--statestore/)).toBeInTheDocument()
+    const banner = await screen.findByTestId('load-error-banner')
+    expect(banner).toHaveTextContent(/no state store detected/i)
+    expect(banner).toHaveTextContent(/select another state store or check the connection/i)
+    // Page chrome still rendered: store selector and filters are usable.
+    expect(screen.getByTestId('store-select')).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: 'Status filter' })).toBeInTheDocument()
+    // The --statestore full-page guidance is only for an empty store list.
+    expect(screen.queryByText(/--statestore/)).toBeNull()
   })
 
   it('shows an empty state when items is an empty array', async () => {
@@ -770,7 +776,7 @@ describe('Workflows page — store selector', () => {
     await waitFor(() => expect(storeSelect.value).toBe('statestore-a')) // the active one
   })
 
-  it('shows the server "could not connect…" message on an unreachable 503 (not the no-store guidance)', async () => {
+  it('shows a banner with the server "could not connect…" message and keeps the store selector usable', async () => {
     server.use(
       http.get('/api/statestores', () => HttpResponse.json(twoStores)),
       http.get('/api/workflows', () =>
@@ -779,10 +785,42 @@ describe('Workflows page — store selector', () => {
       http.get('/api/apps', () => HttpResponse.json([])),
     )
     renderAt()
-    await waitFor(() => expect(screen.getByText(/could not connect to state store/i)).toBeInTheDocument())
-    expect(screen.getByText(/localhost:16379/)).toBeInTheDocument()
+    const banner = await screen.findByTestId('load-error-banner')
+    expect(banner).toHaveTextContent(/could not connect to state store/i)
+    expect(banner).toHaveTextContent(/localhost:16379/)
     // The --statestore guidance is only for the genuine no-store case.
     expect(screen.queryByText(/--statestore/)).toBeNull()
+    // Chrome stays interactive and the table shows the degraded placeholder.
+    expect(screen.getByTestId('store-select')).toBeInTheDocument()
+    expect(screen.getByText(/couldn't load workflows from this store/i)).toBeInTheDocument()
+  })
+
+  it('recovers when the user switches to a reachable store from the degraded state', async () => {
+    // Store b (persisted selection) is unreachable; store a works.
+    window.localStorage.setItem('devdash.workflowStore', 'statestore-b')
+    server.use(
+      http.get('/api/statestores', () => HttpResponse.json(twoStores)),
+      http.get('/api/workflows', ({ request }) => {
+        const url = new URL(request.url)
+        if (url.searchParams.get('store') === 'statestore-b') {
+          return HttpResponse.json(
+            { error: 'could not connect to state store "statestore" (localhost:16379)' },
+            { status: 503 },
+          )
+        }
+        return HttpResponse.json({
+          items: [{ appId: 'order', instanceId: 'a1', name: 'OrderWorkflow', status: 'Running', createdAt: '2026-06-29T10:00:00Z' }],
+        })
+      }),
+      http.get('/api/apps', () => HttpResponse.json([])),
+    )
+    renderAt()
+    await screen.findByTestId('load-error-banner')
+    const storeSelect = screen.getByTestId('store-select') as HTMLSelectElement
+    await userEvent.selectOptions(storeSelect, 'statestore-a')
+    // Rows from the reachable store render and the banner clears.
+    expect(await screen.findByRole('link', { name: 'a1' })).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByTestId('load-error-banner')).toBeNull())
   })
 
   it('instance-row links carry ?store=<id> for the selected store', async () => {

--- a/web/src/pages/Workflows.tsx
+++ b/web/src/pages/Workflows.tsx
@@ -310,7 +310,8 @@ export function Workflows() {
 
   // --- Error states ---
 
-  // No-store guidance block — shared between the empty-list case and the 503 no-store case.
+  // No-store guidance block — full-page, only when the store list itself is empty
+  // (there is no selector to degrade to in that case).
   const noStoreGuidance = (
     <div className="page">
       <p className="err b">No state store detected</p>
@@ -323,28 +324,20 @@ export function Workflows() {
 
   if (noStores) return noStoreGuidance
 
+  // Any workflow-list load error degrades gracefully: the page chrome (store
+  // selector, filters) stays rendered and usable; the error is shown as a
+  // banner above the filters so the user can switch to a reachable store.
+  let loadError: string | null = null
   if (isError) {
     const errStr = String(error)
     if (errStr.includes('503')) {
-      const isNoStore = errStr.includes('no state store detected')
-      if (isNoStore) return noStoreGuidance
       // The server message follows the "API error 503: <message> for <path>" shape.
       // Fall back to a generic message if the separator isn't present.
       const extracted = errStr.replace(/^.*?503[:\s]+/, '').replace(/\s*for\s+\/\S*$/, '').trim()
-      const serverMsg = extracted && extracted !== errStr ? extracted : 'state store unavailable'
-      return (
-        <div className="page">
-          <p className="err b">
-            {serverMsg}
-          </p>
-        </div>
-      )
+      loadError = extracted && extracted !== errStr ? extracted : 'state store unavailable'
+    } else {
+      loadError = `Error loading workflows: ${errStr}`
     }
-    return (
-      <div className="page">
-        <p className="err">Error loading workflows: {errStr}</p>
-      </div>
-    )
   }
 
   return (
@@ -395,6 +388,24 @@ export function Workflows() {
           )}
         </div>
       </div>
+
+      {/* Load-error banner — page stays usable so the user can switch stores */}
+      {loadError && (
+        <div
+          data-testid="load-error-banner"
+          style={{
+            marginBottom: 12,
+            padding: '8px 12px',
+            borderRadius: 8,
+            border: '1px solid var(--line)',
+            background: 'var(--surface)',
+            color: 'var(--fail-fg)',
+            fontSize: 13,
+          }}
+        >
+          {loadError} — Select another state store or check the connection.
+        </div>
+      )}
 
       {/* Remove status banner */}
       {removeStatus && (
@@ -533,6 +544,8 @@ export function Workflows() {
         <div className="tablewrap">
           {(isLoading || (!noStores && selectedStore === null)) ? (
             <p className="muted" style={{ padding: 20 }}>Loading…</p>
+          ) : isError ? (
+            <p className="muted" style={{ padding: 20 }}>Couldn't load workflows from this store.</p>
           ) : items.length === 0 ? (
             <p className="muted" style={{ padding: 20 }}>No workflows found</p>
           ) : (

--- a/web/src/pages/Workflows.tsx
+++ b/web/src/pages/Workflows.tsx
@@ -211,8 +211,13 @@ export function Workflows() {
     enabled: selectedStore !== null,
   })
 
-  // Null-safe guard + de-duplicate by appId/instanceId (safety net against duplicate rows)
-  const items = useMemo<WorkflowSummary[]>(() => dedupeWorkflows(data?.items ?? []), [data?.items])
+  // Null-safe guard + de-duplicate by appId/instanceId (safety net against duplicate rows).
+  // When errored, treat as empty so the pager shows "No results" and row-derived UI
+  // (selection bar, Next button) sees no rows — even if TanStack Query retained stale data.
+  const items = useMemo<WorkflowSummary[]>(
+    () => (isError ? [] : dedupeWorkflows(data?.items ?? [])),
+    [isError, data?.items],
+  )
 
   // App IDs for the filter dropdown come from the store (every app-id with
   // workflow data), not the current page of rows — so applying the filter never
@@ -517,8 +522,8 @@ export function Workflows() {
 
       {/* Main card */}
       <div className="card">
-        {/* Selection bar — shown only when rows selected */}
-        {selected.size > 0 && (
+        {/* Selection bar — shown only when rows selected and the list is not in error */}
+        {selected.size > 0 && !isError && (
           <div className="selbar">
             <span className="cnt">{selected.size} selected</span>
             <span className="grow" />
@@ -675,7 +680,7 @@ export function Workflows() {
               ← Prev
             </button>
             <button
-              disabled={!data?.nextToken}
+              disabled={isError || !data?.nextToken}
               onClick={() => {
                 if (!data?.nextToken) return
                 setHistory((h) => [...h, { token: page, offset: pageOffset }])


### PR DESCRIPTION
## Summary

- **Workflows page degrades gracefully on state-store load errors.** Previously, any workflow-list error (e.g. a docker-compose state store brought down while it's the persisted selection) replaced the entire page, hiding the store selector — leaving no way to switch to a reachable store. Now the header, store selector, and filters always render; the error appears as a banner above the filters ("<server message> — Select another state store or check the connection."), and the table shows a "Couldn't load workflows from this store." placeholder. Stale retained query data is gated too: no leftover pager counts, selection bar, or enabled Next button while errored. The full-page "No state store detected" guidance still applies when the store list itself is empty.
- **Connections panel: Delete → Disconnect.** The per-row action on the Components page is now "Disconnect" (ghost styling, non-destructive), the confirm modal is titled "Disconnect state store?" with a primary confirm button and explicit reassurance that the component YAML file on disk is not deleted, and the toast reads "Disconnected <name>". API semantics unchanged.

Spec: `docs/superpowers/specs/2026-07-06-workflow-store-graceful-degradation-design.md`
Plan: `docs/superpowers/plans/2026-07-06-workflow-store-graceful-degradation.md`

## Test plan

- [x] 601 web tests pass (`cd web && npm test`), tsc clean
- [x] New/updated tests: degraded render on 503 (banner + chrome + placeholder), recovery by switching stores, stale-data gating on background refetch failure, Disconnect wording/styling assertions
- [ ] Manual: bring a compose store down while the Workflows page is open; verify the banner appears and switching to the active store recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)