### PR TITLE
feat: backend connection awareness (offline indicator + polling pause)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,7 +88,7 @@ web/                    React + TypeScript + Vite SPA → web/dist (embedded via
   src/pages/            one component per route (+ component-builder, resiliency-builder)
   src/components/        reusable UI (wizard/, form/ subdirs)
   src/hooks/            TanStack Query data hooks + useLogStream / useFollowScroll
-  src/lib/              api, refresh (polling), query client, helpers
+  src/lib/              api, refresh (polling), connection (backend health), query client, helpers
   src/styles/theme.css  design tokens + component classes
   STYLEGUIDE.md         UI conventions, enforced by src/test/styleguide.test.ts
 scripts/                install.sh, install.ps1, release.sh
@@ -393,7 +393,7 @@ discard handler otherwise); logs are grouped by `component=`
 
 React 19 + TypeScript + Vite, built to `web/dist` and embedded in the binary. `main.tsx`
 mounts the provider stack: `QueryProvider` (TanStack Query) → `RefreshProvider` (global
-polling) → `RouterProvider`. `App.tsx` is the shell (TopNav + collapsible ResourcesSidebar
+polling) → `ConnectionProvider` (backend health) → `RouterProvider`. `App.tsx` is the shell (TopNav + collapsible ResourcesSidebar
 + routed `Outlet`), wrapped by a `SmallScreenGuard` (desktop-width UI) and route-level
 error boundaries.
 
@@ -413,7 +413,13 @@ Every polling query is a TanStack Query hook (`src/hooks/`) that calls `fetchJSO
 (`lib/api.ts`) and takes its `refetchInterval` from the global `RefreshControl`
 (`lib/refresh.tsx`: 1s/3s/5s/10s/Off, persisted). Query keys are conventional
 (`['apps']`, `['apps', id]`, `['workflows']`, `['workflow-stats']`, …); mutations
-invalidate the relevant keys. Pages gate on query errors rather than rendering stale
+invalidate the relevant keys. `ConnectionProvider` (`lib/connection.tsx`) polls
+`GET /api/health` at that same interval (fixed 30s fallback while refresh is paused/Off)
+and mirrors the result into TanStack's `onlineManager`: two consecutive failures flip the
+app offline — pausing every polling query until the next successful probe — and
+`RefreshControl`'s beat dot turns red with a "Backend offline" label. Mutations default to
+`networkMode: 'always'` so an action clicked while the backend is down fails fast through
+its normal error path instead of queueing and firing on recovery. Pages gate on query errors rather than rendering stale
 cache: when the workflow list fails, the Workflows page shows an error banner and clears
 rows, selection, and pagination while the page chrome stays usable. Live logs use SSE via `useLogStream` (a monotonic `revision`
 counter distinct from buffer length, and a `closed`-vs-`error` status) with

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Developers use the dashboard to observe and debug Dapr apps while building local
   highlight, and a follow toggle.
 
 The UI is built for fast scanning and debugging: deep-linkable views, a global autorefresh
-control, full keyboard operability, and cross-navigation between related entities (app →
+control that doubles as a backend-connection indicator (data polling pauses while the
+backend is unreachable and resumes on recovery), full keyboard operability, and
+cross-navigation between related entities (app →
 component → "loaded by" app, etc.).
 
 ## User instructions (download, install, run)

--- a/docs/superpowers/plans/2026-07-07-backend-connection-awareness.md
+++ b/docs/superpowers/plans/2026-07-07-backend-connection-awareness.md
@@ -1,0 +1,531 @@
+# Backend Connection Awareness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the web UI detect when the Go backend is offline, show a red "Backend offline" indicator on the TopNav refresh control, and pause all data polling until it recovers.
+
+**Architecture:** A new `ConnectionProvider` polls the existing `GET /api/health` endpoint at the global refresh interval (30 s fallback when refresh is paused/Off) and mirrors the result into TanStack Query's built-in `onlineManager`, which pauses every other query while offline and auto-refetches on recovery. `RefreshControl` reads the connection state and repurposes its beat dot as the indicator.
+
+**Tech Stack:** React 19, TanStack Query v5 (`onlineManager`, `networkMode`), Vitest + React Testing Library + MSW, plain CSS theme tokens.
+
+Spec: `docs/superpowers/specs/2026-07-07-backend-connection-awareness-design.md`
+
+## Global Constraints
+
+- All frontend commands run from `web/` (`npm test` = `vitest run`, `npm run build` = `tsc -b && vite build`).
+- No hex color literals in `.ts`/`.tsx` — colors come from theme tokens like `var(--fail-fg)` (enforced by `src/test/styleguide.test.ts`). CSS may use `color-mix` with tokens.
+- React 19 context style: render context objects directly as providers (`<ConnectionContext value={…}>`), matching `web/src/lib/refresh.tsx`.
+- MSW test server (from `src/test/setup.ts`) runs with `onUnhandledRequest: 'error'` — component tests must not mount anything that fires unmocked requests. Stub `ConnectionContext` directly in component tests; only `connection.test.tsx` mounts the real polling provider (with MSW handlers).
+- Offline threshold is two consecutive failed health requests (query-client default `retry: 1`); recovery is the first success. Fallback poll cadence when refresh is paused/Off: `30_000` ms.
+- Commit after every task.
+
+---
+
+### Task 1: ConnectionProvider (`web/src/lib/connection.tsx`)
+
+**Files:**
+- Create: `web/src/lib/connection.tsx`
+- Create: `web/src/lib/connection.test.tsx`
+- Modify: `web/src/hooks/useMeta.ts` (remove the now-superseded `useHealth` + `HealthInfo`)
+- Modify: `web/src/hooks/useMeta.test.tsx` (remove the `useHealth` describe block)
+
+**Interfaces:**
+- Consumes: `useRefreshInterval()` / `refetchMs(ctx)` / `RefreshCtx` from `web/src/lib/refresh.tsx`; `fetchJSON` from `web/src/lib/api.ts`; `makeQueryClient`/`QueryProvider` from `web/src/lib/query.tsx`.
+- Produces (used by Tasks 2–3):
+  - `ConnectionProvider({ children }: { children: ReactNode })` — component
+  - `useConnection(): { online: boolean }` — throws outside the provider
+  - `ConnectionContext` — exported so tests can stub `{ online }` without polling
+  - `healthPollMs(ctx: Pick<RefreshCtx, 'intervalMs' | 'paused'>): number`
+  - `HealthInfo` interface (moves here from `useMeta.ts`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `web/src/lib/connection.test.tsx`:
+
+```tsx
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, afterEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { onlineManager, type QueryClient } from '@tanstack/react-query'
+import { server } from '../test/setup'
+import { QueryProvider, makeQueryClient } from './query'
+import { RefreshProvider } from './refresh'
+import { ConnectionProvider, useConnection, healthPollMs } from './connection'
+
+function Probe() {
+  const { online } = useConnection()
+  return <div data-testid="conn-probe">{online ? 'online' : 'offline'}</div>
+}
+
+// retryDelay 0 keeps the fail-retry-fail cycle fast; the retry count (1)
+// matches the production client, so "two consecutive failures" still holds.
+function makeTestClient(): QueryClient {
+  const client = makeQueryClient()
+  client.setDefaultOptions({ queries: { retry: 1, retryDelay: 0 } })
+  return client
+}
+
+function renderWithProviders(client: QueryClient) {
+  return render(
+    <QueryProvider client={client}>
+      <RefreshProvider>
+        <ConnectionProvider>
+          <Probe />
+        </ConnectionProvider>
+      </RefreshProvider>
+    </QueryProvider>,
+  )
+}
+
+afterEach(() => {
+  // ConnectionProvider mirrors state into the module-global onlineManager;
+  // reset so a test that ended offline cannot leak into later tests.
+  onlineManager.setOnline(true)
+})
+
+describe('healthPollMs', () => {
+  it('follows the refresh interval when live', () => {
+    expect(healthPollMs({ intervalMs: 3000, paused: false })).toBe(3000)
+  })
+
+  it('falls back to 30s when paused', () => {
+    expect(healthPollMs({ intervalMs: 3000, paused: true })).toBe(30_000)
+  })
+
+  it('falls back to 30s when the interval is Off', () => {
+    expect(healthPollMs({ intervalMs: 0, paused: false })).toBe(30_000)
+  })
+})
+
+describe('ConnectionProvider', () => {
+  it('is online initially (optimistic) and stays online while /api/health succeeds', async () => {
+    server.use(http.get('/api/health', () => HttpResponse.json({ status: 'ok' })))
+    const client = makeTestClient()
+    renderWithProviders(client)
+    // Before the first response settles the state is optimistic, not offline.
+    expect(screen.getByTestId('conn-probe')).toHaveTextContent('online')
+    await waitFor(() => expect(client.getQueryState(['health'])?.status).toBe('success'))
+    expect(screen.getByTestId('conn-probe')).toHaveTextContent('online')
+    expect(onlineManager.isOnline()).toBe(true)
+  })
+
+  it('flips offline after two consecutive failed checks (initial + retry)', async () => {
+    let calls = 0
+    server.use(
+      http.get('/api/health', () => {
+        calls++
+        return new HttpResponse(null, { status: 500 })
+      }),
+    )
+    renderWithProviders(makeTestClient())
+    await waitFor(() =>
+      expect(screen.getByTestId('conn-probe')).toHaveTextContent('offline'),
+    )
+    expect(calls).toBe(2)
+    expect(onlineManager.isOnline()).toBe(false)
+  })
+
+  it('recovers to online on the next successful check', async () => {
+    server.use(http.get('/api/health', () => new HttpResponse(null, { status: 500 })))
+    const client = makeTestClient()
+    renderWithProviders(client)
+    await waitFor(() =>
+      expect(screen.getByTestId('conn-probe')).toHaveTextContent('offline'),
+    )
+
+    // Later server.use handlers take precedence within a test.
+    server.use(http.get('/api/health', () => HttpResponse.json({ status: 'ok' })))
+    // Stand in for the next interval tick — force the health refetch now.
+    await act(async () => {
+      await client.refetchQueries({ queryKey: ['health'] })
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId('conn-probe')).toHaveTextContent('online'),
+    )
+    expect(onlineManager.isOnline()).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web && npx vitest run src/lib/connection.test.tsx`
+Expected: FAIL — cannot resolve `./connection` (module does not exist).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `web/src/lib/connection.tsx`:
+
+```tsx
+import { createContext, use, useEffect, type ReactNode } from 'react'
+import { onlineManager, useQuery } from '@tanstack/react-query'
+import { fetchJSON } from './api'
+import { refetchMs, useRefreshInterval, type RefreshCtx } from './refresh'
+
+/** Shape returned by GET /api/health */
+export interface HealthInfo {
+  status: string
+}
+
+/** Health poll cadence while the global refresh is paused or Off. */
+const OFFLINE_FALLBACK_MS = 30_000
+
+export interface ConnectionCtx {
+  /** False once the backend health check has failed (initial try + retry). */
+  online: boolean
+}
+
+export const ConnectionContext = createContext<ConnectionCtx | null>(null)
+
+/**
+ * Health poll interval: follows the global refresh interval when live, and
+ * falls back to a slow fixed cadence when refresh is paused or Off, so the
+ * connection indicator never goes stale.
+ */
+export function healthPollMs(ctx: Pick<RefreshCtx, 'intervalMs' | 'paused'>): number {
+  return refetchMs(ctx) || OFFLINE_FALLBACK_MS
+}
+
+/**
+ * Polls GET /api/health and drives two things: the ConnectionContext consumed
+ * by RefreshControl's indicator, and TanStack Query's onlineManager, which
+ * pauses every other query while the backend is unreachable and refetches
+ * them on recovery. Setting onlineManager manually makes this health check
+ * the sole authority on online state (the browser's window online/offline
+ * events are meaningless for a localhost backend). networkMode 'always'
+ * keeps this one probe polling while the onlineManager reports offline.
+ */
+export function ConnectionProvider({ children }: { children: ReactNode }) {
+  const refreshCtx = useRefreshInterval()
+
+  const health = useQuery<HealthInfo>({
+    queryKey: ['health'],
+    queryFn: () => fetchJSON<HealthInfo>('/health'),
+    refetchInterval: healthPollMs(refreshCtx),
+    networkMode: 'always',
+  })
+
+  // Optimistic until the first check settles: isError only turns true after
+  // the query client's retry, i.e. two consecutive failed requests.
+  const online = !health.isError
+
+  useEffect(() => {
+    onlineManager.setOnline(online)
+  }, [online])
+
+  return <ConnectionContext value={{ online }}>{children}</ConnectionContext>
+}
+
+export function useConnection(): ConnectionCtx {
+  const ctx = use(ConnectionContext)
+  if (!ctx) throw new Error('useConnection must be used within a ConnectionProvider')
+  return ctx
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web && npx vitest run src/lib/connection.test.tsx`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Remove the superseded `useHealth` hook**
+
+`HealthInfo` now lives in `connection.tsx`; the old fixed-30s hook is unused. First confirm nothing else consumes it:
+
+Run: `cd web && grep -rn "useHealth\|HealthInfo" src --include="*.ts" --include="*.tsx" | grep -v "src/lib/connection"`
+Expected: matches only in `src/hooks/useMeta.ts` and `src/hooks/useMeta.test.tsx`.
+
+In `web/src/hooks/useMeta.ts`, delete the `HealthInfo` interface and the `useHealth` function (lines 11–14 and 25–32), leaving only `VersionInfo` and `useVersion`.
+
+In `web/src/hooks/useMeta.test.tsx`, delete the entire `describe('useHealth', …)` block and change the import line to:
+
+```tsx
+import { useVersion } from './useMeta'
+```
+
+- [ ] **Step 6: Run the full web test suite**
+
+Run: `cd web && npm test`
+Expected: PASS — everything green (nothing consumes `ConnectionProvider` yet).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/lib/connection.tsx web/src/lib/connection.test.tsx web/src/hooks/useMeta.ts web/src/hooks/useMeta.test.tsx
+git commit -m "feat: add ConnectionProvider polling backend health into onlineManager"
+```
+
+---
+
+### Task 2: Offline indicator in RefreshControl
+
+**Files:**
+- Modify: `web/src/components/RefreshControl.tsx`
+- Modify: `web/src/components/RefreshControl.test.tsx`
+- Modify: `web/src/styles/theme.css` (after line 207, the `.beatbtn.off .beat` rule)
+- Modify: `web/src/components/TopNav.test.tsx`, `web/src/App.test.tsx`, `web/src/components/RouteError.test.tsx` (these render `RefreshControl` via `TopNav`; their wrappers need the stub context or `useConnection` throws)
+
+**Interfaces:**
+- Consumes: `useConnection()` and `ConnectionContext` from Task 1 (`web/src/lib/connection.tsx`).
+- Produces: no new exports — visual states on the existing `RefreshControl`. CSS contract: `beatbtn offline` class on the button, `.offline-label` span with text `Backend offline`, offline title `Backend unreachable — retrying…`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `web/src/components/RefreshControl.test.tsx`, replace the `renderWithProvider` helper (and its imports) so every render supplies a stubbed connection state — the real provider would poll and trip MSW's `onUnhandledRequest: 'error'`:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { RefreshProvider } from '../lib/refresh'
+import { ConnectionContext } from '../lib/connection'
+import { RefreshControl } from './RefreshControl'
+
+function renderWithProvider(online = true) {
+  return render(
+    <RefreshProvider>
+      <ConnectionContext value={{ online }}>
+        <RefreshControl />
+      </ConnectionContext>
+    </RefreshProvider>,
+  )
+}
+```
+
+The existing tests keep passing unchanged (they render online). Append a new describe block at the end of the file:
+
+```tsx
+describe('RefreshControl offline indicator', () => {
+  it('shows the offline dot state, label, and title when the backend is offline', () => {
+    const { container } = renderWithProvider(false)
+    const btn = container.querySelector('button.beatbtn')!
+    // classList (not className.includes): 'offline' contains 'off' as a substring.
+    expect(btn.classList.contains('offline')).toBe(true)
+    expect(btn.classList.contains('off')).toBe(false)
+    expect(screen.getByText('Backend offline')).toBeInTheDocument()
+    expect(btn).toHaveAttribute('title', 'Backend unreachable — retrying…')
+  })
+
+  it('offline styling wins over paused', () => {
+    const { container } = renderWithProvider(false)
+    fireEvent.click(screen.getByRole('button', { name: /pause auto-refresh/i }))
+    const btn = container.querySelector('button.beatbtn')!
+    expect(btn.classList.contains('offline')).toBe(true)
+    expect(btn.classList.contains('off')).toBe(false)
+    expect(btn).toHaveAttribute('title', 'Backend unreachable — retrying…')
+  })
+
+  it('renders no offline label when online', () => {
+    renderWithProvider(true)
+    expect(screen.queryByText('Backend offline')).not.toBeInTheDocument()
+  })
+
+  it('keeps the pause button and interval picker functional while offline', () => {
+    renderWithProvider(false)
+    const btn = screen.getByRole('button', { name: /pause auto-refresh/i })
+    fireEvent.click(btn)
+    expect(btn).toHaveAttribute('aria-pressed', 'true')
+    const sel = screen.getByRole('combobox', { name: /refresh interval/i }) as HTMLSelectElement
+    fireEvent.change(sel, { target: { value: '5000' } })
+    expect(sel.value).toBe('5000')
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify the new ones fail**
+
+Run: `cd web && npx vitest run src/components/RefreshControl.test.tsx`
+Expected: the 4 new tests FAIL (no `offline` class/label); the 7 existing tests PASS.
+
+- [ ] **Step 3: Implement the indicator**
+
+Replace `web/src/components/RefreshControl.tsx` with:
+
+```tsx
+import { useConnection } from '../lib/connection'
+import { useRefreshInterval } from '../lib/refresh'
+
+const INTERVAL_OPTIONS = [
+  { label: '1s', value: 1000 },
+  { label: '3s', value: 3000 },
+  { label: '5s', value: 5000 },
+  { label: '10s', value: 10000 },
+  { label: 'Off', value: 0 },
+]
+
+/**
+ * Compact global refresh control for the top navigation bar. Renders a beating
+ * dot that doubles as a pause/resume button, plus an interval picker. Reads and
+ * writes the global RefreshContext, so it governs polling on every page.
+ *
+ * The dot is also the backend connection indicator: when the health check
+ * reports the backend unreachable it turns red (with a "Backend offline"
+ * label) and that state wins over the live/paused looks.
+ */
+export function RefreshControl() {
+  const { intervalMs, paused, setInterval, setPaused } = useRefreshInterval()
+  const { online } = useConnection()
+
+  const intervalLabel =
+    INTERVAL_OPTIONS.find((o) => o.value === intervalMs)?.label ?? `${intervalMs / 1000}s`
+
+  const off = intervalMs === 0
+  const live = !paused && !off
+  const offline = !online
+
+  // Precedence: offline > off > paused. `off` (interval 0 → nothing polls) is
+  // the more fundamental refresh state, so it wins over `paused` in the title
+  // even when both are set.
+  const title = offline
+    ? 'Backend unreachable — retrying…'
+    : off
+      ? 'Auto-refresh off'
+      : paused
+        ? 'Auto-refresh paused — click to resume'
+        : `Auto-refresh every ${intervalLabel} — click to pause`
+
+  const dotState = offline ? ' offline' : live ? '' : ' off'
+
+  return (
+    <div className="refresh-compact">
+      {offline && (
+        <span className="offline-label" data-cy="offline-label">
+          Backend offline
+        </span>
+      )}
+      <button
+        className={`beatbtn${dotState}`}
+        data-cy="refresh-pause"
+        aria-label="Pause auto-refresh"
+        aria-pressed={paused}
+        title={title}
+        onClick={() => setPaused(!paused)}
+      >
+        <span className="beat" />
+      </button>
+
+      <select
+        className="select compact"
+        data-cy="refresh-interval"
+        aria-label="Refresh interval"
+        value={intervalMs}
+        onChange={(e) => setInterval(Number(e.target.value))}
+      >
+        {INTERVAL_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+```
+
+In `web/src/styles/theme.css`, directly after the `.beatbtn.off .beat` rule (line 207), add:
+
+```css
+.beatbtn.offline .beat { background: var(--fail-fg); animation: beat-offline 2.4s ease-out infinite; }
+@keyframes beat-offline { 0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--fail-fg) 50%, transparent); } 70% { box-shadow: 0 0 0 7px transparent; } 100% { box-shadow: 0 0 0 0 transparent; } }
+.offline-label { color: var(--fail-fg); font-size: 12px; white-space: nowrap; }
+```
+
+- [ ] **Step 4: Run the RefreshControl tests**
+
+Run: `cd web && npx vitest run src/components/RefreshControl.test.tsx`
+Expected: PASS (11 tests).
+
+- [ ] **Step 5: Fix the other tests that render RefreshControl via TopNav**
+
+`RefreshControl` now calls `useConnection()`, so any test rendering `TopNav` without the context throws. In each of the three files below, import the context and nest a stub provider just inside `RefreshProvider` at **every** `render(…)` call site that reaches `TopNav`:
+
+```tsx
+import { ConnectionContext } from '../lib/connection'   // '../lib' from components/, './lib' from src/
+```
+
+Wrap pattern (children unchanged):
+
+```tsx
+<RefreshProvider>
+  <ConnectionContext value={{ online: true }}>
+    {/* existing children of RefreshProvider */}
+  </ConnectionContext>
+</RefreshProvider>
+```
+
+- `web/src/components/TopNav.test.tsx` — render helper around line 50.
+- `web/src/App.test.tsx` — the render calls around lines 46, 100, and 121 (any that mount the router/App).
+- `web/src/components/RouteError.test.tsx` — render helper around line 57.
+
+- [ ] **Step 6: Run the full web test suite**
+
+Run: `cd web && npm test`
+Expected: PASS — including the styleguide test (no hex literals were added to TS/TSX).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/components/RefreshControl.tsx web/src/components/RefreshControl.test.tsx web/src/styles/theme.css web/src/components/TopNav.test.tsx web/src/App.test.tsx web/src/components/RouteError.test.tsx
+git commit -m "feat: show backend offline indicator on the refresh control"
+```
+
+---
+
+### Task 3: Wire ConnectionProvider into the app
+
+**Files:**
+- Modify: `web/src/main.tsx`
+
+**Interfaces:**
+- Consumes: `ConnectionProvider` from Task 1.
+- Produces: the live app renders `QueryProvider → RefreshProvider → ConnectionProvider → RouterProvider`, making `useConnection()` available everywhere (TopNav included) and activating the health poll + onlineManager pausing globally.
+
+- [ ] **Step 1: Mount the provider**
+
+In `web/src/main.tsx`, add the import and wrap `RouterProvider` (ConnectionProvider needs both the query client and the refresh context, so it sits innermost):
+
+```tsx
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { RouterProvider } from 'react-router-dom'
+import './styles/theme.css'
+import { applyPrefs } from './lib/prefs'
+import { router } from './router'
+import { QueryProvider } from './lib/query'
+import { RefreshProvider } from './lib/refresh'
+import { ConnectionProvider } from './lib/connection'
+import { initTelemetry } from './lib/telemetry'
+
+void initTelemetry()
+applyPrefs()
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <QueryProvider>
+      <RefreshProvider>
+        <ConnectionProvider>
+          <RouterProvider router={router} future={{ v7_startTransition: true }} />
+        </ConnectionProvider>
+      </RefreshProvider>
+    </QueryProvider>
+  </StrictMode>,
+)
+```
+
+- [ ] **Step 2: Run the full test suite and the production build**
+
+Run: `cd web && npm test`
+Expected: PASS.
+
+Run: `cd web && npm run build`
+Expected: `tsc -b` and `vite build` both succeed with no type errors.
+
+- [ ] **Step 3 (optional manual verification): Kill the backend and watch the dot**
+
+Start the dashboard (Go backend serving the built web UI, or `npm run dev` with the backend running). Open the UI, then stop the backend process. Within ~2 poll cycles the beat dot turns red with a "Backend offline" label, and the Network tab shows only `/api/health` requests continuing. Restart the backend: the label clears and data queries resume automatically.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/main.tsx
+git commit -m "feat: wire ConnectionProvider into the app provider tree"
+```

--- a/docs/superpowers/specs/2026-07-07-backend-connection-awareness-design.md
+++ b/docs/superpowers/specs/2026-07-07-backend-connection-awareness-design.md
@@ -30,6 +30,11 @@ the UI.
 - **Pause mechanism:** TanStack Query's built-in `onlineManager` — flipping
   it pauses/resumes every existing query with zero changes to the ~10
   existing data hooks.
+- **Mutations fail fast, not queue:** mutations (workflow purge, control-plane
+  start/stop, store add/update/delete) use `networkMode: 'always'` via the
+  global default in `makeQueryClient()`. This ensures they run immediately and
+  surface an error rather than silently queuing while offline and firing
+  unexpectedly on recovery.
 
 ## Design
 
@@ -84,11 +89,12 @@ for the beat dot:
 - Styling: new `.beatbtn.offline` variant and an offline label style in
   `web/src/styles/theme.css`, using the existing `--fail-fg` token.
 
-### 3. App wiring (`web/src/App.tsx`)
+### 3. App wiring (`web/src/main.tsx`)
 
 Mount `ConnectionProvider` around the routed content so both
 `RefreshControl` (in TopNav) and any future consumers can call
-`useConnection()`. Order: `QueryClientProvider` → `RefreshProvider` →
+`useConnection()`. The providers live in `web/src/main.tsx` (not
+`App.tsx`). Order: `QueryClientProvider` → `RefreshProvider` →
 `ConnectionProvider`.
 
 ## Edge cases

--- a/docs/superpowers/specs/2026-07-07-backend-connection-awareness-design.md
+++ b/docs/superpowers/specs/2026-07-07-backend-connection-awareness-design.md
@@ -40,7 +40,7 @@ the UI.
 
 ### 1. ConnectionProvider (`web/src/lib/connection.tsx`, new)
 
-A React context provider mounted in `App.tsx` inside the existing
+A React context provider mounted in `main.tsx` inside the existing
 `QueryClientProvider` and `RefreshProvider`. It owns the health poll and
 exposes connection state:
 

--- a/docs/superpowers/specs/2026-07-07-backend-connection-awareness-design.md
+++ b/docs/superpowers/specs/2026-07-07-backend-connection-awareness-design.md
@@ -1,0 +1,119 @@
+# Backend connection awareness (online/offline indicator) — design
+
+Date: 2026-07-07
+Status: approved
+
+## Problem
+
+The frontend has no awareness of whether the Go backend process is still
+running. When the backend dies, every polling query silently fails: pages
+keep showing stale data, nothing updates, and the user gets no explanation —
+a confusing, disconnected experience. The backend already exposes
+`GET /api/health` (`pkg/server/api.go`) and the frontend has an unused
+`useHealth()` hook (`web/src/hooks/useMeta.ts`), but neither is wired into
+the UI.
+
+## Decisions (from brainstorming)
+
+- **Detection:** poll `/api/health` at the global refresh interval — the
+  health check is the single source of truth for online/offline. Offline is
+  not derived from failures of other data queries.
+- **When refresh is paused or "Off":** the health check keeps running at a
+  slow fixed fallback of **30 seconds**, so the indicator stays truthful at
+  negligible cost.
+- **While offline:** all other data polling is suspended (no storm of
+  failing requests or per-page errors) and resumes automatically on
+  recovery. Pages keep showing their last-fetched data.
+- **Indicator:** repurpose the existing beat dot in `RefreshControl`
+  (TopNav) rather than adding a new UI element. Offline = red dot plus a
+  "Backend offline" text label.
+- **Pause mechanism:** TanStack Query's built-in `onlineManager` — flipping
+  it pauses/resumes every existing query with zero changes to the ~10
+  existing data hooks.
+
+## Design
+
+### 1. ConnectionProvider (`web/src/lib/connection.tsx`, new)
+
+A React context provider mounted in `App.tsx` inside the existing
+`QueryClientProvider` and `RefreshProvider`. It owns the health poll and
+exposes connection state:
+
+- Runs one query against `/health` via the existing `fetchJSON` helper.
+  Query options:
+  - `refetchInterval`: the global refresh interval (`refetchMs(ctx)`) when
+    refresh is live; when refresh is paused or the interval is 0 ("Off"),
+    fall back to a fixed `30_000` ms instead of stopping.
+  - `networkMode: 'always'` — the health query must keep polling while
+    `onlineManager` reports offline (everything else pauses; this query is
+    the recovery probe).
+  - `retry`: keep the query client's existing default (1 retry), so
+    flipping to offline requires **two consecutive failed requests** —
+    protects against a single blip, e.g. during a backend restart.
+- `online` is derived from the query: `true` until the query first enters
+  the error state (optimistic initial load — no red flash on startup), then
+  tracks error/success. Any failure counts: network-level errors and
+  non-2xx responses (both throw from `fetchJSON`).
+- Recovery: the first successful response flips back online immediately.
+- An effect mirrors the state into TanStack:
+  `onlineManager.setOnline(online)`. Calling `setOnline` makes the health
+  check the sole authority on online state, replacing the browser's
+  `window` online/offline events (which are meaningless for a localhost
+  backend). All existing polling queries (default `networkMode: 'online'`)
+  pause while offline and refetch automatically when connectivity returns
+  (`refetchOnReconnect`).
+- Exposes `useConnection(): { online: boolean }`.
+- The now-superseded `useHealth()` hook in `useMeta.ts` (unused, fixed 30 s
+  interval) is removed; its `HealthInfo` type moves to or is redefined in
+  `connection.tsx`.
+
+### 2. Indicator in RefreshControl (`web/src/components/RefreshControl.tsx`)
+
+`RefreshControl` reads `useConnection()` and renders three visual states
+for the beat dot:
+
+- **Live + online:** green beating dot (unchanged).
+- **Paused/off + online:** muted gray dot (unchanged).
+- **Offline (regardless of refresh setting):** the dot turns red
+  (`--fail-fg`) and keeps the beat animation — it is still actively
+  probing. A small red "Backend offline" text label renders next to the
+  control. Offline takes visual precedence over the paused look.
+- The button's `title` tooltip explains the state when offline
+  ("Backend unreachable — retrying…"); pause/resume and the interval
+  dropdown remain functional throughout.
+- Styling: new `.beatbtn.offline` variant and an offline label style in
+  `web/src/styles/theme.css`, using the existing `--fail-fg` token.
+
+### 3. App wiring (`web/src/App.tsx`)
+
+Mount `ConnectionProvider` around the routed content so both
+`RefreshControl` (in TopNav) and any future consumers can call
+`useConnection()`. Order: `QueryClientProvider` → `RefreshProvider` →
+`ConnectionProvider`.
+
+## Edge cases
+
+- **Initial load:** state starts online until the first check completes;
+  a dead backend shows the offline state within roughly one interval plus
+  the retry.
+- **Backend restart:** a blip shorter than one failed request + retry does
+  not flip the indicator.
+- **Dev server:** with the Vite proxy in front, a dead Go backend surfaces
+  as a 5xx or network error — both already count as failures.
+- **Per-page error banners** (e.g. the Workflows store-unavailable banner)
+  are unrelated to backend liveness and unaffected: they concern a healthy
+  backend reporting a bad state store.
+- **"Off" refresh setting:** data queries do not poll (as today), but the
+  health probe still runs every 30 s, so the indicator cannot go stale.
+
+## Testing
+
+Vitest + React Testing Library, following existing test patterns:
+
+- `connection.test.tsx` (new): provider reports `online: true` initially;
+  flips to offline after the health query errors (retry exhausted); flips
+  back on the next success; mirrors state into `onlineManager`; health
+  poll uses the refresh interval when live and 30 s when paused/off.
+- `RefreshControl.test.tsx`: offline renders the red dot class and the
+  "Backend offline" label; offline styling wins over paused; label absent
+  when online; pause button and dropdown still operate while offline.

--- a/web/STYLEGUIDE.md
+++ b/web/STYLEGUIDE.md
@@ -275,7 +275,7 @@ component fails the suite until the doc is updated.
 | Multi-step builder shell | `components/wizard/` (`Wizard`, `Stepper`, `StepNav`) — see §6. |
 | YAML output step | `components/YamlPreview.tsx` — highlighted preview + Copy/Download — see §6. |
 | Connection manager | `components/StateStoreConnectionDialog.tsx` (a `Modal` of `.field` rows driven by `MetadataFieldInput`) + `components/StateStoreConnectionsPanel.tsx`. |
-| Global chrome | `components/TopNav.tsx` hosts `components/RefreshControl.tsx` (the app-wide auto-refresh — never mount a per-page one) and `components/ThemeToggle.tsx`. |
+| Global chrome | `components/TopNav.tsx` hosts `components/RefreshControl.tsx` (the app-wide auto-refresh, whose dot is also the backend-offline indicator — never mount a per-page one) and `components/ThemeToggle.tsx`. |
 | Toast + clipboard | `useToast()` in `lib/toast.tsx`; `copyText()` in `lib/clipboard.ts` — pair them. |
 | Syntax highlight | `lib/json-highlight.tsx` / `lib/yaml-highlight.tsx` → `<pre className="json">` / `<pre className="code">`. |
 
@@ -338,7 +338,9 @@ component fails the suite until the doc is updated.
 - `.toast` (`.show`) — driven by `useToast`.
 - `.hint` — centered faint helper line under content.
 - `.refresh-compact` — the compact global refresh control in the top nav (`.beatbtn` + `.beat`
-  pulse toggle, `.select.compact` interval dropdown); rendered by `RefreshControl`.
+  pulse toggle, `.select.compact` interval dropdown); rendered by `RefreshControl`. The dot
+  doubles as the backend-connection indicator: `.beatbtn.offline` (red `--fail-fg` pulse) +
+  `.offline-label` when the `/api/health` probe fails.
 
 **Code blocks**
 - `<pre className="json">` + `highlightJson(...)` for JSON.

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -7,6 +7,7 @@ import { Placeholder } from './pages/Placeholder'
 import { routes } from './router'
 import { QueryProvider, makeQueryClient } from './lib/query'
 import { RefreshProvider } from './lib/refresh'
+import { ConnectionContext } from './lib/connection'
 import { trackAction, trackView } from './lib/telemetry'
 
 vi.mock('./lib/telemetry', () => ({ trackAction: vi.fn(), trackView: vi.fn() }))
@@ -46,7 +47,9 @@ function renderApp(path = '/') {
   return render(
     <QueryProvider client={client}>
       <RefreshProvider>
-        <RouterProvider router={router} future={{ v7_startTransition: true }} />
+        <ConnectionContext value={{ online: true }}>
+          <RouterProvider router={router} future={{ v7_startTransition: true }} />
+        </ConnectionContext>
       </RefreshProvider>
     </QueryProvider>,
   )
@@ -100,7 +103,9 @@ describe('route switching', () => {
     render(
       <QueryProvider client={client}>
         <RefreshProvider>
-          <RouterProvider router={router} future={{ v7_startTransition: true }} />
+          <ConnectionContext value={{ online: true }}>
+            <RouterProvider router={router} future={{ v7_startTransition: true }} />
+          </ConnectionContext>
         </RefreshProvider>
       </QueryProvider>,
     )
@@ -121,7 +126,9 @@ describe('RUM tracking', () => {
     render(
       <QueryProvider client={client}>
         <RefreshProvider>
-          <RouterProvider router={router} future={{ v7_startTransition: true }} />
+          <ConnectionContext value={{ online: true }}>
+            <RouterProvider router={router} future={{ v7_startTransition: true }} />
+          </ConnectionContext>
         </RefreshProvider>
       </QueryProvider>,
     )

--- a/web/src/components/RefreshControl.test.tsx
+++ b/web/src/components/RefreshControl.test.tsx
@@ -1,12 +1,15 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, beforeEach } from 'vitest'
 import { RefreshProvider } from '../lib/refresh'
+import { ConnectionContext } from '../lib/connection'
 import { RefreshControl } from './RefreshControl'
 
-function renderWithProvider() {
+function renderWithProvider(online = true) {
   return render(
     <RefreshProvider>
-      <RefreshControl />
+      <ConnectionContext value={{ online }}>
+        <RefreshControl />
+      </ConnectionContext>
     </RefreshProvider>,
   )
 }
@@ -84,5 +87,41 @@ describe('RefreshControl (compact)', () => {
     expect(btn).toHaveAttribute('aria-pressed', 'true')
     expect(btn.className).toContain('off')
     expect(btn).toHaveAttribute('title', 'Auto-refresh off')
+  })
+})
+
+describe('RefreshControl offline indicator', () => {
+  it('shows the offline dot state, label, and title when the backend is offline', () => {
+    const { container } = renderWithProvider(false)
+    const btn = container.querySelector('button.beatbtn')!
+    // classList (not className.includes): 'offline' contains 'off' as a substring.
+    expect(btn.classList.contains('offline')).toBe(true)
+    expect(btn.classList.contains('off')).toBe(false)
+    expect(screen.getByText('Backend offline')).toBeInTheDocument()
+    expect(btn).toHaveAttribute('title', 'Backend unreachable — retrying…')
+  })
+
+  it('offline styling wins over paused', () => {
+    const { container } = renderWithProvider(false)
+    fireEvent.click(screen.getByRole('button', { name: /pause auto-refresh/i }))
+    const btn = container.querySelector('button.beatbtn')!
+    expect(btn.classList.contains('offline')).toBe(true)
+    expect(btn.classList.contains('off')).toBe(false)
+    expect(btn).toHaveAttribute('title', 'Backend unreachable — retrying…')
+  })
+
+  it('renders no offline label when online', () => {
+    renderWithProvider(true)
+    expect(screen.queryByText('Backend offline')).not.toBeInTheDocument()
+  })
+
+  it('keeps the pause button and interval picker functional while offline', () => {
+    renderWithProvider(false)
+    const btn = screen.getByRole('button', { name: /pause auto-refresh/i })
+    fireEvent.click(btn)
+    expect(btn).toHaveAttribute('aria-pressed', 'true')
+    const sel = screen.getByRole('combobox', { name: /refresh interval/i }) as HTMLSelectElement
+    fireEvent.change(sel, { target: { value: '5000' } })
+    expect(sel.value).toBe('5000')
   })
 })

--- a/web/src/components/RefreshControl.tsx
+++ b/web/src/components/RefreshControl.tsx
@@ -1,3 +1,4 @@
+import { useConnection } from '../lib/connection'
 import { useRefreshInterval } from '../lib/refresh'
 
 const INTERVAL_OPTIONS = [
@@ -12,28 +13,44 @@ const INTERVAL_OPTIONS = [
  * Compact global refresh control for the top navigation bar. Renders a beating
  * dot that doubles as a pause/resume button, plus an interval picker. Reads and
  * writes the global RefreshContext, so it governs polling on every page.
+ *
+ * The dot is also the backend connection indicator: when the health check
+ * reports the backend unreachable it turns red (with a "Backend offline"
+ * label) and that state wins over the live/paused looks.
  */
 export function RefreshControl() {
   const { intervalMs, paused, setInterval, setPaused } = useRefreshInterval()
+  const { online } = useConnection()
 
   const intervalLabel =
     INTERVAL_OPTIONS.find((o) => o.value === intervalMs)?.label ?? `${intervalMs / 1000}s`
 
   const off = intervalMs === 0
   const live = !paused && !off
+  const offline = !online
 
-  // `off` (interval 0 → nothing polls) is the more fundamental state, so it wins
-  // over `paused` in the title even when both are set.
-  const title = off
-    ? 'Auto-refresh off'
-    : paused
-      ? 'Auto-refresh paused — click to resume'
-      : `Auto-refresh every ${intervalLabel} — click to pause`
+  // Precedence: offline > off > paused. `off` (interval 0 → nothing polls) is
+  // the more fundamental refresh state, so it wins over `paused` in the title
+  // even when both are set.
+  const title = offline
+    ? 'Backend unreachable — retrying…'
+    : off
+      ? 'Auto-refresh off'
+      : paused
+        ? 'Auto-refresh paused — click to resume'
+        : `Auto-refresh every ${intervalLabel} — click to pause`
+
+  const dotState = offline ? ' offline' : live ? '' : ' off'
 
   return (
     <div className="refresh-compact">
+      {offline && (
+        <span className="offline-label" data-cy="offline-label">
+          Backend offline
+        </span>
+      )}
       <button
-        className={`beatbtn${live ? '' : ' off'}`}
+        className={`beatbtn${dotState}`}
         data-cy="refresh-pause"
         aria-label="Pause auto-refresh"
         aria-pressed={paused}

--- a/web/src/components/RouteError.test.tsx
+++ b/web/src/components/RouteError.test.tsx
@@ -6,6 +6,7 @@ import { server } from '../test/setup'
 import { routes } from '../router'
 import { QueryProvider, makeQueryClient } from '../lib/query'
 import { RefreshProvider } from '../lib/refresh'
+import { ConnectionContext } from '../lib/connection'
 import { trackError } from '../lib/telemetry'
 
 vi.mock('../lib/telemetry', () => ({ trackError: vi.fn(), trackAction: vi.fn(), trackView: vi.fn() }))
@@ -57,7 +58,9 @@ function renderBombed() {
   return render(
     <QueryProvider client={client}>
       <RefreshProvider>
-        <RouterProvider router={router} future={{ v7_startTransition: true }} />
+        <ConnectionContext value={{ online: true }}>
+          <RouterProvider router={router} future={{ v7_startTransition: true }} />
+        </ConnectionContext>
       </RefreshProvider>
     </QueryProvider>,
   )

--- a/web/src/components/TopNav.test.tsx
+++ b/web/src/components/TopNav.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { TopNav, NAV_ITEMS } from './TopNav'
 import { RefreshProvider } from '../lib/refresh'
+import { ConnectionContext } from '../lib/connection'
 import { trackAction } from '../lib/telemetry'
 
 vi.mock('../lib/telemetry', () => ({ trackAction: vi.fn() }))
@@ -49,9 +50,11 @@ describe('TopNav', () => {
   function renderNav() {
     return render(
       <RefreshProvider>
-        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-          <TopNav theme="light" onThemeChange={noop} />
-        </MemoryRouter>
+        <ConnectionContext value={{ online: true }}>
+          <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+            <TopNav theme="light" onThemeChange={noop} />
+          </MemoryRouter>
+        </ConnectionContext>
       </RefreshProvider>,
     )
   }

--- a/web/src/hooks/useMeta.test.tsx
+++ b/web/src/hooks/useMeta.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { http, HttpResponse } from 'msw'
 import { server } from '../test/setup'
 import { QueryProvider, makeQueryClient } from '../lib/query'
-import { useVersion, useHealth } from './useMeta'
+import { useVersion } from './useMeta'
 
 // Wrap hooks in a fresh QueryProvider each test to avoid cross-test cache contamination
 function makeWrapper() {
@@ -36,21 +36,5 @@ describe('useVersion', () => {
   it('starts in a pending state', () => {
     const { result } = renderHook(() => useVersion(), { wrapper: makeWrapper() })
     expect(result.current.isPending).toBe(true)
-  })
-})
-
-describe('useHealth', () => {
-  beforeEach(() => {
-    server.use(
-      http.get('/api/health', () =>
-        HttpResponse.json({ status: 'ok' }),
-      ),
-    )
-  })
-
-  it('returns health status from /api/health', async () => {
-    const { result } = renderHook(() => useHealth(), { wrapper: makeWrapper() })
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(result.current.data).toEqual({ status: 'ok' })
   })
 })

--- a/web/src/hooks/useMeta.ts
+++ b/web/src/hooks/useMeta.ts
@@ -8,25 +8,11 @@ export interface VersionInfo {
   date: string
 }
 
-/** Shape returned by GET /api/health */
-export interface HealthInfo {
-  status: string
-}
-
 /** Fetch the server version from /api/version. Refreshes every 60 s. */
 export function useVersion() {
   return useQuery<VersionInfo>({
     queryKey: ['version'],
     queryFn: () => fetchJSON<VersionInfo>('/version'),
     refetchInterval: 60_000,
-  })
-}
-
-/** Fetch server health from /api/health. Refreshes every 30 s. */
-export function useHealth() {
-  return useQuery<HealthInfo>({
-    queryKey: ['health'],
-    queryFn: () => fetchJSON<HealthInfo>('/health'),
-    refetchInterval: 30_000,
   })
 }

--- a/web/src/lib/connection.test.tsx
+++ b/web/src/lib/connection.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, afterEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { onlineManager, type QueryClient } from '@tanstack/react-query'
+import { server } from '../test/setup'
+import { QueryProvider, makeQueryClient } from './query'
+import { RefreshProvider } from './refresh'
+import { ConnectionProvider, useConnection, healthPollMs } from './connection'
+
+function Probe() {
+  const { online } = useConnection()
+  return <div data-testid="conn-probe">{online ? 'online' : 'offline'}</div>
+}
+
+// retryDelay 0 keeps the fail-retry-fail cycle fast; the retry count (1)
+// matches the production client, so "two consecutive failures" still holds.
+function makeTestClient(): QueryClient {
+  const client = makeQueryClient()
+  client.setDefaultOptions({ queries: { retry: 1, retryDelay: 0 } })
+  return client
+}
+
+function renderWithProviders(client: QueryClient) {
+  return render(
+    <QueryProvider client={client}>
+      <RefreshProvider>
+        <ConnectionProvider>
+          <Probe />
+        </ConnectionProvider>
+      </RefreshProvider>
+    </QueryProvider>,
+  )
+}
+
+afterEach(() => {
+  // ConnectionProvider mirrors state into the module-global onlineManager;
+  // reset so a test that ended offline cannot leak into later tests.
+  onlineManager.setOnline(true)
+})
+
+describe('healthPollMs', () => {
+  it('follows the refresh interval when live', () => {
+    expect(healthPollMs({ intervalMs: 3000, paused: false })).toBe(3000)
+  })
+
+  it('falls back to 30s when paused', () => {
+    expect(healthPollMs({ intervalMs: 3000, paused: true })).toBe(30_000)
+  })
+
+  it('falls back to 30s when the interval is Off', () => {
+    expect(healthPollMs({ intervalMs: 0, paused: false })).toBe(30_000)
+  })
+})
+
+describe('ConnectionProvider', () => {
+  it('is online initially (optimistic) and stays online while /api/health succeeds', async () => {
+    server.use(http.get('/api/health', () => HttpResponse.json({ status: 'ok' })))
+    const client = makeTestClient()
+    renderWithProviders(client)
+    // Before the first response settles the state is optimistic, not offline.
+    expect(screen.getByTestId('conn-probe')).toHaveTextContent('online')
+    await waitFor(() => expect(client.getQueryState(['health'])?.status).toBe('success'))
+    expect(screen.getByTestId('conn-probe')).toHaveTextContent('online')
+    expect(onlineManager.isOnline()).toBe(true)
+  })
+
+  it('flips offline after two consecutive failed checks (initial + retry)', async () => {
+    let calls = 0
+    server.use(
+      http.get('/api/health', () => {
+        calls++
+        return new HttpResponse(null, { status: 500 })
+      }),
+    )
+    renderWithProviders(makeTestClient())
+    await waitFor(() =>
+      expect(screen.getByTestId('conn-probe')).toHaveTextContent('offline'),
+    )
+    expect(calls).toBe(2)
+    expect(onlineManager.isOnline()).toBe(false)
+  })
+
+  it('recovers to online on the next successful check', async () => {
+    server.use(http.get('/api/health', () => new HttpResponse(null, { status: 500 })))
+    const client = makeTestClient()
+    renderWithProviders(client)
+    await waitFor(() =>
+      expect(screen.getByTestId('conn-probe')).toHaveTextContent('offline'),
+    )
+
+    // Later server.use handlers take precedence within a test.
+    server.use(http.get('/api/health', () => HttpResponse.json({ status: 'ok' })))
+    // Stand in for the next interval tick — force the health refetch now.
+    await act(async () => {
+      await client.refetchQueries({ queryKey: ['health'] })
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId('conn-probe')).toHaveTextContent('online'),
+    )
+    expect(onlineManager.isOnline()).toBe(true)
+  })
+})

--- a/web/src/lib/connection.tsx
+++ b/web/src/lib/connection.tsx
@@ -1,0 +1,64 @@
+import { createContext, use, useEffect, type ReactNode } from 'react'
+import { onlineManager, useQuery } from '@tanstack/react-query'
+import { fetchJSON } from './api'
+import { refetchMs, useRefreshInterval, type RefreshCtx } from './refresh'
+
+/** Shape returned by GET /api/health */
+export interface HealthInfo {
+  status: string
+}
+
+/** Health poll cadence while the global refresh is paused or Off. */
+const OFFLINE_FALLBACK_MS = 30_000
+
+export interface ConnectionCtx {
+  /** False once the backend health check has failed (initial try + retry). */
+  online: boolean
+}
+
+export const ConnectionContext = createContext<ConnectionCtx | null>(null)
+
+/**
+ * Health poll interval: follows the global refresh interval when live, and
+ * falls back to a slow fixed cadence when refresh is paused or Off, so the
+ * connection indicator never goes stale.
+ */
+export function healthPollMs(ctx: Pick<RefreshCtx, 'intervalMs' | 'paused'>): number {
+  return refetchMs(ctx) || OFFLINE_FALLBACK_MS
+}
+
+/**
+ * Polls GET /api/health and drives two things: the ConnectionContext consumed
+ * by RefreshControl's indicator, and TanStack Query's onlineManager, which
+ * pauses every other query while the backend is unreachable and refetches
+ * them on recovery. Setting onlineManager manually makes this health check
+ * the sole authority on online state (the browser's window online/offline
+ * events are meaningless for a localhost backend). networkMode 'always'
+ * keeps this one probe polling while the onlineManager reports offline.
+ */
+export function ConnectionProvider({ children }: { children: ReactNode }) {
+  const refreshCtx = useRefreshInterval()
+
+  const health = useQuery<HealthInfo>({
+    queryKey: ['health'],
+    queryFn: () => fetchJSON<HealthInfo>('/health'),
+    refetchInterval: healthPollMs(refreshCtx),
+    networkMode: 'always',
+  })
+
+  // Optimistic until the first check settles: isError only turns true after
+  // the query client's retry, i.e. two consecutive failed requests.
+  const online = !health.isError
+
+  useEffect(() => {
+    onlineManager.setOnline(online)
+  }, [online])
+
+  return <ConnectionContext value={{ online }}>{children}</ConnectionContext>
+}
+
+export function useConnection(): ConnectionCtx {
+  const ctx = use(ConnectionContext)
+  if (!ctx) throw new Error('useConnection must be used within a ConnectionProvider')
+  return ctx
+}

--- a/web/src/lib/query.test.tsx
+++ b/web/src/lib/query.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Tests for makeQueryClient() — specifically that mutations use
+ * networkMode: 'always' so they fail fast instead of queuing when
+ * ConnectionProvider has flagged the backend offline via onlineManager.
+ *
+ * A paused mutation is silent and potentially dangerous: a "purge workflow"
+ * action queued while the backend is down could execute minutes later on
+ * recovery without the user expecting it.
+ */
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, afterEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { onlineManager, useMutation } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { server } from '../test/setup'
+import { makeQueryClient, QueryProvider } from './query'
+
+// Build a fresh wrapper for each test so state never leaks.
+function makeWrapper() {
+  const client = makeQueryClient()
+  // Speed up retry delay so tests don't stall.
+  client.setDefaultOptions({ mutations: { networkMode: 'always' } })
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryProvider client={client}>{children}</QueryProvider>
+  }
+  return { client, Wrapper }
+}
+
+afterEach(() => {
+  // ConnectionProvider mirrors state into the module-global onlineManager;
+  // reset so a test that ended offline cannot leak into subsequent tests.
+  onlineManager.setOnline(true)
+})
+
+describe('makeQueryClient mutations default', () => {
+  it('fails fast (isError) instead of pausing (isPaused) when onlineManager is offline', async () => {
+    // Arrange: backend reports an error on this endpoint.
+    server.use(http.post('/api/whatever', () => new HttpResponse(null, { status: 500 })))
+
+    // Build a client whose mutations default is under test — do NOT override
+    // networkMode here; we want makeQueryClient()'s own default to apply.
+    const client = makeQueryClient()
+    function Wrapper({ children }: { children: ReactNode }) {
+      return <QueryProvider client={client}>{children}</QueryProvider>
+    }
+
+    const { result } = renderHook(
+      () =>
+        useMutation({
+          mutationFn: async () => {
+            const res = await fetch('/api/whatever', { method: 'POST' })
+            if (!res.ok) throw new Error(`HTTP ${res.status}`)
+            return res.json()
+          },
+        }),
+      { wrapper: Wrapper },
+    )
+
+    // Simulate ConnectionProvider marking the backend offline.
+    act(() => {
+      onlineManager.setOnline(false)
+    })
+
+    // Trigger the mutation while offline.
+    act(() => {
+      result.current.mutate({})
+    })
+
+    // With networkMode: 'always', the mutation should run immediately and
+    // end in isError (the fetch throws), NOT sit in isPaused.
+    await waitFor(
+      () => {
+        expect(result.current.isError).toBe(true)
+      },
+      { timeout: 3000 },
+    )
+
+    // Confirm it never entered isPaused.
+    expect(result.current.isPaused).toBe(false)
+  })
+
+  it('does not pause mutations while offline — networkMode always is set on makeQueryClient', () => {
+    // Structural assertion: verify that makeQueryClient bakes in the default
+    // rather than relying on call-site overrides.
+    const client = makeQueryClient()
+    const defaults = client.getDefaultOptions()
+    expect(defaults.mutations?.networkMode).toBe('always')
+  })
+})
+
+// Sanity: the existing query default (retry: 1) is still present.
+describe('makeQueryClient queries default', () => {
+  it('keeps retry: 1 for queries', () => {
+    const client = makeQueryClient()
+    const defaults = client.getDefaultOptions()
+    expect(defaults.queries?.retry).toBe(1)
+  })
+})

--- a/web/src/lib/query.test.tsx
+++ b/web/src/lib/query.test.tsx
@@ -11,20 +11,8 @@ import { renderHook, waitFor, act } from '@testing-library/react'
 import { describe, it, expect, afterEach } from 'vitest'
 import { http, HttpResponse } from 'msw'
 import { onlineManager, useMutation } from '@tanstack/react-query'
-import type { ReactNode } from 'react'
 import { server } from '../test/setup'
 import { makeQueryClient, QueryProvider } from './query'
-
-// Build a fresh wrapper for each test so state never leaks.
-function makeWrapper() {
-  const client = makeQueryClient()
-  // Speed up retry delay so tests don't stall.
-  client.setDefaultOptions({ mutations: { networkMode: 'always' } })
-  function Wrapper({ children }: { children: ReactNode }) {
-    return <QueryProvider client={client}>{children}</QueryProvider>
-  }
-  return { client, Wrapper }
-}
 
 afterEach(() => {
   // ConnectionProvider mirrors state into the module-global onlineManager;
@@ -56,13 +44,9 @@ describe('makeQueryClient mutations default', () => {
       { wrapper: Wrapper },
     )
 
-    // Simulate ConnectionProvider marking the backend offline.
+    // Simulate ConnectionProvider marking the backend offline and trigger the mutation.
     act(() => {
       onlineManager.setOnline(false)
-    })
-
-    // Trigger the mutation while offline.
-    act(() => {
       result.current.mutate({})
     })
 

--- a/web/src/lib/query.test.tsx
+++ b/web/src/lib/query.test.tsx
@@ -11,6 +11,7 @@ import { renderHook, waitFor, act } from '@testing-library/react'
 import { describe, it, expect, afterEach } from 'vitest'
 import { http, HttpResponse } from 'msw'
 import { onlineManager, useMutation } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
 import { server } from '../test/setup'
 import { makeQueryClient, QueryProvider } from './query'
 
@@ -47,7 +48,7 @@ describe('makeQueryClient mutations default', () => {
     // Simulate ConnectionProvider marking the backend offline and trigger the mutation.
     act(() => {
       onlineManager.setOnline(false)
-      result.current.mutate({})
+      result.current.mutate()
     })
 
     // With networkMode: 'always', the mutation should run immediately and

--- a/web/src/lib/query.tsx
+++ b/web/src/lib/query.tsx
@@ -6,6 +6,12 @@ export function makeQueryClient() {
       queries: {
         retry: 1,
       },
+      // Mutations must fail fast (not queue) while ConnectionProvider has
+      // flagged the backend offline via onlineManager — a purge or stop
+      // firing minutes later on recovery would be surprising.
+      mutations: {
+        networkMode: 'always',
+      },
     },
   })
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,6 +6,7 @@ import { applyPrefs } from './lib/prefs'
 import { router } from './router'
 import { QueryProvider } from './lib/query'
 import { RefreshProvider } from './lib/refresh'
+import { ConnectionProvider } from './lib/connection'
 import { initTelemetry } from './lib/telemetry'
 
 void initTelemetry()
@@ -15,7 +16,9 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryProvider>
       <RefreshProvider>
-        <RouterProvider router={router} future={{ v7_startTransition: true }} />
+        <ConnectionProvider>
+          <RouterProvider router={router} future={{ v7_startTransition: true }} />
+        </ConnectionProvider>
       </RefreshProvider>
     </QueryProvider>
   </StrictMode>,

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -205,6 +205,9 @@ table.t.click tbody tr:hover { background: var(--surface-2); }
 .beatbtn:focus-visible { outline: 2px solid var(--accent2); outline-offset: 2px; }
 .beatbtn .beat { width: 8px; height: 8px; border-radius: 50%; background: var(--accent-bright); animation: beat 2.4s ease-out infinite; }
 .beatbtn.off .beat { background: var(--muted); animation: none; box-shadow: none; }
+.beatbtn.offline .beat { background: var(--fail-fg); animation: beat-offline 2.4s ease-out infinite; }
+@keyframes beat-offline { 0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--fail-fg) 50%, transparent); } 70% { box-shadow: 0 0 0 7px transparent; } 100% { box-shadow: 0 0 0 0 transparent; } }
+.offline-label { color: var(--fail-fg); font-size: 12px; white-space: nowrap; }
 .select.compact { padding: 4px 26px 4px 8px; font-size: 12px; border-radius: 8px; background-position: right 8px center; }
 .search { display: flex; align-items: center; gap: 8px; background: var(--surface); border: 1px solid var(--line); border-radius: 9px; padding: 7px 11px; color: var(--faint); font-size: 13px; min-width: 170px; flex: 1; }
 .search input { flex: 1; background: transparent; border: none; outline: none; color: var(--text); font: inherit; font-size: 13px; }


### PR DESCRIPTION
## Summary

The frontend previously had no idea when the Go backend died: pages kept showing stale data, queries failed silently, and nothing explained why the UI stopped updating. This PR makes the web UI backend-connection-aware:

- **Detection** — a new `ConnectionProvider` (`web/src/lib/connection.tsx`) polls the existing `GET /api/health` endpoint at the global refresh interval, falling back to a fixed 30 s cadence when refresh is paused or Off so the indicator never goes stale. Two consecutive failed requests flip it offline (blip protection); the first success flips it back.
- **Polling pause** — the provider mirrors the state into TanStack Query's built-in `onlineManager`, so every existing data query pauses while the backend is unreachable and auto-refetches on recovery, with zero changes to the individual hooks. Mutations get `networkMode: 'always'` so a purge/start/stop clicked while offline fails fast through its normal error path instead of silently queueing and firing on recovery.
- **Indicator** — the beat dot in the TopNav refresh control doubles as the connection indicator: red pulsing dot + "Backend offline" label (theme `--fail-fg` token) when unreachable, taking precedence over the paused/off looks. Pause button and interval picker stay functional throughout.

The superseded fixed-interval `useHealth` hook was removed. Spec and implementation plan are included under `docs/superpowers/`.

## Test plan

- [x] 633 web tests passing (12 new: provider online/offline/recovery transitions incl. exact two-failure threshold, `healthPollMs` interval selection, offline indicator rendering/precedence/controls, mutation fail-fast behavior)
- [x] Production build clean (`tsc -b && vite build`)
- [x] Whole-branch review: approved (one Important finding — mutation queueing — found and fixed in-branch)
- [ ] Manual: run dashboard, kill the Go backend → red dot + "Backend offline" within ~2 poll cycles, only `/api/health` requests continue; restart backend → indicator clears, data refetches automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)