### PR TITLE
Surface workflow application errors in the detail view

### DIFF
--- a/docs/superpowers/plans/2026-07-08-workflow-application-errors.md
+++ b/docs/superpowers/plans/2026-07-08-workflow-application-errors.md
@@ -1,0 +1,588 @@
+# Workflow Application Errors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface application errors (exceptions thrown in Dapr workflow activities, sub-orchestrations, or the workflow itself) in the workflow detail page — as per-event error details in the event history list and a top-level failure banner.
+
+**Architecture:** The Go backend already reads durabletask history from the state store but discards failure details during decoding. We capture `TaskFailureDetails` (type, message, stack trace) onto each `HistoryEvent`, re-type a failed `ExecutionCompleted` as `ExecutionFailed`, and reuse the already-decoded workflow-level `FailureDetails`. The React frontend adds a red error box inside failed event rows and a dismissible-detail failure banner near the page header.
+
+**Tech Stack:** Go (durabletask-go protos, testify), React 19 + TypeScript, Vitest + Testing Library + MSW, plain CSS with theme tokens.
+
+## Global Constraints
+
+- Backend unit tests use the `//go:build unit` build tag and run with `-tags unit`.
+- New JSON fields use `omitempty` so existing golden output (`testdata/golden/execution_running.golden.json`, a no-failure run) stays byte-identical.
+- Vitest does NOT typecheck — after any `.ts`/`.tsx` change run `cd web && npx tsc -b` (or `npm run build`).
+- Reuse existing theme tokens (`--fail-fg`, `--fail-bg`, `--text`, `--surface-2`, `--line-soft`, `--muted`) — do not introduce new color values.
+- Follow existing patterns: copy buttons use `copyText(...)` + `toast.show(...)`; long code uses `<pre className="json">` (already `max-height: 23.25em; overflow: auto`).
+
+---
+
+### Task 1: Backend — capture failure details during decode
+
+**Files:**
+- Modify: `pkg/workflow/types.go` (add `StackTrace` to `FailureDetails`; add `FailureDetails` field to `HistoryEvent`)
+- Modify: `pkg/workflow/decode.go` (add `failureFromProto` helper; populate per-event and workflow-level)
+- Test: `pkg/workflow/decode_test.go` (new cases)
+
+**Interfaces:**
+- Consumes: `github.com/dapr/durabletask-go/api/protos` — `TaskFailureDetails{ErrorType string, ErrorMessage string, StackTrace *wrapperspb.StringValue}`; getters `GetFailureDetails()` on `TaskFailedEvent`, `ChildWorkflowInstanceFailedEvent`, `ExecutionCompletedEvent`; `runtimestate.FailureDetails(rs) (*protos.TaskFailureDetails, error)`.
+- Produces:
+  - `type FailureDetails struct { ErrorType, Message, StackTrace string }` (JSON: `errorType`, `message`, `stackTrace`, all `omitempty`)
+  - `HistoryEvent.FailureDetails *FailureDetails` (JSON: `failureDetails,omitempty`)
+  - `func failureFromProto(fd *protos.TaskFailureDetails) *FailureDetails`
+  - Event type `"ExecutionFailed"` emitted for a failed `ExecutionCompleted`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `pkg/workflow/decode_test.go` (the file already imports `protos`, `require`, `timestamppb`, `wrapperspb`):
+
+```go
+func TestDecodeTaskAndSubOrchFailureDetails(t *testing.T) {
+	now := timestamppb.Now()
+	history := []*protos.HistoryEvent{
+		{EventId: 0, Timestamp: now, EventType: &protos.HistoryEvent_ExecutionStarted{ExecutionStarted: &protos.ExecutionStartedEvent{Name: "W"}}},
+		{EventId: 1, Timestamp: now, EventType: &protos.HistoryEvent_TaskScheduled{TaskScheduled: &protos.TaskScheduledEvent{Name: "Charge"}}},
+		{EventId: 2, Timestamp: now, EventType: &protos.HistoryEvent_TaskFailed{TaskFailed: &protos.TaskFailedEvent{
+			TaskScheduledId: 1,
+			FailureDetails: &protos.TaskFailureDetails{
+				ErrorType:    "ChargeError",
+				ErrorMessage: "card declined",
+				StackTrace:   &wrapperspb.StringValue{Value: "at Charge()\n at Run()"},
+			},
+		}}},
+		{EventId: 3, Timestamp: now, EventType: &protos.HistoryEvent_ChildWorkflowInstanceFailed{ChildWorkflowInstanceFailed: &protos.ChildWorkflowInstanceFailedEvent{
+			TaskScheduledId: 1,
+			FailureDetails: &protos.TaskFailureDetails{
+				ErrorType:    "ChildError",
+				ErrorMessage: "child boom",
+			},
+		}}},
+	}
+	ex := DecodeExecution("order", "inst-tf", history, "")
+
+	byType := map[string]HistoryEvent{}
+	for _, e := range ex.History {
+		byType[e.Type] = e
+	}
+
+	tf := byType["TaskFailed"]
+	require.NotNil(t, tf.FailureDetails)
+	require.Equal(t, "ChargeError", tf.FailureDetails.ErrorType)
+	require.Equal(t, "card declined", tf.FailureDetails.Message)
+	require.Equal(t, "at Charge()\n at Run()", tf.FailureDetails.StackTrace)
+
+	sf := byType["SubOrchestrationFailed"]
+	require.NotNil(t, sf.FailureDetails)
+	require.Equal(t, "ChildError", sf.FailureDetails.ErrorType)
+	require.Equal(t, "child boom", sf.FailureDetails.Message)
+	require.Equal(t, "", sf.FailureDetails.StackTrace) // none provided
+}
+
+func TestDecodeExecutionFailed(t *testing.T) {
+	now := timestamppb.Now()
+	history := []*protos.HistoryEvent{
+		{EventId: 0, Timestamp: now, EventType: &protos.HistoryEvent_ExecutionStarted{ExecutionStarted: &protos.ExecutionStartedEvent{Name: "W"}}},
+		{EventId: 1, Timestamp: now, EventType: &protos.HistoryEvent_ExecutionCompleted{ExecutionCompleted: &protos.ExecutionCompletedEvent{
+			WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED,
+			FailureDetails: &protos.TaskFailureDetails{
+				ErrorType:    "System.InvalidOperationException",
+				ErrorMessage: "boom",
+				StackTrace:   &wrapperspb.StringValue{Value: "at Foo()\n at Bar()"},
+			},
+		}}},
+	}
+	ex := DecodeExecution("order", "inst-f", history, "")
+
+	require.Equal(t, StatusFailed, ex.Status)
+
+	// Workflow-level failure details populated, incl. stack trace.
+	require.NotNil(t, ex.FailureDetails)
+	require.Equal(t, "System.InvalidOperationException", ex.FailureDetails.ErrorType)
+	require.Equal(t, "boom", ex.FailureDetails.Message)
+	require.Equal(t, "at Foo()\n at Bar()", ex.FailureDetails.StackTrace)
+
+	// Terminal event re-typed to ExecutionFailed with its own failure details.
+	last := ex.History[len(ex.History)-1]
+	require.Equal(t, "ExecutionFailed", last.Type)
+	require.NotNil(t, last.FailureDetails)
+	require.Equal(t, "boom", last.FailureDetails.Message)
+	require.Nil(t, last.Output)
+}
+
+func TestDecodeExecutionCompletedNoFailure(t *testing.T) {
+	now := timestamppb.Now()
+	history := []*protos.HistoryEvent{
+		{EventId: 0, Timestamp: now, EventType: &protos.HistoryEvent_ExecutionStarted{ExecutionStarted: &protos.ExecutionStartedEvent{Name: "W"}}},
+		{EventId: 1, Timestamp: now, EventType: &protos.HistoryEvent_ExecutionCompleted{ExecutionCompleted: &protos.ExecutionCompletedEvent{
+			WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED,
+			Result:         &wrapperspb.StringValue{Value: `"done"`},
+		}}},
+	}
+	ex := DecodeExecution("order", "inst-ok", history, "")
+	last := ex.History[len(ex.History)-1]
+	require.Equal(t, "ExecutionCompleted", last.Type)
+	require.Nil(t, last.FailureDetails)
+	require.NotNil(t, last.Output)
+	require.Equal(t, `"done"`, *last.Output)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit ./pkg/workflow/ -run 'TestDecodeTaskAndSubOrchFailureDetails|TestDecodeExecutionFailed|TestDecodeExecutionCompletedNoFailure' -v`
+Expected: compile error — `FailureDetails` field on `HistoryEvent` and `StackTrace` field on `FailureDetails` do not exist yet.
+
+- [ ] **Step 3: Extend the types**
+
+In `pkg/workflow/types.go`, replace the `FailureDetails` struct:
+
+```go
+type FailureDetails struct {
+	ErrorType  string `json:"errorType,omitempty"`
+	Message    string `json:"message,omitempty"`
+	StackTrace string `json:"stackTrace,omitempty"`
+}
+```
+
+And add a field to `HistoryEvent` (after `Output`):
+
+```go
+type HistoryEvent struct {
+	SequenceID     int32           `json:"sequenceId"`
+	Timestamp      time.Time       `json:"timestamp"`
+	Type           string          `json:"type"`
+	Name           string          `json:"name,omitempty"`
+	InstanceID     string          `json:"instanceId,omitempty"`  // child instance id for SubOrchestrationCreated
+	ScheduledID    *int32          `json:"scheduledId,omitempty"` // start event's EventId; set on completion/fired events
+	Input          *string         `json:"input,omitempty"`
+	Output         *string         `json:"output,omitempty"`
+	FailureDetails *FailureDetails `json:"failureDetails,omitempty"` // set on TaskFailed / SubOrchestrationFailed / ExecutionFailed
+}
+```
+
+- [ ] **Step 4: Add the helper and wire it into decode**
+
+In `pkg/workflow/decode.go`, add the helper near `strval` / `i32ptr` at the bottom:
+
+```go
+func failureFromProto(fd *protos.TaskFailureDetails) *FailureDetails {
+	if fd == nil {
+		return nil
+	}
+	return &FailureDetails{
+		ErrorType:  fd.GetErrorType(),
+		Message:    fd.GetErrorMessage(),
+		StackTrace: fd.GetStackTrace().GetValue(),
+	}
+}
+```
+
+Replace the workflow-level block in `DecodeExecution` (currently lines 42-44):
+
+```go
+	if fd, err := runtimestate.FailureDetails(rs); err == nil && fd != nil {
+		ex.FailureDetails = failureFromProto(fd)
+	}
+```
+
+In `decodeEvent`, replace the `ExecutionCompleted`, `TaskFailed`, and `ChildWorkflowInstanceFailed` cases:
+
+```go
+	case e.GetExecutionCompleted() != nil:
+		c := e.GetExecutionCompleted()
+		if fd := c.GetFailureDetails(); fd != nil {
+			ev.Type = "ExecutionFailed"
+			ev.FailureDetails = failureFromProto(fd)
+		} else {
+			ev.Type = "ExecutionCompleted"
+			ev.Output = strval(c.GetResult())
+		}
+```
+
+```go
+	case e.GetTaskFailed() != nil:
+		ev.Type = "TaskFailed"
+		f := e.GetTaskFailed()
+		ev.ScheduledID = i32ptr(f.GetTaskScheduledId())
+		ev.FailureDetails = failureFromProto(f.GetFailureDetails())
+```
+
+```go
+	case e.GetChildWorkflowInstanceFailed() != nil:
+		ev.Type = "SubOrchestrationFailed"
+		f := e.GetChildWorkflowInstanceFailed()
+		ev.ScheduledID = i32ptr(f.GetTaskScheduledId())
+		ev.FailureDetails = failureFromProto(f.GetFailureDetails())
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test -tags unit ./pkg/workflow/ -run 'TestDecodeTaskAndSubOrchFailureDetails|TestDecodeExecutionFailed|TestDecodeExecutionCompletedNoFailure' -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Run the full package suite (guard the golden test)**
+
+Run: `go test -tags unit ./pkg/workflow/... && go test -tags integration ./pkg/workflow/ -run Golden`
+Expected: PASS. The golden run has no failures, so `omitempty` keeps its output unchanged. (If the integration build tag needs the sqlite deps and fails to build in your environment, run at least the unit suite and note it.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/workflow/types.go pkg/workflow/decode.go pkg/workflow/decode_test.go
+git commit -m "feat(workflow): decode activity/workflow failure details"
+```
+
+---
+
+### Task 2: Frontend — failure types + per-event error box
+
+**Files:**
+- Modify: `web/src/types/workflow.ts` (add `WorkflowFailureDetails`; wire into event + execution)
+- Modify: `web/src/pages/WorkflowDetail.tsx` (`EventRow`: treat failure as details, render error box)
+- Modify: `web/src/styles/theme.css` (`.evfail*` classes)
+- Test: `web/src/pages/WorkflowDetail.test.tsx` (`EventRow` cases)
+
+**Interfaces:**
+- Consumes: `FailureDetails` JSON shape from Task 1 (`errorType`, `message`, `stackTrace`); existing `copyText`, `toast.show`, `.evbody`/`.lblrow`/`.lbl`/`.copybtn`/`.json` styles.
+- Produces:
+  - `export interface WorkflowFailureDetails { errorType?: string; message?: string; stackTrace?: string }`
+  - `WorkflowHistoryEvent.failureDetails?: WorkflowFailureDetails`
+  - `WorkflowExecution.failureDetails?: WorkflowFailureDetails`
+  - CSS classes `.evfail`, `.evfail-type`, `.evfail-msg` (consumed by Task 3 banner styling context only for tokens).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `describe('EventRow', ...)` block in `web/src/pages/WorkflowDetail.test.tsx`:
+
+```tsx
+it('renders a red error box (type + message + copyable stack trace) for a failed event', async () => {
+  const { container } = row({
+    type: 'TaskFailed',
+    sequenceId: 4,
+    timestamp: '2026-06-28T10:00:02.000Z',
+    failureDetails: {
+      errorType: 'ChargeError',
+      message: 'card declined',
+      stackTrace: 'at Charge()\n at Run()',
+    },
+  })
+  // Row is expandable (was a bare static row before).
+  expect(container.querySelector('details')).not.toBeNull()
+  expect(container.querySelector('.evfail')).not.toBeNull()
+  expect(screen.getByText('ChargeError')).toBeInTheDocument()
+  expect(screen.getByText('card declined')).toBeInTheDocument()
+  expect(screen.getByText(/at Charge\(\)/)).toBeInTheDocument()
+  expect(screen.getByText('Stack trace')).toBeInTheDocument()
+})
+
+it('omits the stack-trace section when a failed event has no stack trace', () => {
+  const { container } = row({
+    type: 'SubOrchestrationFailed',
+    sequenceId: 5,
+    timestamp: '2026-06-28T10:00:03.000Z',
+    failureDetails: { errorType: 'ChildError', message: 'child boom' },
+  })
+  expect(container.querySelector('.evfail')).not.toBeNull()
+  expect(screen.getByText('child boom')).toBeInTheDocument()
+  expect(screen.queryByText('Stack trace')).toBeNull()
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd web && npx vitest run src/pages/WorkflowDetail.test.tsx -t 'error box|omits the stack-trace'`
+Expected: FAIL — no `.evfail` element; the `TaskFailed` row is static (no `details`), so `container.querySelector('details')` is null and the error text is absent.
+
+- [ ] **Step 3: Add the types**
+
+In `web/src/types/workflow.ts`, add the interface (above `WorkflowHistoryEvent`):
+
+```ts
+export interface WorkflowFailureDetails {
+  errorType?: string
+  message?: string
+  stackTrace?: string
+}
+```
+
+Add the field to `WorkflowHistoryEvent` (after `output`):
+
+```ts
+  output?: string
+  failureDetails?: WorkflowFailureDetails
+```
+
+Replace the inline `failureDetails` on `WorkflowExecution`:
+
+```ts
+  failureDetails?: WorkflowFailureDetails
+```
+
+- [ ] **Step 4: Render the error box in `EventRow`**
+
+In `web/src/pages/WorkflowDetail.tsx`:
+
+Import the new type — change the existing type import:
+
+```tsx
+import type { WorkflowStatus, WorkflowHistoryEvent, WorkflowFailureDetails } from '../types/workflow'
+```
+
+In `EventRow`, replace the `hasDetails` line (currently line 156):
+
+```tsx
+  const failure = event.failureDetails
+  const hasDetails = !!(event.input || event.output || failure)
+```
+
+Inside the expandable `<div className="evbody">` (before the `event.input` block, currently line 201), add the error box:
+
+```tsx
+              {failure && (
+                <div className="evfail">
+                  <span className="evfail-type">{failure.errorType || 'Error'}</span>
+                  {failure.message && <div className="evfail-msg">{failure.message}</div>}
+                  {failure.stackTrace && (
+                    <div>
+                      <div className="lblrow">
+                        <span className="lbl">Stack trace</span>
+                        <button
+                          className="copybtn"
+                          onClick={() => {
+                            copyText(failure.stackTrace ?? '')
+                            toast.show('Stack trace copied')
+                          }}
+                        >
+                          ⧉ Copy
+                        </button>
+                      </div>
+                      <pre className="json">{failure.stackTrace}</pre>
+                    </div>
+                  )}
+                </div>
+              )}
+```
+
+- [ ] **Step 5: Add the CSS**
+
+In `web/src/styles/theme.css`, after the `.evbody .lblrow .copybtn` rule (around line 446), add:
+
+```css
+.evbody .evfail { display: grid; gap: 6px; padding: 9px 11px; border-radius: 8px; border: 1px solid color-mix(in srgb, var(--fail-fg) 35%, transparent); background: color-mix(in srgb, var(--fail-fg) 10%, transparent); }
+.evfail-type { font-family: var(--mono); font-size: 11.5px; font-weight: 600; color: var(--fail-fg); }
+.evfail-msg { font-size: 12.5px; color: var(--text); white-space: pre-wrap; word-break: break-word; }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd web && npx vitest run src/pages/WorkflowDetail.test.tsx -t 'error box|omits the stack-trace'`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Typecheck**
+
+Run: `cd web && npx tsc -b`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/types/workflow.ts web/src/pages/WorkflowDetail.tsx web/src/styles/theme.css web/src/pages/WorkflowDetail.test.tsx
+git commit -m "feat(web): show per-event failure details in workflow history"
+```
+
+---
+
+### Task 3: Frontend — top-level failure banner
+
+**Files:**
+- Modify: `web/src/pages/WorkflowDetail.tsx` (add `FailureBanner` component; render below `dhead`)
+- Modify: `web/src/styles/theme.css` (`.failbanner*` classes)
+- Test: `web/src/pages/WorkflowDetail.test.tsx` (banner cases via full-page render)
+
+**Interfaces:**
+- Consumes: `WorkflowExecution.failureDetails` (Task 2 type); `WorkflowFailureDetails`; existing `.tbtn`, `.lblrow`, `.lbl`, `.copybtn`, `.json` styles; `useState` (already imported), `copyText`, `ToastHandle`.
+- Produces: `FailureBanner` (internal component, not exported); DOM class `.failbanner` with a "Show stack trace" / "Hide stack trace" toggle button.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new `describe` block near the end of `web/src/pages/WorkflowDetail.test.tsx` (it already imports `renderDetail`, `server`, `http`, `HttpResponse`, `screen`, `waitFor`, `userEvent`):
+
+```tsx
+describe('WorkflowDetail — failure banner', () => {
+  beforeEach(() => {
+    server.use(http.get('/api/apps', () => HttpResponse.json([{ appId: 'order', health: 'healthy' }])))
+  })
+
+  it('shows a failure banner with type + message, stack trace hidden until toggled', async () => {
+    server.use(
+      http.get('/api/workflows/order/abc', () =>
+        HttpResponse.json({
+          appId: 'order',
+          instanceId: 'abc',
+          name: 'OrderWorkflow',
+          status: 'Failed',
+          createdAt: '2026-06-26T10:00:00Z',
+          lastUpdatedAt: '2026-06-26T10:00:05Z',
+          replayCount: 0,
+          failureDetails: {
+            errorType: 'System.InvalidOperationException',
+            message: 'boom',
+            stackTrace: 'at Foo()\n at Bar()',
+          },
+          history: [
+            { sequenceId: 0, timestamp: '2026-06-26T10:00:00Z', type: 'ExecutionStarted', name: 'OrderWorkflow' },
+            { sequenceId: 1, timestamp: '2026-06-26T10:00:05Z', type: 'ExecutionFailed', failureDetails: { errorType: 'System.InvalidOperationException', message: 'boom', stackTrace: 'at Foo()\n at Bar()' } },
+          ],
+        }),
+      ),
+    )
+    renderDetail()
+    const banner = await screen.findByRole('alert')
+    expect(banner).toHaveTextContent('System.InvalidOperationException')
+    expect(banner).toHaveTextContent('boom')
+    // Stack trace hidden initially.
+    expect(screen.queryByText(/at Foo\(\)/)).toBeNull()
+    await userEvent.click(screen.getByRole('button', { name: /show stack trace/i }))
+    expect(screen.getByText(/at Foo\(\)/)).toBeInTheDocument()
+  })
+
+  it('shows no failure banner for a completed workflow', async () => {
+    server.use(
+      http.get('/api/workflows/order/abc', () =>
+        HttpResponse.json({
+          appId: 'order',
+          instanceId: 'abc',
+          name: 'OrderWorkflow',
+          status: 'Completed',
+          createdAt: '2026-06-26T10:00:00Z',
+          lastUpdatedAt: '2026-06-26T10:00:05Z',
+          replayCount: 0,
+          history: [
+            { sequenceId: 0, timestamp: '2026-06-26T10:00:00Z', type: 'ExecutionStarted', name: 'OrderWorkflow' },
+          ],
+        }),
+      ),
+    )
+    renderDetail()
+    await waitFor(() => expect(screen.getByText('COMPLETED')).toBeInTheDocument())
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd web && npx vitest run src/pages/WorkflowDetail.test.tsx -t 'failure banner'`
+Expected: FAIL — no element with `role="alert"` is rendered.
+
+- [ ] **Step 3: Add the `FailureBanner` component**
+
+In `web/src/pages/WorkflowDetail.tsx`, add this component just above `export function WorkflowDetail()` (after the `EventRow` definition):
+
+```tsx
+function FailureBanner({ failure, toast }: { failure: WorkflowFailureDetails; toast: ToastHandle }) {
+  const [showStack, setShowStack] = useState(false)
+  return (
+    <div className="failbanner" role="alert">
+      <div className="failbanner-head">
+        <span className="failbanner-icon" aria-hidden="true">⚠</span>
+        <span className="failbanner-type">{failure.errorType || 'Workflow failed'}</span>
+        {failure.stackTrace && (
+          <button className="tbtn" onClick={() => setShowStack((s) => !s)}>
+            {showStack ? 'Hide stack trace' : 'Show stack trace'}
+          </button>
+        )}
+      </div>
+      {failure.message && <div className="failbanner-msg">{failure.message}</div>}
+      {failure.stackTrace && showStack && (
+        <div>
+          <div className="lblrow">
+            <span className="lbl">Stack trace</span>
+            <button
+              className="copybtn"
+              onClick={() => {
+                copyText(failure.stackTrace ?? '')
+                toast.show('Stack trace copied')
+              }}
+            >
+              ⧉ Copy
+            </button>
+          </div>
+          <pre className="json">{failure.stackTrace}</pre>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Render the banner below the page header**
+
+In `WorkflowDetail`'s returned JSX, immediately after the closing `</div>` of the `dhead` block (the page header — currently line 517, right before the `{/* Meta grid */}` comment), add:
+
+```tsx
+      {execution.failureDetails && (
+        <FailureBanner failure={execution.failureDetails} toast={toast} />
+      )}
+```
+
+- [ ] **Step 5: Add the CSS**
+
+In `web/src/styles/theme.css`, after the `.evfail-msg` rule added in Task 2, add:
+
+```css
+.failbanner { display: grid; gap: 8px; padding: 12px 14px; margin-bottom: 18px; border-radius: 10px; border: 1px solid color-mix(in srgb, var(--fail-fg) 40%, transparent); background: var(--fail-bg); }
+.failbanner-head { display: flex; align-items: center; gap: 9px; }
+.failbanner-icon { color: var(--fail-fg); }
+.failbanner-type { font-family: var(--mono); font-size: 13px; font-weight: 600; color: var(--fail-fg); }
+.failbanner-head .tbtn { margin-left: auto; }
+.failbanner-msg { font-size: 13px; color: var(--text); white-space: pre-wrap; word-break: break-word; }
+.failbanner .lblrow { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd web && npx vitest run src/pages/WorkflowDetail.test.tsx -t 'failure banner'`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Full frontend suite + typecheck**
+
+Run: `cd web && npx tsc -b && npx vitest run src/pages/WorkflowDetail.test.tsx`
+Expected: no type errors; all `WorkflowDetail`/`EventRow` tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/pages/WorkflowDetail.tsx web/src/styles/theme.css web/src/pages/WorkflowDetail.test.tsx
+git commit -m "feat(web): add workflow failure banner to detail page"
+```
+
+---
+
+### Task 4: End-to-end verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full build + tests**
+
+Run: `make build && make test`
+Expected: web build (`tsc -b && vite build`) succeeds; `test-go` (unit) and `test-web` pass.
+
+- [ ] **Step 2: Manual smoke check (optional but recommended)**
+
+Use the `run` skill (or `make build && ./bin/dev-dashboard`) to launch the dashboard against a store containing a failed workflow instance, and confirm on the workflow detail page:
+- the red failure banner appears below the header with error type + message and a working "Show stack trace" toggle + copy button;
+- a `TaskFailed` / `SubOrchestrationFailed` row is expandable and shows the red error box with type, message, and (when present) a copyable stack trace;
+- a failed run's terminal event renders as `ExecutionFailed` with the `n-endfail` node dot;
+- completed / running workflows show no banner and no error boxes (regression check).
+
+If no failed instance is readily available, note that automated tests (Tasks 1–3) cover the behavior and state that the manual check was skipped.
+
+---
+
+## Notes on existing code that already supports this
+
+- `nodeClass` in `WorkflowDetail.tsx` already maps `TaskFailed`/`SubOrchestrationFailed` → `n-fail` (via `endsWith('Failed') && !startsWith('Execution')`) and `ExecutionFailed` → `n-endfail`. **No change needed.**
+- `lib/eventOrder.ts` already lists `ExecutionFailed` in `TERMINAL_EXEC_TYPES`, so a re-typed terminal event pins to the bottom (asc) correctly. **No change needed.**
+- `.n-fail` / `.n-endfail` node-dot CSS already exists in `theme.css`. **No change needed.**

--- a/docs/superpowers/specs/2026-07-08-workflow-application-errors-design.md
+++ b/docs/superpowers/specs/2026-07-08-workflow-application-errors-design.md
@@ -1,0 +1,237 @@
+# Surface workflow application errors in the detail view — design
+
+Date: 2026-07-08
+Status: approved
+
+## Problem
+
+When an exception is thrown inside a Dapr workflow activity, a
+sub-orchestration, or the workflow (orchestrator) itself, the failure never
+surfaces in the workflow detail page's event history. The event list shows a
+bare `TaskFailed` / `SubOrchestrationFailed` row with just the type name — no
+error message, no type, no stack trace — and a failed workflow shows no
+explanation at all beyond the `Failed` status pill.
+
+The data is available but discarded:
+
+- **Per-event failure details are dropped at decode time.** In
+  `pkg/workflow/decode.go`, `decodeEvent` handles `TaskFailed`,
+  `ChildWorkflowInstanceFailed` (→ `SubOrchestrationFailed`), and
+  `ExecutionCompleted` but never reads their `GetFailureDetails()`. The Go
+  `HistoryEvent` struct (`pkg/workflow/types.go`) has no failure field, and
+  neither does the TS `WorkflowHistoryEvent` (`web/src/types/workflow.ts`).
+- **Workflow-level failure is decoded but never rendered.**
+  `DecodeExecution` already populates `ex.FailureDetails` (errorType +
+  message) via `runtimestate.FailureDetails`, and the API returns it, but a
+  repo-wide search shows `execution.failureDetails` is never read in the UI.
+- **Dead frontend code anticipates the fix.** `nodeClass` in
+  `WorkflowDetail.tsx` already maps `n-fail` / `n-endfail`, and
+  `lib/eventOrder.ts` lists an `ExecutionFailed` type in `TERMINAL_EXEC_TYPES`
+  — but the backend never emits `ExecutionFailed`, so those paths are unused.
+
+The underlying durabletask proto
+(`github.com/dapr/durabletask-go/api/protos`) exposes everything needed:
+`TaskFailedEvent.GetFailureDetails()`,
+`ChildWorkflowInstanceFailedEvent.GetFailureDetails()`, and
+`ExecutionCompletedEvent.GetFailureDetails()`, each returning a
+`*TaskFailureDetails` with `GetErrorType()`, `GetErrorMessage()`,
+`GetStackTrace() *StringValue`, `GetInnerFailure()`, and `GetIsNonRetriable()`.
+
+## Prior art (old dashboard)
+
+The old dashboard (`cloudgrid/tools/diagrid-dashboard`) JSON-marshalled
+`TaskFailed.FailureDetails` into the event's `Output` field and colored failed
+rows red by matching the event type. It also had an intended dedicated red
+"Failure Details" box (message + stack trace), but that box keyed off fields
+the real backend never emitted, so in practice the error only appeared as an
+Output JSON blob. We take the structured approach the old UI intended but
+never actually wired up.
+
+## Decisions (from brainstorming)
+
+- **Detail shown:** error **type + message + stack trace**. Stack traces can
+  be long, so they are visually contained (scrollable / collapsed).
+- **Surface in two places:** a **top-level failure banner** on the workflow
+  detail page (driven by the already-fetched `execution.failureDetails`) **and**
+  **per-event error details** in the event history list.
+- **Failed workflow event type:** the backend will emit `ExecutionFailed`
+  (instead of `ExecutionCompleted`) when the completion event carries failure
+  details. This lights up the existing `n-endfail` node styling and
+  `TERMINAL_EXEC_TYPES` ordering code.
+- **Structured field, not marshalled-into-Output** — reject the old
+  dashboard's approach; carry failure details as a dedicated typed object so
+  the UI can style it distinctly.
+
+## Design
+
+### 1. Backend types (`pkg/workflow/types.go`)
+
+Extend the existing `FailureDetails` struct with a stack trace (it is already
+used for the workflow-level failure, so extending it serves both the banner
+and per-event rendering):
+
+```go
+type FailureDetails struct {
+	ErrorType  string `json:"errorType,omitempty"`
+	Message    string `json:"message,omitempty"`
+	StackTrace string `json:"stackTrace,omitempty"`
+}
+```
+
+Add a failure field to `HistoryEvent`:
+
+```go
+type HistoryEvent struct {
+	// ...existing fields...
+	FailureDetails *FailureDetails `json:"failureDetails,omitempty"`
+}
+```
+
+`IsNonRetriable` is intentionally omitted (YAGNI) — it can be added later if a
+concrete need appears.
+
+### 2. Backend decode (`pkg/workflow/decode.go`)
+
+Add a helper that maps the proto failure details onto our struct:
+
+```go
+func failureFromProto(fd *protos.TaskFailureDetails) *FailureDetails {
+	if fd == nil {
+		return nil
+	}
+	return &FailureDetails{
+		ErrorType:  fd.GetErrorType(),
+		Message:    fd.GetErrorMessage(),
+		StackTrace: fd.GetStackTrace().GetValue(),
+	}
+}
+```
+
+Wire it into `decodeEvent`:
+
+- `TaskFailed`:
+  `ev.FailureDetails = failureFromProto(e.GetTaskFailed().GetFailureDetails())`
+- `SubOrchestrationFailed`:
+  `ev.FailureDetails = failureFromProto(e.GetChildWorkflowInstanceFailed().GetFailureDetails())`
+- `ExecutionCompleted`: if
+  `e.GetExecutionCompleted().GetFailureDetails() != nil`, set
+  `ev.Type = "ExecutionFailed"` and attach the failure; otherwise keep
+  `ExecutionCompleted` and the existing `Output` result.
+
+Also ensure the workflow-level `ex.FailureDetails` carries the stack trace.
+`runtimestate.FailureDetails(rs)` returns the same `*TaskFailureDetails`, so
+reuse `failureFromProto` in `DecodeExecution` instead of the current
+inline two-field construction.
+
+### 3. Frontend types (`web/src/types/workflow.ts`)
+
+```ts
+export interface WorkflowFailureDetails {
+  errorType?: string
+  message?: string
+  stackTrace?: string
+}
+
+export interface WorkflowHistoryEvent {
+  // ...existing fields...
+  failureDetails?: WorkflowFailureDetails
+}
+
+export interface WorkflowExecution extends WorkflowSummary {
+  // ...
+  failureDetails?: WorkflowFailureDetails // was inline { errorType?; message? }
+  // ...
+}
+```
+
+### 4. Frontend event row (`EventRow` in `web/src/pages/WorkflowDetail.tsx`)
+
+- Treat a present `event.failureDetails` as "has details" so failed events
+  become expandable (today, with no input/output, they render as bare static
+  rows): `const hasDetails = !!(event.input || event.output || event.failureDetails)`.
+- Add an **error branch** in the expandable body, rendered **above** Input /
+  Output when present:
+  - A red-tinted, red-bordered box showing the **error type** (as a heading /
+    label) and the **error message**.
+  - The **stack trace** in a scrollable `<pre>` (contained height), with a
+    **copy button** matching the existing Input/Output copy pattern. Omitted
+    entirely when there is no stack trace.
+- **Node dot styling:** ensure `nodeClass` returns `n-fail` for `TaskFailed` /
+  `SubOrchestrationFailed` and `n-endfail` for `ExecutionFailed` (classes
+  already exist in CSS; verify the mapping covers the actual emitted type
+  strings).
+
+### 5. Frontend page banner (`WorkflowDetail`)
+
+When `execution.failureDetails` is present, render an **error banner** near the
+top of the detail page (below the header / status pill):
+
+- Red-tinted banner with the error type + message always visible.
+- Stack trace behind a **"Show stack trace"** toggle (collapsed by default) so
+  it does not dominate the page. Omitted when there is no stack trace.
+
+### 6. Styling
+
+Reuse existing failure CSS affordances (`n-fail`, `n-endfail`) and the app's
+error color tokens. The error box and banner share a consistent red-tinted,
+red-bordered treatment. No new color tokens unless the existing palette lacks
+an error tint.
+
+## Error handling / edge cases
+
+- **Activity fails with no stack trace:** the stack-trace section is omitted;
+  type + message still render.
+- **Workflow fails without a failed activity event** (e.g. orchestrator throws
+  directly): the top-level banner still shows from `execution.failureDetails`,
+  and the terminal event is `ExecutionFailed` with its own failure details.
+- **Message-only failure:** renders type (if any) + message; no stack trace box.
+- **Non-failed events:** unchanged — no failure field, no error branch.
+
+## Testing
+
+### Backend (`pkg/workflow`)
+
+- Decode tests asserting `failureDetails` (type, message, stack trace) is
+  populated for:
+  - a `TaskFailed` event,
+  - a `SubOrchestrationFailed` (`ChildWorkflowInstanceFailed`) event,
+  - an `ExecutionCompleted` carrying failure details → decoded as
+    `ExecutionFailed` with failure details, and the workflow-level
+    `execution.failureDetails` populated including stack trace.
+- A non-failing `ExecutionCompleted` still decodes as `ExecutionCompleted`
+  with its `Output` result and no `failureDetails`.
+- Fixtures can be adapted from the old dashboard's
+  `pkg/workflow/history/history_test.go`.
+
+### Frontend (`web`)
+
+- `EventRow`: renders the red error box (type + message) and a stack-trace
+  `<pre>` with copy button for an event carrying `failureDetails`; the row is
+  expandable.
+- `EventRow`: an event with `failureDetails` but no stack trace omits the
+  stack-trace section.
+- Banner: appears with type + message when `execution.failureDetails` is set,
+  and the stack trace is toggled behind "Show stack trace".
+
+### Build / typecheck
+
+Run `make build` (or `tsc -b`) after frontend type changes — vitest alone does
+not typecheck.
+
+## Files touched
+
+- `pkg/workflow/types.go` — extend `FailureDetails`, add field to `HistoryEvent`
+- `pkg/workflow/decode.go` — `failureFromProto` helper; populate per-event and
+  reuse for workflow-level
+- `pkg/workflow/decode_test.go` (or existing decode test file) — new cases
+- `web/src/types/workflow.ts` — `WorkflowFailureDetails`, event + execution fields
+- `web/src/pages/WorkflowDetail.tsx` — `EventRow` error branch, banner, node class
+- `web/src/pages/WorkflowDetail.css` (or the relevant stylesheet) — error box /
+  banner styling if not already covered
+- Frontend test file for `WorkflowDetail` / `EventRow`
+
+## Non-goals
+
+- Rendering `innerFailure` chains (nested exception causes).
+- Surfacing `isNonRetriable` / retry-attempt metadata.
+- Any change to how errors are stored or emitted by the Dapr runtime.

--- a/pkg/workflow/decode.go
+++ b/pkg/workflow/decode.go
@@ -84,6 +84,9 @@ func decodeEvent(e *protos.HistoryEvent) HistoryEvent {
 		ev.Input = strval(s.GetInput())
 	case e.GetExecutionCompleted() != nil:
 		c := e.GetExecutionCompleted()
+		// A failed run surfaces as an ExecutionCompleted event carrying
+		// FailureDetails (durabletask has no separate ExecutionFailed event); we
+		// key the re-type off its presence, which mirrors the workflow-level status.
 		if fd := c.GetFailureDetails(); fd != nil {
 			ev.Type = "ExecutionFailed"
 			ev.FailureDetails = failureFromProto(fd)

--- a/pkg/workflow/decode.go
+++ b/pkg/workflow/decode.go
@@ -40,7 +40,7 @@ func DecodeExecution(appID, instanceID string, history []*protos.HistoryEvent, c
 		ex.Output = &v
 	}
 	if fd, err := runtimestate.FailureDetails(rs); err == nil && fd != nil {
-		ex.FailureDetails = &FailureDetails{ErrorType: fd.GetErrorType(), Message: fd.GetErrorMessage()}
+		ex.FailureDetails = failureFromProto(fd)
 	}
 	if status.IsTerminal() {
 		if upd, err := runtimestate.LastUpdatedTime(rs); err == nil && !upd.IsZero() {
@@ -83,8 +83,14 @@ func decodeEvent(e *protos.HistoryEvent) HistoryEvent {
 		ev.Name = s.GetName()
 		ev.Input = strval(s.GetInput())
 	case e.GetExecutionCompleted() != nil:
-		ev.Type = "ExecutionCompleted"
-		ev.Output = strval(e.GetExecutionCompleted().GetResult())
+		c := e.GetExecutionCompleted()
+		if fd := c.GetFailureDetails(); fd != nil {
+			ev.Type = "ExecutionFailed"
+			ev.FailureDetails = failureFromProto(fd)
+		} else {
+			ev.Type = "ExecutionCompleted"
+			ev.Output = strval(c.GetResult())
+		}
 	case e.GetExecutionTerminated() != nil:
 		ev.Type = "ExecutionTerminated"
 		ev.Output = strval(e.GetExecutionTerminated().GetInput())
@@ -104,7 +110,9 @@ func decodeEvent(e *protos.HistoryEvent) HistoryEvent {
 		ev.ScheduledID = i32ptr(c.GetTaskScheduledId())
 	case e.GetTaskFailed() != nil:
 		ev.Type = "TaskFailed"
-		ev.ScheduledID = i32ptr(e.GetTaskFailed().GetTaskScheduledId())
+		f := e.GetTaskFailed()
+		ev.ScheduledID = i32ptr(f.GetTaskScheduledId())
+		ev.FailureDetails = failureFromProto(f.GetFailureDetails())
 	case e.GetTimerCreated() != nil:
 		ev.Type = "TimerCreated"
 	case e.GetTimerFired() != nil:
@@ -136,7 +144,9 @@ func decodeEvent(e *protos.HistoryEvent) HistoryEvent {
 		ev.ScheduledID = i32ptr(c.GetTaskScheduledId())
 	case e.GetChildWorkflowInstanceFailed() != nil:
 		ev.Type = "SubOrchestrationFailed"
-		ev.ScheduledID = i32ptr(e.GetChildWorkflowInstanceFailed().GetTaskScheduledId())
+		f := e.GetChildWorkflowInstanceFailed()
+		ev.ScheduledID = i32ptr(f.GetTaskScheduledId())
+		ev.FailureDetails = failureFromProto(f.GetFailureDetails())
 	default:
 		ev.Type = "Unknown"
 	}
@@ -152,3 +162,14 @@ func strval(v *wrapperspb.StringValue) *string {
 }
 
 func i32ptr(v int32) *int32 { return &v }
+
+func failureFromProto(fd *protos.TaskFailureDetails) *FailureDetails {
+	if fd == nil {
+		return nil
+	}
+	return &FailureDetails{
+		ErrorType:  fd.GetErrorType(),
+		Message:    fd.GetErrorMessage(),
+		StackTrace: fd.GetStackTrace().GetValue(),
+	}
+}

--- a/pkg/workflow/decode_test.go
+++ b/pkg/workflow/decode_test.go
@@ -144,3 +144,92 @@ func TestDecodeSubOrchestrationCreated(t *testing.T) {
 	require.Equal(t, "ChildWorkflow", ex.History[1].Name)
 	require.Equal(t, "child-inst-9", ex.History[1].InstanceID)
 }
+
+func TestDecodeTaskAndSubOrchFailureDetails(t *testing.T) {
+	now := timestamppb.Now()
+	history := []*protos.HistoryEvent{
+		{EventId: 0, Timestamp: now, EventType: &protos.HistoryEvent_ExecutionStarted{ExecutionStarted: &protos.ExecutionStartedEvent{Name: "W"}}},
+		{EventId: 1, Timestamp: now, EventType: &protos.HistoryEvent_TaskScheduled{TaskScheduled: &protos.TaskScheduledEvent{Name: "Charge"}}},
+		{EventId: 2, Timestamp: now, EventType: &protos.HistoryEvent_TaskFailed{TaskFailed: &protos.TaskFailedEvent{
+			TaskScheduledId: 1,
+			FailureDetails: &protos.TaskFailureDetails{
+				ErrorType:    "ChargeError",
+				ErrorMessage: "card declined",
+				StackTrace:   &wrapperspb.StringValue{Value: "at Charge()\n at Run()"},
+			},
+		}}},
+		{EventId: 3, Timestamp: now, EventType: &protos.HistoryEvent_ChildWorkflowInstanceFailed{ChildWorkflowInstanceFailed: &protos.ChildWorkflowInstanceFailedEvent{
+			TaskScheduledId: 1,
+			FailureDetails: &protos.TaskFailureDetails{
+				ErrorType:    "ChildError",
+				ErrorMessage: "child boom",
+			},
+		}}},
+	}
+	ex := DecodeExecution("order", "inst-tf", history, "")
+
+	byType := map[string]HistoryEvent{}
+	for _, e := range ex.History {
+		byType[e.Type] = e
+	}
+
+	tf := byType["TaskFailed"]
+	require.NotNil(t, tf.FailureDetails)
+	require.Equal(t, "ChargeError", tf.FailureDetails.ErrorType)
+	require.Equal(t, "card declined", tf.FailureDetails.Message)
+	require.Equal(t, "at Charge()\n at Run()", tf.FailureDetails.StackTrace)
+
+	sf := byType["SubOrchestrationFailed"]
+	require.NotNil(t, sf.FailureDetails)
+	require.Equal(t, "ChildError", sf.FailureDetails.ErrorType)
+	require.Equal(t, "child boom", sf.FailureDetails.Message)
+	require.Equal(t, "", sf.FailureDetails.StackTrace) // none provided
+}
+
+func TestDecodeExecutionFailed(t *testing.T) {
+	now := timestamppb.Now()
+	history := []*protos.HistoryEvent{
+		{EventId: 0, Timestamp: now, EventType: &protos.HistoryEvent_ExecutionStarted{ExecutionStarted: &protos.ExecutionStartedEvent{Name: "W"}}},
+		{EventId: 1, Timestamp: now, EventType: &protos.HistoryEvent_ExecutionCompleted{ExecutionCompleted: &protos.ExecutionCompletedEvent{
+			WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED,
+			FailureDetails: &protos.TaskFailureDetails{
+				ErrorType:    "System.InvalidOperationException",
+				ErrorMessage: "boom",
+				StackTrace:   &wrapperspb.StringValue{Value: "at Foo()\n at Bar()"},
+			},
+		}}},
+	}
+	ex := DecodeExecution("order", "inst-f", history, "")
+
+	require.Equal(t, StatusFailed, ex.Status)
+
+	// Workflow-level failure details populated, incl. stack trace.
+	require.NotNil(t, ex.FailureDetails)
+	require.Equal(t, "System.InvalidOperationException", ex.FailureDetails.ErrorType)
+	require.Equal(t, "boom", ex.FailureDetails.Message)
+	require.Equal(t, "at Foo()\n at Bar()", ex.FailureDetails.StackTrace)
+
+	// Terminal event re-typed to ExecutionFailed with its own failure details.
+	last := ex.History[len(ex.History)-1]
+	require.Equal(t, "ExecutionFailed", last.Type)
+	require.NotNil(t, last.FailureDetails)
+	require.Equal(t, "boom", last.FailureDetails.Message)
+	require.Nil(t, last.Output)
+}
+
+func TestDecodeExecutionCompletedNoFailure(t *testing.T) {
+	now := timestamppb.Now()
+	history := []*protos.HistoryEvent{
+		{EventId: 0, Timestamp: now, EventType: &protos.HistoryEvent_ExecutionStarted{ExecutionStarted: &protos.ExecutionStartedEvent{Name: "W"}}},
+		{EventId: 1, Timestamp: now, EventType: &protos.HistoryEvent_ExecutionCompleted{ExecutionCompleted: &protos.ExecutionCompletedEvent{
+			WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED,
+			Result:         &wrapperspb.StringValue{Value: `"done"`},
+		}}},
+	}
+	ex := DecodeExecution("order", "inst-ok", history, "")
+	last := ex.History[len(ex.History)-1]
+	require.Equal(t, "ExecutionCompleted", last.Type)
+	require.Nil(t, last.FailureDetails)
+	require.NotNil(t, last.Output)
+	require.Equal(t, `"done"`, *last.Output)
+}

--- a/pkg/workflow/types.go
+++ b/pkg/workflow/types.go
@@ -38,19 +38,21 @@ func (s Status) IsTerminal() bool {
 }
 
 type FailureDetails struct {
-	ErrorType string `json:"errorType,omitempty"`
-	Message   string `json:"message,omitempty"`
+	ErrorType  string `json:"errorType,omitempty"`
+	Message    string `json:"message,omitempty"`
+	StackTrace string `json:"stackTrace,omitempty"`
 }
 
 type HistoryEvent struct {
-	SequenceID  int32     `json:"sequenceId"`
-	Timestamp   time.Time `json:"timestamp"`
-	Type        string    `json:"type"`
-	Name        string    `json:"name,omitempty"`
-	InstanceID  string    `json:"instanceId,omitempty"`  // child instance id for SubOrchestrationCreated
-	ScheduledID *int32    `json:"scheduledId,omitempty"` // start event's EventId; set on completion/fired events
-	Input       *string   `json:"input,omitempty"`
-	Output      *string   `json:"output,omitempty"`
+	SequenceID     int32           `json:"sequenceId"`
+	Timestamp      time.Time       `json:"timestamp"`
+	Type           string          `json:"type"`
+	Name           string          `json:"name,omitempty"`
+	InstanceID     string          `json:"instanceId,omitempty"`  // child instance id for SubOrchestrationCreated
+	ScheduledID    *int32          `json:"scheduledId,omitempty"` // start event's EventId; set on completion/fired events
+	Input          *string         `json:"input,omitempty"`
+	Output         *string         `json:"output,omitempty"`
+	FailureDetails *FailureDetails `json:"failureDetails,omitempty"` // set on TaskFailed / SubOrchestrationFailed / ExecutionFailed
 }
 
 type ExecutionSummary struct {

--- a/web/src/pages/WorkflowDetail.test.tsx
+++ b/web/src/pages/WorkflowDetail.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, act } from '@testing-library/react'
+import { render, screen, waitFor, act, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { http, HttpResponse } from 'msw'
@@ -1235,13 +1235,7 @@ describe('WorkflowDetail — failure banner', () => {
           },
           history: [
             { sequenceId: 0, timestamp: '2026-06-26T10:00:00Z', type: 'ExecutionStarted', name: 'OrderWorkflow' },
-            // Note: intentionally no failureDetails on this history event — the
-            // event-level failure box (.evfail) is already covered by Task 2's
-            // tests above, and duplicating the same stack trace text here would
-            // collide with this test's "hidden until toggled" assertion (the
-            // per-event box, though visually collapsed via a closed <details>,
-            // is still present in the DOM and matched by queryByText).
-            { sequenceId: 1, timestamp: '2026-06-26T10:00:05Z', type: 'ExecutionFailed' },
+            { sequenceId: 1, timestamp: '2026-06-26T10:00:05Z', type: 'ExecutionFailed', failureDetails: { errorType: 'System.InvalidOperationException', message: 'boom', stackTrace: 'at Foo()\n at Bar()' } },
           ],
         }),
       ),
@@ -1250,10 +1244,13 @@ describe('WorkflowDetail — failure banner', () => {
     const banner = await screen.findByRole('alert')
     expect(banner).toHaveTextContent('System.InvalidOperationException')
     expect(banner).toHaveTextContent('boom')
-    // Stack trace hidden initially.
-    expect(screen.queryByText(/at Foo\(\)/)).toBeNull()
+    // Stack trace hidden initially. Scope to the banner: the same stack-trace
+    // text also appears in the per-event .evfail box (Task 2), which is present
+    // in the DOM even while its <details> is collapsed — so a page-wide query
+    // would match that instead. within(banner) asserts the banner's own toggle.
+    expect(within(banner).queryByText(/at Foo\(\)/)).toBeNull()
     await userEvent.click(screen.getByRole('button', { name: /show stack trace/i }))
-    expect(screen.getByText(/at Foo\(\)/)).toBeInTheDocument()
+    expect(within(banner).getByText(/at Foo\(\)/)).toBeInTheDocument()
   })
 
   it('shows no failure banner for a completed workflow', async () => {

--- a/web/src/pages/WorkflowDetail.test.tsx
+++ b/web/src/pages/WorkflowDetail.test.tsx
@@ -966,6 +966,8 @@ describe('EventRow', () => {
     expect(screen.getByText('card declined')).toBeInTheDocument()
     expect(screen.getByText(/at Charge\(\)/)).toBeInTheDocument()
     expect(screen.getByText('Stack trace')).toBeInTheDocument()
+    // Stack trace uses the wrapping class so long frames stay inside the box.
+    expect(container.querySelector('pre.stacktrace')).not.toBeNull()
   })
 
   it('omits the stack-trace section when a failed event has no stack trace', () => {
@@ -1251,6 +1253,8 @@ describe('WorkflowDetail — failure banner', () => {
     expect(within(banner).queryByText(/at Foo\(\)/)).toBeNull()
     await userEvent.click(screen.getByRole('button', { name: /show stack trace/i }))
     expect(within(banner).getByText(/at Foo\(\)/)).toBeInTheDocument()
+    // Stack trace uses the wrapping class so long frames stay inside the banner.
+    expect(banner.querySelector('pre.stacktrace')).not.toBeNull()
   })
 
   it('shows no failure banner for a completed workflow', async () => {

--- a/web/src/pages/WorkflowDetail.test.tsx
+++ b/web/src/pages/WorkflowDetail.test.tsx
@@ -1211,3 +1211,70 @@ describe('WorkflowDetail — pair selection', () => {
     }
   })
 })
+
+describe('WorkflowDetail — failure banner', () => {
+  beforeEach(() => {
+    server.use(http.get('/api/apps', () => HttpResponse.json([{ appId: 'order', health: 'healthy' }])))
+  })
+
+  it('shows a failure banner with type + message, stack trace hidden until toggled', async () => {
+    server.use(
+      http.get('/api/workflows/order/abc', () =>
+        HttpResponse.json({
+          appId: 'order',
+          instanceId: 'abc',
+          name: 'OrderWorkflow',
+          status: 'Failed',
+          createdAt: '2026-06-26T10:00:00Z',
+          lastUpdatedAt: '2026-06-26T10:00:05Z',
+          replayCount: 0,
+          failureDetails: {
+            errorType: 'System.InvalidOperationException',
+            message: 'boom',
+            stackTrace: 'at Foo()\n at Bar()',
+          },
+          history: [
+            { sequenceId: 0, timestamp: '2026-06-26T10:00:00Z', type: 'ExecutionStarted', name: 'OrderWorkflow' },
+            // Note: intentionally no failureDetails on this history event — the
+            // event-level failure box (.evfail) is already covered by Task 2's
+            // tests above, and duplicating the same stack trace text here would
+            // collide with this test's "hidden until toggled" assertion (the
+            // per-event box, though visually collapsed via a closed <details>,
+            // is still present in the DOM and matched by queryByText).
+            { sequenceId: 1, timestamp: '2026-06-26T10:00:05Z', type: 'ExecutionFailed' },
+          ],
+        }),
+      ),
+    )
+    renderDetail()
+    const banner = await screen.findByRole('alert')
+    expect(banner).toHaveTextContent('System.InvalidOperationException')
+    expect(banner).toHaveTextContent('boom')
+    // Stack trace hidden initially.
+    expect(screen.queryByText(/at Foo\(\)/)).toBeNull()
+    await userEvent.click(screen.getByRole('button', { name: /show stack trace/i }))
+    expect(screen.getByText(/at Foo\(\)/)).toBeInTheDocument()
+  })
+
+  it('shows no failure banner for a completed workflow', async () => {
+    server.use(
+      http.get('/api/workflows/order/abc', () =>
+        HttpResponse.json({
+          appId: 'order',
+          instanceId: 'abc',
+          name: 'OrderWorkflow',
+          status: 'Completed',
+          createdAt: '2026-06-26T10:00:00Z',
+          lastUpdatedAt: '2026-06-26T10:00:05Z',
+          replayCount: 0,
+          history: [
+            { sequenceId: 0, timestamp: '2026-06-26T10:00:00Z', type: 'ExecutionStarted', name: 'OrderWorkflow' },
+          ],
+        }),
+      ),
+    )
+    renderDetail()
+    await waitFor(() => expect(screen.getByText('COMPLETED')).toBeInTheDocument())
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/web/src/pages/WorkflowDetail.test.tsx
+++ b/web/src/pages/WorkflowDetail.test.tsx
@@ -947,6 +947,38 @@ describe('EventRow', () => {
       `${d.toLocaleDateString()} - ${d.toLocaleTimeString()}`,
     )
   })
+
+  it('renders a red error box (type + message + copyable stack trace) for a failed event', async () => {
+    const { container } = row({
+      type: 'TaskFailed',
+      sequenceId: 4,
+      timestamp: '2026-06-28T10:00:02.000Z',
+      failureDetails: {
+        errorType: 'ChargeError',
+        message: 'card declined',
+        stackTrace: 'at Charge()\n at Run()',
+      },
+    })
+    // Row is expandable (was a bare static row before).
+    expect(container.querySelector('details')).not.toBeNull()
+    expect(container.querySelector('.evfail')).not.toBeNull()
+    expect(screen.getByText('ChargeError')).toBeInTheDocument()
+    expect(screen.getByText('card declined')).toBeInTheDocument()
+    expect(screen.getByText(/at Charge\(\)/)).toBeInTheDocument()
+    expect(screen.getByText('Stack trace')).toBeInTheDocument()
+  })
+
+  it('omits the stack-trace section when a failed event has no stack trace', () => {
+    const { container } = row({
+      type: 'SubOrchestrationFailed',
+      sequenceId: 5,
+      timestamp: '2026-06-28T10:00:03.000Z',
+      failureDetails: { errorType: 'ChildError', message: 'child boom' },
+    })
+    expect(container.querySelector('.evfail')).not.toBeNull()
+    expect(screen.getByText('child boom')).toBeInTheDocument()
+    expect(screen.queryByText('Stack trace')).toBeNull()
+  })
 })
 
 describe('WorkflowDetail — pair selection', () => {

--- a/web/src/pages/WorkflowDetail.tsx
+++ b/web/src/pages/WorkflowDetail.tsx
@@ -297,6 +297,41 @@ export function EventRow({
   )
 }
 
+function FailureBanner({ failure, toast }: { failure: WorkflowFailureDetails; toast: ToastHandle }) {
+  const [showStack, setShowStack] = useState(false)
+  return (
+    <div className="failbanner" role="alert">
+      <div className="failbanner-head">
+        <span className="failbanner-icon" aria-hidden="true">⚠</span>
+        <span className="failbanner-type">{failure.errorType || 'Workflow failed'}</span>
+        {failure.stackTrace && (
+          <button className="tbtn" onClick={() => setShowStack((s) => !s)}>
+            {showStack ? 'Hide stack trace' : 'Show stack trace'}
+          </button>
+        )}
+      </div>
+      {failure.message && <div className="failbanner-msg">{failure.message}</div>}
+      {failure.stackTrace && showStack && (
+        <div>
+          <div className="lblrow">
+            <span className="lbl">Stack trace</span>
+            <button
+              className="copybtn"
+              onClick={() => {
+                copyText(failure.stackTrace ?? '')
+                toast.show('Stack trace copied')
+              }}
+            >
+              ⧉ Copy
+            </button>
+          </div>
+          <pre className="json">{failure.stackTrace}</pre>
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
@@ -539,6 +574,10 @@ export function WorkflowDetail() {
           </button>
         </div>
       </div>
+
+      {execution.failureDetails && (
+        <FailureBanner failure={execution.failureDetails} toast={toast} />
+      )}
 
       {/* ------------------------------------------------------------------ */}
       {/* Meta grid                                                            */}

--- a/web/src/pages/WorkflowDetail.tsx
+++ b/web/src/pages/WorkflowDetail.tsx
@@ -9,7 +9,7 @@ import { elapsed, elapsedTenths, formatOffset, formatDateTime, formatDuration } 
 import { highlightJson } from '../lib/json-highlight'
 import { useToast, type ToastHandle } from '../lib/toast'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
-import type { WorkflowStatus, WorkflowHistoryEvent } from '../types/workflow'
+import type { WorkflowStatus, WorkflowHistoryEvent, WorkflowFailureDetails } from '../types/workflow'
 import { copyText } from '../lib/clipboard'
 import { sortHistoryForDisplay, orderHistoryForDisplay, eventAnchorId, type HistoryOrder } from '../lib/eventOrder'
 import { buildPairIndex, type PairInfo } from '../lib/pairing'
@@ -153,7 +153,8 @@ export function EventRow({
       <span className="evtag">{eventIdTag}</span>
     ) : null
 
-  const hasDetails = !!(event.input || event.output)
+  const failure: WorkflowFailureDetails | undefined = event.failureDetails
+  const hasDetails = !!(event.input || event.output || failure)
 
   const selectable = !!pair
   const onHeaderClick = (e: ReactMouseEvent) => {
@@ -198,6 +199,29 @@ export function EventRow({
               </button>
             </summary>
             <div className="evbody">
+              {failure && (
+                <div className="evfail">
+                  <span className="evfail-type">{failure.errorType || 'Error'}</span>
+                  {failure.message && <div className="evfail-msg">{failure.message}</div>}
+                  {failure.stackTrace && (
+                    <div>
+                      <div className="lblrow">
+                        <span className="lbl">Stack trace</span>
+                        <button
+                          className="copybtn"
+                          onClick={() => {
+                            copyText(failure.stackTrace ?? '')
+                            toast.show('Stack trace copied')
+                          }}
+                        >
+                          ⧉ Copy
+                        </button>
+                      </div>
+                      <pre className="json">{failure.stackTrace}</pre>
+                    </div>
+                  )}
+                </div>
+              )}
               {event.input && (
                 <div>
                   <div className="lblrow">

--- a/web/src/pages/WorkflowDetail.tsx
+++ b/web/src/pages/WorkflowDetail.tsx
@@ -217,7 +217,7 @@ export function EventRow({
                           ⧉ Copy
                         </button>
                       </div>
-                      <pre className="json">{failure.stackTrace}</pre>
+                      <pre className="json stacktrace">{failure.stackTrace}</pre>
                     </div>
                   )}
                 </div>
@@ -325,7 +325,7 @@ function FailureBanner({ failure, toast }: { failure: WorkflowFailureDetails; to
               ⧉ Copy
             </button>
           </div>
-          <pre className="json">{failure.stackTrace}</pre>
+          <pre className="json stacktrace">{failure.stackTrace}</pre>
         </div>
       )}
     </div>

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -443,6 +443,9 @@ details[open] .caret { transform: rotate(90deg); }
 .evbody pre { margin: 0; font-family: var(--mono); font-size: 11.5px; line-height: 1.55; background: var(--surface-2); border: 1px solid var(--line-soft); border-radius: 8px; padding: 9px 11px; max-height: 23.25em; overflow: auto; }
 .evbody .lblrow { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 5px; }
 .evbody .lblrow .copybtn { padding: 2px 7px; font-size: 10px; }
+.evbody .evfail { display: grid; gap: 6px; padding: 9px 11px; border-radius: 8px; border: 1px solid color-mix(in srgb, var(--fail-fg) 35%, transparent); background: color-mix(in srgb, var(--fail-fg) 10%, transparent); }
+.evfail-type { font-family: var(--mono); font-size: 11.5px; font-weight: 600; color: var(--fail-fg); }
+.evfail-msg { font-size: 12.5px; color: var(--text); white-space: pre-wrap; word-break: break-word; }
 .retrybadge { font-family: var(--mono); font-size: 10px; color: var(--pend-fg); background: var(--pend-bg); border-radius: 5px; padding: 1px 6px; }
 .err { color: var(--fail-fg); }
 .ev.reveal { animation: fadein .28s ease; }

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -446,6 +446,13 @@ details[open] .caret { transform: rotate(90deg); }
 .evbody .evfail { display: grid; gap: 6px; padding: 9px 11px; border-radius: 8px; border: 1px solid color-mix(in srgb, var(--fail-fg) 35%, transparent); background: color-mix(in srgb, var(--fail-fg) 10%, transparent); }
 .evfail-type { font-family: var(--mono); font-size: 11.5px; font-weight: 600; color: var(--fail-fg); }
 .evfail-msg { font-size: 12.5px; color: var(--text); white-space: pre-wrap; word-break: break-word; }
+.failbanner { display: grid; gap: 8px; padding: 12px 14px; margin-bottom: 18px; border-radius: 10px; border: 1px solid color-mix(in srgb, var(--fail-fg) 40%, transparent); background: var(--fail-bg); }
+.failbanner-head { display: flex; align-items: center; gap: 9px; }
+.failbanner-icon { color: var(--fail-fg); }
+.failbanner-type { font-family: var(--mono); font-size: 13px; font-weight: 600; color: var(--fail-fg); }
+.failbanner-head .tbtn { margin-left: auto; }
+.failbanner-msg { font-size: 13px; color: var(--text); white-space: pre-wrap; word-break: break-word; }
+.failbanner .lblrow { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .retrybadge { font-family: var(--mono); font-size: 10px; color: var(--pend-fg); background: var(--pend-bg); border-radius: 5px; padding: 1px 6px; }
 .err { color: var(--fail-fg); }
 .ev.reveal { animation: fadein .28s ease; }

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -453,6 +453,10 @@ details[open] .caret { transform: rotate(90deg); }
 .failbanner-head .tbtn { margin-left: auto; }
 .failbanner-msg { font-size: 13px; color: var(--text); white-space: pre-wrap; word-break: break-word; }
 .failbanner .lblrow { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+/* Stack traces wrap (long frames/paths) instead of overflowing the box, while
+   keeping the vertical max-height scroll from pre.json. Scoped to .stacktrace so
+   JSON payloads keep their non-wrapping, horizontally-scrolling layout. */
+pre.stacktrace { white-space: pre-wrap; overflow-wrap: anywhere; }
 .retrybadge { font-family: var(--mono); font-size: 10px; color: var(--pend-fg); background: var(--pend-bg); border-radius: 5px; padding: 1px 6px; }
 .err { color: var(--fail-fg); }
 .ev.reveal { animation: fadein .28s ease; }

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -444,8 +444,8 @@ details[open] .caret { transform: rotate(90deg); }
 .evbody .lblrow { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 5px; }
 .evbody .lblrow .copybtn { padding: 2px 7px; font-size: 10px; }
 .evbody .evfail { display: grid; gap: 6px; padding: 9px 11px; border-radius: 8px; border: 1px solid color-mix(in srgb, var(--fail-fg) 35%, transparent); background: color-mix(in srgb, var(--fail-fg) 10%, transparent); }
-.evfail-type { font-family: var(--mono); font-size: 11.5px; font-weight: 600; color: var(--fail-fg); }
-.evfail-msg { font-size: 12.5px; color: var(--text); white-space: pre-wrap; word-break: break-word; }
+.evbody .evfail-type { font-family: var(--mono); font-size: 11.5px; font-weight: 600; color: var(--fail-fg); }
+.evbody .evfail-msg { font-size: 12.5px; color: var(--text); white-space: pre-wrap; word-break: break-word; }
 .failbanner { display: grid; gap: 8px; padding: 12px 14px; margin-bottom: 18px; border-radius: 10px; border: 1px solid color-mix(in srgb, var(--fail-fg) 40%, transparent); background: var(--fail-bg); }
 .failbanner-head { display: flex; align-items: center; gap: 9px; }
 .failbanner-icon { color: var(--fail-fg); }

--- a/web/src/types/workflow.ts
+++ b/web/src/types/workflow.ts
@@ -10,6 +10,12 @@ export interface WorkflowSummary {
   lastUpdatedAt?: string
 }
 
+export interface WorkflowFailureDetails {
+  errorType?: string
+  message?: string
+  stackTrace?: string
+}
+
 export interface WorkflowHistoryEvent {
   sequenceId: number
   timestamp: string
@@ -19,6 +25,7 @@ export interface WorkflowHistoryEvent {
   scheduledId?: number // start event's EventId; present on completion/fired events
   input?: string
   output?: string
+  failureDetails?: WorkflowFailureDetails
 }
 
 export interface WorkflowExecution extends WorkflowSummary {
@@ -26,7 +33,7 @@ export interface WorkflowExecution extends WorkflowSummary {
   output?: string
   customStatus?: string
   replayCount: number
-  failureDetails?: { errorType?: string; message?: string }
+  failureDetails?: WorkflowFailureDetails
   history: WorkflowHistoryEvent[]
 }
 


### PR DESCRIPTION
## Problem

When an exception is thrown inside a Dapr workflow activity, a sub-orchestration, or the workflow (orchestrator) itself, the failure never surfaced in the workflow detail page's event history. Failed rows showed only their type name — no error message, type, or stack trace — and a failed workflow showed no explanation beyond the `Failed` status pill. The data existed but was discarded during decoding (and the workflow-level `failureDetails`, though returned by the API, was never rendered).

## What changed

**Backend (`pkg/workflow`)**
- Extend `FailureDetails` with `StackTrace`; add a `FailureDetails` field to `HistoryEvent`.
- `decode.go` now captures `TaskFailureDetails` (type / message / stack trace) for `TaskFailed` and `SubOrchestrationFailed`, via a single reusable `failureFromProto` helper that also backs the workflow-level failure.
- A failed terminal `ExecutionCompleted` is re-typed to `ExecutionFailed`, lighting up the existing `nodeClass`/`eventOrder` paths that already anticipated it.
- New JSON fields use `omitempty`, so the no-failure golden output stays byte-identical.

**Frontend (`web`)**
- New `WorkflowFailureDetails` type.
- A red per-event error box (error type + message + copyable stack trace) inside failed event rows in the history list.
- A page-level `FailureBanner` near the header (type + message always visible; stack trace behind a Show/Hide toggle), driven by the already-fetched `execution.failureDetails`.

## Testing

- `make build` clean; `make test` green (Go workflow suite + web 637/637); `tsc -b` clean.
- New backend decode tests: `TaskFailed`, `SubOrchestrationFailed`, failed `ExecutionCompleted`→`ExecutionFailed`, and a non-failing completion regression.
- New frontend tests: per-event error box (incl. stack-trace omission when absent) and the failure banner (type/message + toggle; absent for completed workflows).

## Non-goals

- Rendering `innerFailure` chains or surfacing `isNonRetriable`/retry metadata.

Design spec and implementation plan included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)