### PR TITLE
Version-update awareness: startup notice + web indicator

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -365,6 +365,13 @@ background refresh runs; a failed fetch is remembered for a short negative TTL a
 evicts the last-good response. The response exposes one latest blog/report and the next
 upcoming webinar/event, with UTM params appended to diagrid.io links.
 
+### Update check (`pkg/updatecheck`)
+
+Resolves the latest GitHub release (reusing `pkg/selfupdate`'s resolver), compares it to
+the running version with semver, and caches the result. Consumed by the CLI startup notice
+and by `GET /api/update-check` for the web indicator. Fails silent; skipped for `dev`/source
+builds.
+
 ### Metadata (`pkg/metadata`)
 
 An embedded component-metadata catalog (`//go:embed component-metadata-bundle.json`)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ refresh cycle.
 
 ## Updating the dashboard
 
+On startup the dashboard checks GitHub for a newer release. If one exists, it prints
+a notice as the first line of output and the web UI shows an **Update available**
+indicator next to the version number in the Resources panel. The check is best-effort:
+it is skipped for source/dev builds and fails silently when offline.
+
 Update to the latest release (no-op if already current)
 
 ```sh

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/diagridio/dev-dashboard/pkg/logging"
 	"github.com/diagridio/dev-dashboard/pkg/metadata"
 	"github.com/diagridio/dev-dashboard/pkg/server"
+	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
 	"github.com/diagridio/dev-dashboard/pkg/version"
 	"github.com/diagridio/dev-dashboard/web"
 	"github.com/spf13/cobra"
@@ -93,6 +94,7 @@ func runServe(ctx context.Context, port int, basePath string, noOpen bool, state
 	_, crtRunner := containerruntime.Detect()
 	composeSrc := discovery.NewComposeSource(crtRunner)
 	telemetry := telemetryEnabled(os.Getenv)
+	updateCheck := updatecheck.New(&http.Client{Timeout: 5 * time.Second}, "https://api.github.com", "diagridio/dev-dashboard", version.Get().Version, time.Hour)
 	opts, closers := assembleOptions(ctx, serveDeps{
 		BasePath:       basePath,
 		StateStorePath: stateStore,
@@ -105,6 +107,7 @@ func runServe(ctx context.Context, port int, basePath string, noOpen bool, state
 		ComposeEnv:       composeSrc.Env,
 		ContainerLogs:    containerLogStream(crtRunner),
 		TelemetryEnabled: telemetry,
+		UpdateCheck:      updateCheck,
 	}, dist)
 	for _, close := range closers {
 		close := close
@@ -113,6 +116,7 @@ func runServe(ctx context.Context, port int, basePath string, noOpen bool, state
 
 	srv := server.New(addr, opts)
 
+	maybeAnnounceUpdate(ctx, updateCheck, version.Get().Version)
 	fmt.Printf("Diagrid Dev Dashboard is running → %s\n", url)
 	if telemetry {
 		fmt.Println("We're using anonymous usage telemetry to improve the dashboard. Set DEVDASHBOARD_TELEMETRY_OPTOUT=true to disable (restart required).")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -13,6 +13,7 @@ import (
 	"github.com/diagridio/dev-dashboard/pkg/news"
 	"github.com/diagridio/dev-dashboard/pkg/resources"
 	"github.com/diagridio/dev-dashboard/pkg/server"
+	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
 	"github.com/diagridio/dev-dashboard/pkg/version"
 )
 
@@ -35,6 +36,9 @@ type serveDeps struct {
 	// TelemetryEnabled reflects DEVDASHBOARD_TELEMETRY_OPTOUT, read once at
 	// process start in runServe.
 	TelemetryEnabled bool
+	// UpdateCheck is the shared latest-release checker; also used by runServe to
+	// print the startup notice, so the server reuses its warmed cache.
+	UpdateCheck updatecheck.Service
 }
 
 // containerLogStream adapts a runtime Runner into the log-stream dependency.
@@ -98,5 +102,6 @@ func assembleOptions(ctx context.Context, deps serveDeps, dist fs.FS) (server.Op
 		News:             newsSvc,
 		ControlPlane:     controlplane.New(),
 		TelemetryEnabled: deps.TelemetryEnabled,
+		UpdateCheck:      deps.UpdateCheck,
 	}, []func() error{rc.Close}
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/diagridio/dev-dashboard/pkg/discovery"
+	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,4 +73,20 @@ func TestAssembleOptions_TelemetryEnabledPassedThrough(t *testing.T) {
 	})
 
 	require.True(t, opts.TelemetryEnabled)
+}
+
+// TestAssembleOptionsPropagatesUpdateCheck verifies that serveDeps.UpdateCheck
+// is threaded into server.Options.UpdateCheck unchanged, so runServe's
+// startup-notice service and the server's /api/update-check endpoint share the
+// same warmed cache instance.
+func TestAssembleOptionsPropagatesUpdateCheck(t *testing.T) {
+	uc := updatecheck.New(nil, "https://api.github.com", "diagridio/dev-dashboard", "1.2.0", time.Hour)
+	opts, closers := assembleOptions(context.Background(), serveDeps{
+		Apps:        emptyApps{},
+		UpdateCheck: uc,
+	}, nil)
+	for _, c := range closers {
+		defer func(c func() error) { _ = c() }(c)
+	}
+	require.Same(t, uc, opts.UpdateCheck)
 }

--- a/cmd/update_notice.go
+++ b/cmd/update_notice.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
+)
+
+// formatUpdateNotice renders the two-line "new version available" notice.
+func formatUpdateNotice(current, latest string) string {
+	return fmt.Sprintf(
+		"A new version of the Dapr Dev Dashboard is available: %s → %s\n"+
+			"Run `dev-dashboard update` to upgrade.\n",
+		current, latest)
+}
+
+// printUpdateNotice writes the notice to w when an update is available; it writes
+// nothing otherwise.
+func printUpdateNotice(w io.Writer, r updatecheck.Result) {
+	if !r.UpdateAvailable {
+		return
+	}
+	fmt.Fprint(w, formatUpdateNotice(r.Current, r.Latest))
+}

--- a/cmd/update_notice.go
+++ b/cmd/update_notice.go
@@ -1,10 +1,15 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"os"
+	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
+	"github.com/mattn/go-isatty"
 )
 
 // formatUpdateNotice renders the two-line "new version available" notice.
@@ -22,4 +27,27 @@ func printUpdateNotice(w io.Writer, r updatecheck.Result) {
 		return
 	}
 	fmt.Fprint(w, formatUpdateNotice(r.Current, r.Latest))
+}
+
+// maybeAnnounceUpdate runs the startup version check and prints the notice to
+// stdout as the first output. For dev/source builds it does nothing (no spinner,
+// no network call). On a TTY it shows a spinner while the (2s-bounded) check runs.
+func maybeAnnounceUpdate(ctx context.Context, uc updatecheck.Service, current string) {
+	if uc == nil || !updatecheck.IsReleaseVersion(current) {
+		return
+	}
+	cctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	var sp *spinner.Spinner
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		sp = spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithWriter(os.Stdout))
+		sp.Suffix = " Checking for new versions…"
+		sp.Start()
+	}
+	r := uc.Check(cctx)
+	if sp != nil {
+		sp.Stop()
+	}
+	printUpdateNotice(os.Stdout, r)
 }

--- a/cmd/update_notice_test.go
+++ b/cmd/update_notice_test.go
@@ -1,0 +1,32 @@
+//go:build unit
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatUpdateNotice(t *testing.T) {
+	got := formatUpdateNotice("v1.2.0", "v1.3.0")
+	require.Equal(t,
+		"A new version of the Dapr Dev Dashboard is available: v1.2.0 → v1.3.0\n"+
+			"Run `dev-dashboard update` to upgrade.\n",
+		got)
+}
+
+func TestPrintUpdateNoticeWhenAvailable(t *testing.T) {
+	var buf bytes.Buffer
+	printUpdateNotice(&buf, updatecheck.Result{Current: "v1.2.0", Latest: "v1.3.0", UpdateAvailable: true})
+	require.Contains(t, buf.String(), "v1.2.0 → v1.3.0")
+	require.Contains(t, buf.String(), "dev-dashboard update")
+}
+
+func TestPrintUpdateNoticeSuppressedWhenNotAvailable(t *testing.T) {
+	var buf bytes.Buffer
+	printUpdateNotice(&buf, updatecheck.Result{Current: "v1.3.0", Latest: "v1.3.0", UpdateAvailable: false})
+	require.Empty(t, buf.String())
+}

--- a/docs/superpowers/plans/2026-07-08-version-update-awareness.md
+++ b/docs/superpowers/plans/2026-07-08-version-update-awareness.md
@@ -1,0 +1,1196 @@
+# Version-update Awareness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tell dashboard users when a newer release exists — a first-line CLI startup notice and a clickable "Update available" indicator in the web Resources panel (expanded and collapsed).
+
+**Architecture:** One shared backend service (`pkg/updatecheck`) resolves the latest GitHub release (reusing `selfupdate`'s resolver) and compares it to the running version with semver. The CLI calls it once at startup (with a spinner) and prints a notice; the HTTP server reuses the same instance to answer `GET /api/update-check`, which the SPA polls to drive the indicator.
+
+**Tech Stack:** Go (cobra CLI, chi HTTP), `golang.org/x/mod/semver`, `github.com/briandowns/spinner`, `github.com/mattn/go-isatty` (all already in the module graph). React + TypeScript + Vite + TanStack Query; Vitest + MSW for web tests.
+
+## Global Constraints
+
+- **Go ≥ 1.26**, Node.js 20 — matching the repo.
+- **Repo constant:** `diagridio/dev-dashboard`. **GitHub API base:** `https://api.github.com`. **Release URL:** `https://github.com/diagridio/dev-dashboard/releases/tag/<tag>`.
+- **Notice copy (verbatim):**
+  ```
+  A new version of the Dapr Dev Dashboard is available: <current> → <latest>
+  Run `dev-dashboard update` to upgrade.
+  ```
+- **Startup check timeout:** 2s. **Service cache TTL:** 1h positive, negative-cache capped at 5m.
+- **`dev`/invalid-semver builds:** no spinner, no network call, no notice, no badge.
+- **Fail silent:** offline / rate-limited / errored checks yield `UpdateAvailable: false`; never surfaced as an error.
+- **No opt-out** (no env var, no flag).
+- **Go build tags:** unit tests need `//go:build unit`; run with `go test -tags unit ./...`. Integration tests need `//go:build integration`.
+- **Commits:** every commit uses `git commit -s` (DCO) and ends its message with the trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. **Do not run any git command unless the user has explicitly authorized it in the session** (per the user's global instructions); if a Commit step is reached without that authorization, pause and ask.
+- **Windows dev:** run Go tests with `go test -tags unit -race ./...`; web tests with `cd web; npm test`.
+
+## File Structure
+
+**Backend (new):**
+- `pkg/updatecheck/updatecheck.go` — `Result`, `IsReleaseVersion`, `evaluate` (pure compare), `withV`.
+- `pkg/updatecheck/service.go` — `Service` interface, caching `New`/`Check`.
+- `pkg/updatecheck/updatecheck_test.go`, `pkg/updatecheck/service_test.go` — unit tests.
+- `pkg/server/updatecheck.go` — `updateCheckRouter`.
+- `pkg/server/updatecheck_test.go` — `fakeUpdateCheck` + endpoint test.
+
+**Backend (modified):**
+- `pkg/selfupdate/resolve.go`, `selfupdate.go`, `fetch_test.go` — export `ResolveLatest`.
+- `pkg/server/server.go` — `Options.UpdateCheck` field; pass to `apiRouter`.
+- `pkg/server/api.go` — `apiRouter` gains `updatecheck.Service` param; mounts `/update-check`.
+- `pkg/server/api_test.go`, `statestores_test.go`, `workflows_test.go` — update `apiRouter(...)` call sites.
+- `cmd/root.go` — build the service, announce at startup (spinner + notice), pass into deps.
+- `cmd/serve.go` — `serveDeps.UpdateCheck`; wire into `assembleOptions`.
+- `cmd/update_notice.go` (new) — `formatUpdateNotice`, `printUpdateNotice`, `maybeAnnounceUpdate`.
+- `cmd/update_notice_test.go` (new), `cmd/serve_test.go` (add propagation test).
+
+**Frontend (modified):**
+- `web/src/hooks/useMeta.ts` — `UpdateInfo` + `useUpdateCheck`.
+- `web/src/hooks/useMeta.test.tsx` — hook test.
+- `web/src/components/ResourcesSidebar.tsx` — badge + collapsed indicator + `onUpdateAvailableChange` prop.
+- `web/src/components/ResourcesSidebar.test.tsx` — badge/indicator tests + default mock.
+- `web/src/App.tsx` — `update-available` class from a new state.
+- `web/src/App.test.tsx` — default `/api/update-check` mock.
+- `web/src/styles/theme.css` — badge + dot styling + collapsed rule.
+
+**Docs (modified):** `README.md`, `ARCHITECTURE.md`.
+
+---
+
+## Task 1: Export `selfupdate.ResolveLatest`
+
+Pure rename so `pkg/updatecheck` can reuse the GitHub latest-release resolver. No behavior change.
+
+**Files:**
+- Modify: `pkg/selfupdate/resolve.go:29-48`
+- Modify: `pkg/selfupdate/selfupdate.go:68`
+- Modify: `pkg/selfupdate/fetch_test.go:42,90`
+
+**Interfaces:**
+- Produces: `func ResolveLatest(ctx context.Context, client *http.Client, apiBase, repo string) (string, error)` — returns the latest release tag normalized with a leading `v` (e.g. `v1.3.0`).
+
+- [ ] **Step 1: Rename the function and update its doc comment**
+
+In `pkg/selfupdate/resolve.go`, change the comment and signature:
+
+```go
+// ResolveLatest queries the GitHub releases API for repo's latest tag_name and
+// returns it normalized (with a leading "v"). The /releases/latest endpoint
+// excludes prereleases by design, so this always resolves to the latest stable release.
+func ResolveLatest(ctx context.Context, client *http.Client, apiBase, repo string) (string, error) {
+```
+
+(Leave the body unchanged.)
+
+- [ ] **Step 2: Update the caller in `selfupdate.go`**
+
+At `pkg/selfupdate/selfupdate.go:68`, change:
+
+```go
+		v, err := ResolveLatest(ctx, u.HTTP, u.APIBase, u.Repo)
+```
+
+- [ ] **Step 3: Update the test references**
+
+In `pkg/selfupdate/fetch_test.go`, at both call sites (lines 42 and 90) change `resolveLatest(` to `ResolveLatest(`.
+
+- [ ] **Step 4: Run the selfupdate tests to verify they pass**
+
+Run: `go test -tags unit ./pkg/selfupdate/...`
+Expected: PASS (all existing tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/selfupdate
+git commit -s -m "refactor(selfupdate): export ResolveLatest for reuse"
+```
+
+---
+
+## Task 2: `pkg/updatecheck` pure comparison logic
+
+The version comparison and release-URL construction, with no network — fully unit-testable.
+
+**Files:**
+- Create: `pkg/updatecheck/updatecheck.go`
+- Test: `pkg/updatecheck/updatecheck_test.go`
+
+**Interfaces:**
+- Produces:
+  - `type Result struct { Current, Latest string; UpdateAvailable bool; ReleaseURL string }` (JSON tags `current`, `latest`, `updateAvailable`, `releaseUrl`).
+  - `func IsReleaseVersion(v string) bool` — true when `v` is a valid semver (after adding a leading `v`); false for `dev`/empty/garbage.
+  - `func evaluate(current, latest, repo string) Result` — pure comparison used by the service.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `pkg/updatecheck/updatecheck_test.go`:
+
+```go
+//go:build unit
+
+package updatecheck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsReleaseVersion(t *testing.T) {
+	require.True(t, IsReleaseVersion("1.2.0"))
+	require.True(t, IsReleaseVersion("v1.2.0"))
+	require.False(t, IsReleaseVersion("dev"))
+	require.False(t, IsReleaseVersion(""))
+	require.False(t, IsReleaseVersion("garbage"))
+}
+
+func TestEvaluate(t *testing.T) {
+	const repo = "diagridio/dev-dashboard"
+
+	t.Run("newer available", func(t *testing.T) {
+		r := evaluate("1.2.0", "v1.3.0", repo)
+		require.True(t, r.UpdateAvailable)
+		require.Equal(t, "v1.2.0", r.Current)
+		require.Equal(t, "v1.3.0", r.Latest)
+		require.Equal(t, "https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0", r.ReleaseURL)
+	})
+
+	t.Run("equal", func(t *testing.T) {
+		r := evaluate("v1.3.0", "v1.3.0", repo)
+		require.False(t, r.UpdateAvailable)
+		require.Empty(t, r.ReleaseURL)
+	})
+
+	t.Run("current newer than latest", func(t *testing.T) {
+		r := evaluate("v1.4.0", "v1.3.0", repo)
+		require.False(t, r.UpdateAvailable)
+	})
+
+	t.Run("dev current is never an update", func(t *testing.T) {
+		r := evaluate("dev", "v1.3.0", repo)
+		require.False(t, r.UpdateAvailable)
+		require.Empty(t, r.ReleaseURL)
+	})
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test -tags unit ./pkg/updatecheck/...`
+Expected: FAIL — package/functions undefined (build error).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `pkg/updatecheck/updatecheck.go`:
+
+```go
+// Package updatecheck reports whether a newer dev-dashboard release exists.
+package updatecheck
+
+import (
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+// Result is the update-availability payload shared by the CLI notice and the
+// GET /api/update-check endpoint. When UpdateAvailable is true, Current and
+// Latest are normalized with a leading "v" and ReleaseURL points at the release.
+type Result struct {
+	Current         string `json:"current"`
+	Latest          string `json:"latest"`
+	UpdateAvailable bool   `json:"updateAvailable"`
+	ReleaseURL      string `json:"releaseUrl"`
+}
+
+// IsReleaseVersion reports whether v is a real released version (valid semver
+// once a leading "v" is ensured). A source/dev build ("dev") is not.
+func IsReleaseVersion(v string) bool {
+	return semver.IsValid(withV(v))
+}
+
+// evaluate compares current against latest and builds the Result. An update is
+// available only when both are valid semver and latest is strictly greater.
+func evaluate(current, latest, repo string) Result {
+	cur := withV(current)
+	lat := withV(latest)
+	if semver.IsValid(cur) && semver.IsValid(lat) && semver.Compare(lat, cur) > 0 {
+		return Result{
+			Current:         cur,
+			Latest:          lat,
+			UpdateAvailable: true,
+			ReleaseURL:      "https://github.com/" + repo + "/releases/tag/" + lat,
+		}
+	}
+	return Result{Current: current, Latest: latest}
+}
+
+// withV normalizes a version to a single leading "v" (trimming space). Empty
+// stays empty. "1.2.0" -> "v1.2.0"; "v1.2.0" -> "v1.2.0".
+func withV(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	return "v" + strings.TrimPrefix(v, "v")
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test -tags unit ./pkg/updatecheck/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/updatecheck/updatecheck.go pkg/updatecheck/updatecheck_test.go
+git commit -s -m "feat(updatecheck): add semver comparison and Result type"
+```
+
+---
+
+## Task 3: `pkg/updatecheck` caching service
+
+The `Service` that resolves the latest release (via `selfupdate.ResolveLatest`) and caches it, so the web endpoint reuses the startup check.
+
+**Files:**
+- Create: `pkg/updatecheck/service.go`
+- Test: `pkg/updatecheck/service_test.go`
+
+**Interfaces:**
+- Consumes: `selfupdate.ResolveLatest` (Task 1); `evaluate` (Task 2).
+- Produces:
+  - `type Service interface { Check(ctx context.Context) Result }`
+  - `func New(client *http.Client, apiBase, repo, current string, ttl time.Duration) Service`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `pkg/updatecheck/service_test.go`:
+
+```go
+//go:build unit
+
+package updatecheck
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// latestServer serves the GitHub /releases/latest shape and counts hits.
+func latestServer(t *testing.T, tag string, hits *int32) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(hits, 1)
+		require.Equal(t, "/repos/diagridio/dev-dashboard/releases/latest", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"` + tag + `"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestServiceCheckReportsUpdate(t *testing.T) {
+	var hits int32
+	srv := latestServer(t, "v1.3.0", &hits)
+	svc := New(srv.Client(), srv.URL, "diagridio/dev-dashboard", "1.2.0", time.Hour)
+
+	r := svc.Check(context.Background())
+	require.True(t, r.UpdateAvailable)
+	require.Equal(t, "v1.3.0", r.Latest)
+	require.Equal(t, "https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0", r.ReleaseURL)
+}
+
+func TestServiceCachesWithinTTL(t *testing.T) {
+	var hits int32
+	srv := latestServer(t, "v1.3.0", &hits)
+	svc := New(srv.Client(), srv.URL, "diagridio/dev-dashboard", "1.2.0", time.Hour)
+
+	_ = svc.Check(context.Background())
+	_ = svc.Check(context.Background())
+	require.Equal(t, int32(1), atomic.LoadInt32(&hits), "second Check should hit cache")
+}
+
+func TestServiceNegativeCacheOnError(t *testing.T) {
+	var hits int32
+	// Server that always 500s.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	svc := New(srv.Client(), srv.URL, "diagridio/dev-dashboard", "1.2.0", time.Hour)
+
+	r1 := svc.Check(context.Background())
+	require.False(t, r1.UpdateAvailable)
+	r2 := svc.Check(context.Background())
+	require.False(t, r2.UpdateAvailable)
+	require.Equal(t, int32(1), atomic.LoadInt32(&hits), "failed fetch should be negative-cached, not re-probed")
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test -tags unit ./pkg/updatecheck/... -run TestService`
+Expected: FAIL — `New` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `pkg/updatecheck/service.go`:
+
+```go
+package updatecheck
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/diagridio/dev-dashboard/pkg/selfupdate"
+)
+
+// maxNegativeTTL caps how long a failed resolve suppresses retries.
+const maxNegativeTTL = 5 * time.Minute
+
+// Service reports whether a newer release exists, caching the result.
+type Service interface {
+	Check(ctx context.Context) Result
+}
+
+type service struct {
+	client  *http.Client
+	apiBase string
+	repo    string
+	current string
+	ttl     time.Duration
+	negTTL  time.Duration
+
+	mu        sync.Mutex
+	cached    Result
+	fetchedAt time.Time
+	failedAt  time.Time
+	hasResult bool
+}
+
+// New builds a caching update-check service. ttl is the positive cache lifetime;
+// failed resolves are negatively cached for half the ttl, capped at 5m.
+func New(client *http.Client, apiBase, repo, current string, ttl time.Duration) Service {
+	negTTL := ttl / 2
+	if negTTL > maxNegativeTTL {
+		negTTL = maxNegativeTTL
+	}
+	return &service{
+		client:  client,
+		apiBase: apiBase,
+		repo:    repo,
+		current: current,
+		ttl:     ttl,
+		negTTL:  negTTL,
+	}
+}
+
+// Check returns update availability, serving from cache when fresh. On a resolve
+// error the last-good result is preserved (zero Result if none) and the failure
+// is negatively cached so the endpoint is not re-probed on every request.
+func (s *service) Check(ctx context.Context) Result {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	if s.hasResult && now.Sub(s.fetchedAt) < s.ttl {
+		return s.cached
+	}
+	if !s.failedAt.IsZero() && now.Sub(s.failedAt) < s.negTTL {
+		return s.cached
+	}
+
+	latest, err := selfupdate.ResolveLatest(ctx, s.client, s.apiBase, s.repo)
+	if err != nil {
+		s.failedAt = time.Now()
+		return s.cached
+	}
+	s.cached = evaluate(s.current, latest, s.repo)
+	s.fetchedAt = time.Now()
+	s.failedAt = time.Time{}
+	s.hasResult = true
+	return s.cached
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test -tags unit ./pkg/updatecheck/...`
+Expected: PASS (all updatecheck tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/updatecheck/service.go pkg/updatecheck/service_test.go
+git commit -s -m "feat(updatecheck): add caching service backed by GitHub releases"
+```
+
+---
+
+## Task 4: Server endpoint `GET /api/update-check`
+
+Expose the service over HTTP, mirroring the `/news` pattern.
+
+**Files:**
+- Create: `pkg/server/updatecheck.go`
+- Create: `pkg/server/updatecheck_test.go`
+- Modify: `pkg/server/server.go:20-36` (Options), `:48` (apiRouter call)
+- Modify: `pkg/server/api.go:21` (signature), `:97-98` (mount)
+- Modify: `pkg/server/api_test.go:16,30`, `pkg/server/statestores_test.go:60`, `pkg/server/workflows_test.go:243,254`
+
+**Interfaces:**
+- Consumes: `updatecheck.Service`, `updatecheck.Result` (Task 3).
+- Produces: `func updateCheckRouter(svc updatecheck.Service) http.Handler` (GET `/` → `Result` JSON); `Options.UpdateCheck updatecheck.Service`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `pkg/server/updatecheck_test.go`:
+
+```go
+//go:build unit
+
+package server
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeUpdateCheck struct{ r updatecheck.Result }
+
+func (f fakeUpdateCheck) Check(context.Context) updatecheck.Result { return f.r }
+
+func TestUpdateCheckEndpoint(t *testing.T) {
+	h := updateCheckRouter(fakeUpdateCheck{r: updatecheck.Result{
+		Current: "v1.2.0", Latest: "v1.3.0", UpdateAvailable: true,
+		ReleaseURL: "https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0",
+	}})
+	res, body := get(t, h, "/")
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Contains(t, body, `"updateAvailable":true`)
+	require.Contains(t, body, `"latest":"v1.3.0"`)
+	require.Contains(t, body, `"releaseUrl":"https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0"`)
+}
+```
+
+(The `get(t, handler, path)` helper is the same one used by `news_test.go` in this package.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test -tags unit ./pkg/server/... -run TestUpdateCheckEndpoint`
+Expected: FAIL — `updateCheckRouter` undefined.
+
+- [ ] **Step 3: Create the router**
+
+Create `pkg/server/updatecheck.go`:
+
+```go
+package server
+
+import (
+	"net/http"
+
+	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
+	"github.com/go-chi/chi/v5"
+)
+
+// updateCheckRouter returns an http.Handler for the /update-check sub-tree.
+// GET / returns whether a newer release is available as JSON.
+func updateCheckRouter(svc updatecheck.Service) http.Handler {
+	r := chi.NewRouter()
+	r.Get("/", func(w http.ResponseWriter, req *http.Request) {
+		writeJSON(w, http.StatusOK, svc.Check(req.Context()))
+	})
+	return r
+}
+```
+
+- [ ] **Step 4: Add the Options field and wire the router**
+
+In `pkg/server/server.go`, add to the `Options` struct (after `News news.Service`):
+
+```go
+	UpdateCheck  updatecheck.Service
+```
+
+Add the import `"github.com/diagridio/dev-dashboard/pkg/updatecheck"` to `server.go`. Then update the `apiRouter(...)` call at line 48 to pass it (append the last arg):
+
+```go
+		router.Mount("/api", apiRouter(opts.Version, opts.Apps, opts.ContainerLogs, opts.Backend, opts.Stores, opts.Resources, opts.News, opts.ControlPlane, opts.UpdateCheck))
+```
+
+In `pkg/server/api.go`, add the import `"github.com/diagridio/dev-dashboard/pkg/updatecheck"`, extend the signature, and mount the route:
+
+```go
+func apiRouter(v version.Info, apps discovery.Service, containerLogs func(context.Context, string) (<-chan string, error), backend WorkflowBackend, stores StoreRegistry, res resources.Service, newsSvc news.Service, cp controlplane.Manager, uc updatecheck.Service) http.Handler {
+```
+
+After the `/news` mount (line 97), add:
+
+```go
+	r.Mount("/update-check", updateCheckRouter(uc))
+```
+
+- [ ] **Step 5: Update the other `apiRouter` call sites in tests**
+
+Append `, fakeUpdateCheck{}` as the final argument at each:
+- `pkg/server/api_test.go:16` and `:30`
+- `pkg/server/statestores_test.go:60`
+- `pkg/server/workflows_test.go:243` and `:254`
+
+Example for `api_test.go:16`:
+
+```go
+	srv := httptest.NewServer(apiRouter(version.Info{Version: "test"}, newFakeApps(), nil, newFakeBackend(fakeWF{}), nil, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{}))
+```
+
+- [ ] **Step 6: Run the server tests to verify they pass**
+
+Run: `go test -tags unit ./pkg/server/...`
+Expected: PASS (new endpoint test + all existing).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/server
+git commit -s -m "feat(server): add GET /api/update-check endpoint"
+```
+
+---
+
+## Task 5: CLI notice formatting
+
+Pure, testable notice functions (no spinner, no network).
+
+**Files:**
+- Create: `cmd/update_notice.go`
+- Test: `cmd/update_notice_test.go`
+
+**Interfaces:**
+- Consumes: `updatecheck.Result` (Task 3).
+- Produces:
+  - `func formatUpdateNotice(current, latest string) string` — the two-line notice, with a trailing newline.
+  - `func printUpdateNotice(w io.Writer, r updatecheck.Result)` — writes the notice iff `r.UpdateAvailable`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/update_notice_test.go`:
+
+```go
+//go:build unit
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatUpdateNotice(t *testing.T) {
+	got := formatUpdateNotice("v1.2.0", "v1.3.0")
+	require.Equal(t,
+		"A new version of the Dapr Dev Dashboard is available: v1.2.0 → v1.3.0\n"+
+			"Run `dev-dashboard update` to upgrade.\n",
+		got)
+}
+
+func TestPrintUpdateNoticeWhenAvailable(t *testing.T) {
+	var buf bytes.Buffer
+	printUpdateNotice(&buf, updatecheck.Result{Current: "v1.2.0", Latest: "v1.3.0", UpdateAvailable: true})
+	require.Contains(t, buf.String(), "v1.2.0 → v1.3.0")
+	require.Contains(t, buf.String(), "dev-dashboard update")
+}
+
+func TestPrintUpdateNoticeSuppressedWhenNotAvailable(t *testing.T) {
+	var buf bytes.Buffer
+	printUpdateNotice(&buf, updatecheck.Result{Current: "v1.3.0", Latest: "v1.3.0", UpdateAvailable: false})
+	require.Empty(t, buf.String())
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test -tags unit ./cmd/... -run "UpdateNotice"`
+Expected: FAIL — `formatUpdateNotice` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `cmd/update_notice.go`:
+
+```go
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
+)
+
+// formatUpdateNotice renders the two-line "new version available" notice.
+func formatUpdateNotice(current, latest string) string {
+	return fmt.Sprintf(
+		"A new version of the Dapr Dev Dashboard is available: %s → %s\n"+
+			"Run `dev-dashboard update` to upgrade.\n",
+		current, latest)
+}
+
+// printUpdateNotice writes the notice to w when an update is available; it writes
+// nothing otherwise.
+func printUpdateNotice(w io.Writer, r updatecheck.Result) {
+	if !r.UpdateAvailable {
+		return
+	}
+	fmt.Fprint(w, formatUpdateNotice(r.Current, r.Latest))
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test -tags unit ./cmd/... -run "UpdateNotice"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/update_notice.go cmd/update_notice_test.go
+git commit -s -m "feat(cmd): add update-notice formatting"
+```
+
+---
+
+## Task 6: Wire the startup check into `runServe`
+
+Build the shared service, announce at startup with a spinner, and pass the same instance to the server.
+
+**Files:**
+- Modify: `cmd/update_notice.go` (add `maybeAnnounceUpdate`)
+- Modify: `cmd/root.go` (imports; build service; announce; pass into deps)
+- Modify: `cmd/serve.go:22-38` (`serveDeps.UpdateCheck`), `:89-101` (`assembleOptions`)
+- Modify: `cmd/serve_test.go` (propagation test)
+- Modify: `go.mod` / `go.sum` (promote `briandowns/spinner`, `mattn/go-isatty` to direct via `go mod tidy`)
+
+**Interfaces:**
+- Consumes: `updatecheck.New`, `updatecheck.Service`, `updatecheck.IsReleaseVersion` (Tasks 2-3); `printUpdateNotice` (Task 5).
+- Produces: `func maybeAnnounceUpdate(ctx context.Context, uc updatecheck.Service, current string)`; `serveDeps.UpdateCheck updatecheck.Service`.
+
+- [ ] **Step 1: Write the failing test (deps propagation)**
+
+Add to `cmd/serve_test.go` (it already has `//go:build unit` and is `package cmd`):
+
+```go
+func TestAssembleOptionsPropagatesUpdateCheck(t *testing.T) {
+	uc := updatecheck.New(nil, "https://api.github.com", "diagridio/dev-dashboard", "1.2.0", time.Hour)
+	opts, closers := assembleOptions(context.Background(), serveDeps{
+		Apps:        newStaticApps(nil),
+		UpdateCheck: uc,
+	}, nil)
+	for _, c := range closers {
+		defer func(c func() error) { _ = c() }(c)
+	}
+	require.Same(t, uc, opts.UpdateCheck)
+}
+```
+
+Add imports as needed to `serve_test.go`: `"context"`, `"time"`, `"github.com/diagridio/dev-dashboard/pkg/updatecheck"`, and `"github.com/stretchr/testify/require"` if not already present. Use the package's existing apps test double for `Apps`; if the helper is named differently than `newStaticApps`, substitute the existing one (grep `serve_test.go` for how other tests construct `serveDeps.Apps`) — a nil-tolerant fake is required because `assembleOptions` calls `Apps.List`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test -tags unit ./cmd/... -run TestAssembleOptionsPropagatesUpdateCheck`
+Expected: FAIL — `serveDeps.UpdateCheck` / `Options.UpdateCheck` undefined.
+
+- [ ] **Step 3: Add `UpdateCheck` to `serveDeps` and `assembleOptions`**
+
+In `cmd/serve.go`, add the import `"github.com/diagridio/dev-dashboard/pkg/updatecheck"`, add a field to `serveDeps` (after `TelemetryEnabled bool`):
+
+```go
+	// UpdateCheck is the shared latest-release checker; also used by runServe to
+	// print the startup notice, so the server reuses its warmed cache.
+	UpdateCheck updatecheck.Service
+```
+
+In the returned `server.Options` literal (after `TelemetryEnabled: deps.TelemetryEnabled,`), add:
+
+```go
+		UpdateCheck:      deps.UpdateCheck,
+```
+
+- [ ] **Step 4: Run the propagation test to verify it passes**
+
+Run: `go test -tags unit ./cmd/... -run TestAssembleOptionsPropagatesUpdateCheck`
+Expected: PASS.
+
+- [ ] **Step 5: Add `maybeAnnounceUpdate`**
+
+Append to `cmd/update_notice.go` (add imports `"context"`, `"os"`, `"time"`, `"github.com/briandowns/spinner"`, `"github.com/mattn/go-isatty"`):
+
+```go
+// maybeAnnounceUpdate runs the startup version check and prints the notice to
+// stdout as the first output. For dev/source builds it does nothing (no spinner,
+// no network call). On a TTY it shows a spinner while the (2s-bounded) check runs.
+func maybeAnnounceUpdate(ctx context.Context, uc updatecheck.Service, current string) {
+	if uc == nil || !updatecheck.IsReleaseVersion(current) {
+		return
+	}
+	cctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	var sp *spinner.Spinner
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		sp = spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithWriter(os.Stdout))
+		sp.Suffix = " Checking for new versions…"
+		sp.Start()
+	}
+	r := uc.Check(cctx)
+	if sp != nil {
+		sp.Stop()
+	}
+	printUpdateNotice(os.Stdout, r)
+}
+```
+
+- [ ] **Step 6: Build the service and announce in `runServe`**
+
+In `cmd/root.go`, add the import `"github.com/diagridio/dev-dashboard/pkg/updatecheck"`. In `runServe`, after the `telemetry := telemetryEnabled(os.Getenv)` line (root.go:95) build the service:
+
+```go
+	updateCheck := updatecheck.New(&http.Client{Timeout: 5 * time.Second}, "https://api.github.com", "diagridio/dev-dashboard", version.Get().Version, time.Hour)
+```
+
+Add `UpdateCheck: updateCheck,` to the `serveDeps{...}` literal passed to `assembleOptions` (alongside `TelemetryEnabled: telemetry,`).
+
+Then, immediately before the existing `fmt.Printf("Diagrid Dev Dashboard is running → %s\n", url)` line (root.go:116), add:
+
+```go
+	maybeAnnounceUpdate(ctx, updateCheck, version.Get().Version)
+```
+
+- [ ] **Step 7: Tidy modules to promote the new direct dependencies**
+
+Run: `go mod tidy`
+Expected: `github.com/briandowns/spinner` and `github.com/mattn/go-isatty` move to the direct `require` block; no unrelated churn.
+
+- [ ] **Step 8: Build and run the full Go unit suite**
+
+Run: `go build ./... && go test -tags unit -race ./cmd/... ./pkg/updatecheck/... ./pkg/server/... ./pkg/selfupdate/...`
+Expected: build succeeds; all PASS.
+
+- [ ] **Step 9: Manually sanity-check the notice (optional but recommended)**
+
+Run: `go build -o bin/dev-dashboard.exe . ; ./bin/dev-dashboard.exe --no-open`
+Expected on a `dev` build: no spinner, no notice (dev is skipped), then the normal "running →" line. (A real notice only appears from a released, older binary.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add cmd go.mod go.sum
+git commit -s -m "feat(cmd): announce available updates on startup"
+```
+
+---
+
+## Task 7: Web `useUpdateCheck` hook
+
+**Files:**
+- Modify: `web/src/hooks/useMeta.ts`
+- Test: `web/src/hooks/useMeta.test.tsx`
+
+**Interfaces:**
+- Produces:
+  - `interface UpdateInfo { current: string; latest: string; updateAvailable: boolean; releaseUrl: string }`
+  - `function useUpdateCheck(): UseQueryResult<UpdateInfo>` — polls `/update-check` every 5 min.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web/src/hooks/useMeta.test.tsx` (import `useUpdateCheck` alongside `useVersion`):
+
+```ts
+describe('useUpdateCheck', () => {
+  beforeEach(() => {
+    server.use(
+      http.get('/api/update-check', () =>
+        HttpResponse.json({
+          current: 'v1.2.0',
+          latest: 'v1.3.0',
+          updateAvailable: true,
+          releaseUrl: 'https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0',
+        }),
+      ),
+    )
+  })
+
+  it('returns update info from /api/update-check', async () => {
+    const { result } = renderHook(() => useUpdateCheck(), { wrapper: makeWrapper() })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual({
+      current: 'v1.2.0',
+      latest: 'v1.3.0',
+      updateAvailable: true,
+      releaseUrl: 'https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0',
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd web; npx vitest run src/hooks/useMeta.test.tsx`
+Expected: FAIL — `useUpdateCheck` is not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `web/src/hooks/useMeta.ts`:
+
+```ts
+/** Shape returned by GET /api/update-check */
+export interface UpdateInfo {
+  current: string
+  latest: string
+  updateAvailable: boolean
+  releaseUrl: string
+}
+
+/** Fetch update availability from /api/update-check. Refreshes every 5 min. */
+export function useUpdateCheck() {
+  return useQuery<UpdateInfo>({
+    queryKey: ['update-check'],
+    queryFn: () => fetchJSON<UpdateInfo>('/update-check'),
+    staleTime: 5 * 60 * 1000,
+    refetchInterval: 5 * 60 * 1000,
+  })
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd web; npx vitest run src/hooks/useMeta.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/hooks/useMeta.ts web/src/hooks/useMeta.test.tsx
+git commit -s -m "feat(web): add useUpdateCheck hook"
+```
+
+---
+
+## Task 8: Web UI indicator (expanded badge + collapsed dot)
+
+Render the indicator in both sidebar states, and apply the `update-available` class on `.app`.
+
+**Files:**
+- Modify: `web/src/components/ResourcesSidebar.tsx`
+- Modify: `web/src/components/ResourcesSidebar.test.tsx`
+- Modify: `web/src/App.tsx`
+- Modify: `web/src/App.test.tsx`
+- Modify: `web/src/styles/theme.css`
+
+**Interfaces:**
+- Consumes: `useUpdateCheck`, `UpdateInfo` (Task 7).
+- Produces: `ResourcesSidebarProps` gains `onUpdateAvailableChange: (v: boolean) => void` (mirrors `onHasNewChange`).
+
+- [ ] **Step 1: Write the failing tests**
+
+First, add a default `/api/update-check` mock so existing tests don't error (recall `onUnhandledRequest: 'error'`). In `web/src/components/ResourcesSidebar.test.tsx`, extend the `beforeEach` (line 45-49) to add:
+
+```ts
+  server.use(
+    http.get('/api/update-check', () =>
+      HttpResponse.json({ current: 'v1.2.3', latest: 'v1.2.3', updateAvailable: false, releaseUrl: '' }),
+    ),
+  )
+```
+
+Update `SidebarWrapper` (line 21-34) to own an `updateAvailable` state and apply the class, and pass the new prop:
+
+```tsx
+function SidebarWrapper({ initialCollapsed = false }: { initialCollapsed?: boolean }) {
+  const [collapsed, setCollapsed] = useState(initialCollapsed)
+  const [hasNew, setHasNew] = useState(false)
+  const [updateAvailable, setUpdateAvailable] = useState(false)
+  return (
+    <div
+      className={['app', collapsed ? 'collapsed' : '', hasNew ? 'has-new' : '', updateAvailable ? 'update-available' : '']
+        .filter(Boolean)
+        .join(' ')}
+      data-theme="light"
+    >
+      <ResourcesSidebar
+        collapsed={collapsed}
+        onCollapsedChange={setCollapsed}
+        onHasNewChange={setHasNew}
+        onUpdateAvailableChange={setUpdateAvailable}
+      />
+    </div>
+  )
+}
+```
+
+Also add `onUpdateAvailableChange={() => undefined}` to the `renderWithSpy` wrapper (line 351-364).
+
+Then add a new describe block:
+
+```tsx
+describe('ResourcesSidebar update indicator', () => {
+  const withUpdate = () =>
+    server.use(
+      http.get('/api/update-check', () =>
+        HttpResponse.json({
+          current: 'v1.2.0',
+          latest: 'v1.3.0',
+          updateAvailable: true,
+          releaseUrl: 'https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0',
+        }),
+      ),
+    )
+
+  it('shows an Update available link in the footer when an update exists', async () => {
+    withUpdate()
+    renderSidebar()
+    const link = await screen.findByRole('link', { name: /Update available/i })
+    expect(link).toHaveAttribute('href', 'https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('shows no update link when up to date', async () => {
+    // default beforeEach mock has updateAvailable:false
+    renderSidebar()
+    await screen.findByRole('link', { name: 'Diagrid' })
+    expect(screen.queryByRole('link', { name: /Update available/i })).not.toBeInTheDocument()
+  })
+
+  it('renders the collapsed update indicator linking to the release', async () => {
+    withUpdate()
+    renderSidebar({ initialCollapsed: true })
+    const link = await screen.findByRole('link', { name: /version .* is available/i })
+    expect(link).toHaveAttribute('href', 'https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0')
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web; npx vitest run src/components/ResourcesSidebar.test.tsx`
+Expected: FAIL — the new prop / links don't exist yet.
+
+- [ ] **Step 3: Implement the sidebar changes**
+
+In `web/src/components/ResourcesSidebar.tsx`:
+
+Add `useUpdateCheck` to the existing import from `../hooks/useMeta`:
+
+```tsx
+import { useVersion, useUpdateCheck } from '../hooks/useMeta'
+```
+
+Extend the props interface:
+
+```tsx
+interface ResourcesSidebarProps {
+  collapsed: boolean
+  onCollapsedChange: (v: boolean) => void
+  onHasNewChange: (v: boolean) => void
+  onUpdateAvailableChange: (v: boolean) => void
+}
+```
+
+Update the function signature and add the hook + bubble-up (near the `useNews`/`useVersion` calls, ~line 159-168):
+
+```tsx
+export function ResourcesSidebar({ collapsed, onCollapsedChange, onHasNewChange, onUpdateAvailableChange }: ResourcesSidebarProps) {
+  const [seen, setSeen] = useState<Set<string>>(() => getSeen())
+  const { data: news } = useNews()
+  const { data: versionData } = useVersion()
+  const { data: update } = useUpdateCheck()
+
+  const updateAvailable = update?.updateAvailable ?? false
+  useEffect(() => {
+    onUpdateAvailableChange(updateAvailable)
+  }, [updateAvailable, onUpdateAvailableChange])
+```
+
+In the collapsed vertical panel (`.sbvert`, ~line 229-248), add the indicator as the first child inside the div, before the bell button:
+
+```tsx
+      <div className="sbvert" data-testid="sidebar-collapsed-label">
+        {updateAvailable && update && (
+          <a
+            className="updot"
+            id="update-v"
+            href={update.releaseUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`Version ${update.latest} is available — update`}
+            title={`${update.latest} is available — update`}
+            onClick={() => trackAction('update_click', { placement: 'collapsed', latest: update.latest })}
+          />
+        )}
+```
+
+In the footer (`.sbfoot`, ~line 250-261), add the badge inside the "Powered by" `.pw` span, after the version text:
+
+```tsx
+          {' · '}v{version}
+          {updateAvailable && update && (
+            <>
+              {'  '}
+              <a
+                className="upbadge"
+                href={update.releaseUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={`${update.latest} is available`}
+                onClick={() => trackAction('update_click', { placement: 'footer', latest: update.latest })}
+              >
+                <span className="updot" aria-hidden="true" /> Update available <span className="ext">↗</span>
+              </a>
+            </>
+          )}
+```
+
+- [ ] **Step 4: Wire `App.tsx`**
+
+In `web/src/App.tsx`, add state and class, and pass the prop:
+
+```tsx
+  const [hasNew, setHasNew] = useState(false)
+  const [updateAvailable, setUpdateAvailable] = useState(false)
+```
+
+```tsx
+  const appClass = ['app', collapsed ? 'collapsed' : '', hasNew ? 'has-new' : '', updateAvailable ? 'update-available' : '']
+    .filter(Boolean)
+    .join(' ')
+```
+
+```tsx
+        <ResourcesSidebar
+          collapsed={collapsed}
+          onCollapsedChange={setCollapsed}
+          onHasNewChange={setHasNew}
+          onUpdateAvailableChange={setUpdateAvailable}
+        />
+```
+
+- [ ] **Step 5: Add the default `/api/update-check` mock to `App.test.tsx`**
+
+In `web/src/App.test.tsx`, add to the `beforeEach` `server.use(...)` block (line 31-40):
+
+```ts
+    http.get('/api/update-check', () =>
+      HttpResponse.json({ current: '9.9.9', latest: '9.9.9', updateAvailable: false, releaseUrl: '' }),
+    ),
+```
+
+- [ ] **Step 6: Add the CSS**
+
+In `web/src/styles/theme.css`, after the bell rules (~line 109), add:
+
+```css
+/* Update-available indicator (footer badge + collapsed dot) */
+.upbadge { color: var(--primary); text-decoration: none; white-space: nowrap; display: inline-flex; align-items: center; gap: 4px; }
+.upbadge:hover { text-decoration: underline; }
+.updot { width: 7px; height: 7px; border-radius: 50%; background: var(--primary); display: inline-block; }
+.sbvert #update-v { display: none; }
+.app.update-available.collapsed #update-v { display: inline-block; margin-bottom: 8px; }
+```
+
+- [ ] **Step 7: Run the web tests to verify they pass**
+
+Run: `cd web; npx vitest run src/components/ResourcesSidebar.test.tsx src/App.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 8: Run the full web suite + lint**
+
+Run: `cd web; npm test; npm run lint`
+Expected: all PASS (no unhandled-request errors, no lint errors). If any other suite errors on an unhandled `/api/update-check` request, add the same `updateAvailable:false` default mock to that suite's `beforeEach`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/src/components/ResourcesSidebar.tsx web/src/components/ResourcesSidebar.test.tsx web/src/App.tsx web/src/App.test.tsx web/src/styles/theme.css
+git commit -s -m "feat(web): show update-available indicator in Resources panel"
+```
+
+---
+
+## Task 9: Documentation
+
+Document the startup notice and the indicator.
+
+**Files:**
+- Modify: `README.md` (the "Updating the dashboard" section)
+- Modify: `ARCHITECTURE.md` (data-sources list — near the News entry)
+
+- [ ] **Step 1: Update README**
+
+In `README.md`, at the start of the "Updating the dashboard" section (after line 91's heading), add:
+
+```markdown
+On startup the dashboard checks GitHub for a newer release. If one exists, it prints
+a notice as the first line of output and the web UI shows an **Update available**
+indicator next to the version number in the Resources panel. The check is best-effort:
+it is skipped for source/dev builds and fails silently when offline.
+```
+
+- [ ] **Step 2: Update ARCHITECTURE**
+
+In `ARCHITECTURE.md`, find the bullet describing the News endpoint (search for "News" / "product feed") and add a sibling bullet:
+
+```markdown
+- **Update check** (`pkg/updatecheck`) — resolves the latest GitHub release (reusing
+  `pkg/selfupdate`'s resolver), compares it to the running version with semver, and
+  caches the result. Consumed by the CLI startup notice and by `GET /api/update-check`
+  for the web indicator. Fails silent; skipped for `dev`/source builds.
+```
+
+(If `ARCHITECTURE.md` has a component/endpoint table rather than a bullet list, add a matching row instead, following the surrounding format.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md ARCHITECTURE.md
+git commit -s -m "docs: document version-update awareness"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Startup notice as first line, with version + update command → Tasks 5, 6 (notice copy verbatim in Global Constraints).
+- Spinner "Checking for new versions…" + TTY handling + 2s timeout → Task 6 (`maybeAnnounceUpdate`).
+- Skip for dev/invalid → Task 2 (`IsReleaseVersion`), Task 6 guard.
+- Shared backend service, reuse `selfupdate` resolver → Tasks 1, 3, 6 (one instance built in `runServe`, passed to server).
+- Separate `/api/update-check` endpoint → Task 4.
+- Web hook (5-min poll) → Task 7.
+- Expanded footer badge + collapsed indicator, `update-available` class → Task 8.
+- No opt-out, fail-silent, prerelease-excluded, normalization → Global Constraints + Tasks 2, 3 (`/releases/latest` via `ResolveLatest`, `withV`).
+- Tests across Go unit, server, cmd, web → Tasks 2-8.
+- Docs → Task 9.
+
+**2. Placeholder scan:** No TBD/TODO; every code step contains complete code. The one conditional instruction (Task 6 Step 1 apps double, Task 8 Step 8 extra mocks) gives an explicit grep/action, not a vague "handle it".
+
+**3. Type consistency:** `Result{Current, Latest, UpdateAvailable, ReleaseURL}` with JSON `current/latest/updateAvailable/releaseUrl` is used identically in Go (Tasks 2-6) and TS `UpdateInfo` (Task 7) and the web mocks (Tasks 7-8). `Service.Check(ctx) Result`, `updateCheckRouter(svc)`, `Options.UpdateCheck`, `apiRouter(..., uc)`, `serveDeps.UpdateCheck`, `maybeAnnounceUpdate(ctx, uc, current)`, `formatUpdateNotice(current, latest)`, `printUpdateNotice(w, r)`, `useUpdateCheck()`, and the `onUpdateAvailableChange` prop are consistent across their defining and consuming tasks.

--- a/docs/superpowers/specs/2026-07-08-version-update-awareness-design.md
+++ b/docs/superpowers/specs/2026-07-08-version-update-awareness-design.md
@@ -1,0 +1,186 @@
+# Version-update awareness (startup notice + web indicator)
+
+**Status:** Approved design — ready for implementation planning
+**Date:** 2026-07-08
+
+## Summary
+
+Make it obvious when a newer dashboard release exists. On startup the CLI resolves
+the latest GitHub release, compares it to the running version, and — if a newer one
+exists — prints a notice as the first output, with the upgrade command. The web UI
+shows a clickable "Update available" indicator next to the version number in the
+Resources panel, visible whether the panel is expanded or collapsed.
+
+Both surfaces read from **one shared backend service**, so the web indicator reuses
+the startup check's cached result and no duplicate GitHub calls are made.
+
+```
+A new version of the Dapr Dev Dashboard is available: v1.2.0 → v1.3.0
+Run `dev-dashboard update` to upgrade.
+
+Diagrid Dev Dashboard is running → http://127.0.0.1:9090/
+```
+
+## Goals
+
+- A prominent, first-line startup notice when a newer release is available, naming
+  the current and latest versions and the exact upgrade command.
+- A visual indicator in the web UI next to the version number, in both the expanded
+  and collapsed Resources panel.
+- Reuse the existing self-update GitHub release resolution; no bespoke duplicate.
+- Fail silent and fast: offline, rate-limited, or errored checks produce no notice,
+  no badge, and negligible startup delay.
+
+## Non-goals
+
+- **Auto-update.** This is read-only awareness. Upgrading remains the explicit,
+  user-initiated `dev-dashboard update` command. (This revisits — narrowly — the
+  self-update spec's "no background update checks" non-goal: a lightweight read-only
+  *check* is now in scope; automatic *installation* is still not.)
+- **Opt-out.** No env var or flag to disable the check. It already fails silently and
+  fast, so there is no hard blocker; suppressing the GitHub call on principle is out
+  of scope.
+- **Prerelease awareness.** The check uses GitHub's `/releases/latest`, which excludes
+  prereleases by design.
+- **Package-manager installs.** As with `update`, users on Homebrew/Scoop/winget (when
+  those exist) upgrade through the package manager; the notice still informs them a
+  newer version exists.
+
+## Architecture
+
+One shared backend service resolves and caches the latest release. The CLI calls it
+once at startup (blocking, with a spinner); the HTTP server reuses the same instance
+to answer a web endpoint the SPA polls. A `dev`/source build has an invalid semver
+version, so it is treated as "no update" everywhere — developers never see the notice
+or badge.
+
+```
+                    ┌─────────────────────────────┐
+   startup (once) → │  pkg/updatecheck.Service     │ → GitHub /releases/latest
+   GET /api/…     → │  (cached, TTL + neg-cache)   │   (via selfupdate.ResolveLatest)
+                    └─────────────────────────────┘
+                              │ Result{Current, Latest, UpdateAvailable, ReleaseURL}
+                    ┌─────────┴──────────┐
+              CLI notice           /api/update-check → web badge
+```
+
+## Backend — `pkg/updatecheck` (new package)
+
+A small, isolated domain package following the `pkg/news` pattern (its own
+`service.go` + response type, no dependency on `cmd/`).
+
+- **`Result`** — JSON-tagged struct:
+  ```go
+  type Result struct {
+      Current         string `json:"current"`
+      Latest          string `json:"latest"`
+      UpdateAvailable bool   `json:"updateAvailable"`
+      ReleaseURL      string `json:"releaseUrl"`
+  }
+  ```
+- **`Service` interface** — `Check(ctx context.Context) Result`. A caching
+  implementation with a ~1h positive TTL and short negative-cache window (mirroring
+  `pkg/news`), so the web's polling never hammers GitHub and a failed fetch is not
+  re-probed on every request. A failed or errored fetch yields
+  `UpdateAvailable: false` and is never surfaced as an error to callers.
+- **Comparison** — `golang.org/x/mod/semver` (already in the module graph):
+  `UpdateAvailable = IsValid(cur) && IsValid(latest) && Compare(latest, cur) > 0`.
+  Both versions are normalized to a leading `v` first. An invalid current version
+  (e.g. `dev`) → `false`.
+- **Latest resolution** — reuse the existing GitHub `/releases/latest` logic by
+  **exporting `selfupdate.ResolveLatest`** (rename the current unexported
+  `resolveLatest`). `updatecheck` imports `selfupdate` for this one call rather than
+  duplicating the request/parse.
+- **`ReleaseURL`** — `https://github.com/diagridio/dev-dashboard/releases/tag/<latest>`,
+  pointing at the new release's own notes.
+
+## CLI startup (`cmd/root.go`, `runServe`)
+
+Before the existing "running →" line:
+
+1. If the current version is `dev`/invalid semver → skip entirely (no spinner, no
+   network call).
+2. Otherwise run the check:
+   - If stdout is a TTY (`github.com/mattn/go-isatty` / `golang.org/x/term`, both in
+     the module graph), show a `github.com/briandowns/spinner` labeled
+     **"Checking for new versions…"**; run `Check` under a **2s timeout** context;
+     stop and clear the spinner line.
+   - When piped/redirected (non-TTY), skip the spinner animation but still run the
+     same bounded check.
+3. If `UpdateAvailable`, print the two-line notice; then continue with the existing
+   "running →" and telemetry lines. On up-to-date / error / offline, print nothing.
+
+The notice text is produced by a pure, unit-testable helper
+`formatUpdateNotice(current, latest string) string` that the startup path writes to
+an `io.Writer`. The same `updatecheck.Service` instance built here is passed into the
+serve options so the HTTP layer reuses its cache (no second GitHub call).
+
+Notice format:
+
+```
+A new version of the Dapr Dev Dashboard is available: <current> → <latest>
+Run `dev-dashboard update` to upgrade.
+```
+
+## Web — API
+
+- **New endpoint `GET /api/update-check`** returning the `Result` JSON. Wired through
+  the server options like `newsSvc` (`apiRouter` gains an `updatecheck.Service`
+  parameter). Kept **separate from `GET /api/version`**, which stays pure static build
+  info; update-availability is dynamic and network-derived.
+
+## Web — UI
+
+Data flows through one source: `App.tsx` already owns the sidebar `collapsed` state
+and applies the `has-new` class from the news hook. It gains a new `useUpdateCheck`
+hook result, applies an `update-available` class to `.app` (exactly as `has-new` is
+applied today), and passes the result to `ResourcesSidebar` so both the expanded and
+collapsed renders read from it.
+
+- **`useUpdateCheck` hook** (`web/src/hooks/useMeta.ts`) — polls `/api/update-check`
+  (5-minute interval; the data is stable). Returns `{ current, latest, updateAvailable,
+  releaseUrl }`.
+
+- **Expanded state — `.sbfoot`:** when `updateAvailable`, render a clickable badge next
+  to `v{version}`: `● Update available ↗`, linking to `releaseUrl`
+  (`target="_blank" rel="noopener noreferrer"`), tooltip "v1.3.0 is available", with a
+  `trackAction` telemetry call on click. Nothing rendered when up to date.
+
+- **Collapsed state — `.sbvert`:** `.app.collapsed .sbfoot` is `display: none`, so the
+  footer badge is hidden when collapsed. Add a parallel indicator in the vertical strip,
+  mirroring the existing `#bell-v` / `has-new` mechanism:
+  - A small update dot/icon (e.g. `#update-v`) in `.sbvert`, a link to `releaseUrl`
+    (`target="_blank"`) with `aria-label`/tooltip "v1.3.0 is available — update".
+  - Shown only when collapsed **and** an update is available, via a new
+    `theme.css` rule `.app.update-available.collapsed #update-v { display: inline-flex }`
+    alongside the existing bell rules, plus the dot styling (per `web/STYLEGUIDE.md`).
+
+This keeps the indicator visible whether the panel is open or closed.
+
+## Testing
+
+- **Go unit (`pkg/updatecheck`)** — table-driven comparison (dev/invalid, equal, newer,
+  older); caching + negative caching behavior; release-URL shape. GitHub API served via
+  `httptest`.
+- **Go unit (`cmd`)** — `formatUpdateNotice` output; startup path writing to a buffer
+  with a stub `updatecheck.Service` (asserts the notice is printed when an update exists
+  and suppressed otherwise, including the `dev`-version skip).
+- **`pkg/selfupdate`** — existing tests updated for the exported `ResolveLatest` (behavior
+  unchanged).
+- **Server integration** — `/api/update-check` returns the expected JSON from a stub
+  service.
+- **Web (`ResourcesSidebar.test.tsx`)** — expanded badge visible and linking to
+  `releaseUrl` when available, absent otherwise; collapsed-state indicator visible and
+  linking to `releaseUrl` when an update is available and the panel is collapsed, absent
+  otherwise.
+
+## Edge cases
+
+- **Offline / rate-limited / GitHub error** → `Check` returns `UpdateAvailable: false`;
+  no notice, no badge. Negative-cached to avoid re-probing on every request.
+- **`dev` / source build** → invalid semver → no notice, no badge, no network call at
+  startup.
+- **Version normalization** → both current and latest normalized to a leading `v` before
+  `semver.Compare`.
+- **Startup latency** → bounded by the 2s check timeout; a hung/slow GitHub call cannot
+  delay startup beyond that.

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,17 @@ go 1.26.4
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0
+	github.com/briandowns/spinner v1.19.0
 	github.com/dapr/cli v1.18.0
 	github.com/dapr/components-contrib v1.18.0
 	github.com/dapr/durabletask-go v0.12.1
 	github.com/dapr/kit v0.18.1
 	github.com/go-chi/chi/v5 v5.3.0
+	github.com/mattn/go-isatty v0.0.20
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/mod v0.35.0
 	google.golang.org/protobuf v1.36.11
 	sigs.k8s.io/yaml v1.5.0
 )
@@ -54,7 +57,6 @@ require (
 	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/briandowns/spinner v1.19.0 // indirect
 	github.com/bufbuild/protocompile v0.6.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -134,7 +136,6 @@ require (
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mikeee/aws_credential_helper v0.0.1-alpha.2 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
@@ -199,7 +200,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
-	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/pkg/selfupdate/fetch_test.go
+++ b/pkg/selfupdate/fetch_test.go
@@ -39,7 +39,7 @@ func TestResolveLatest(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	v, err := resolveLatest(context.Background(), srv.Client(), srv.URL, "diagridio/dev-dashboard")
+	v, err := ResolveLatest(context.Background(), srv.Client(), srv.URL, "diagridio/dev-dashboard")
 	require.NoError(t, err)
 	require.Equal(t, "v1.2.0", v)
 	require.Equal(t, "/repos/diagridio/dev-dashboard/releases/latest", gotPath)
@@ -87,7 +87,7 @@ func TestResolveLatestEmptyTag(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := resolveLatest(context.Background(), srv.Client(), srv.URL, "diagridio/dev-dashboard")
+	_, err := ResolveLatest(context.Background(), srv.Client(), srv.URL, "diagridio/dev-dashboard")
 	require.Error(t, err)
 	require.False(t, errors.Is(err, errNotFound))
 }

--- a/pkg/selfupdate/resolve.go
+++ b/pkg/selfupdate/resolve.go
@@ -26,10 +26,10 @@ func versionsEqual(a, b string) bool {
 		strings.TrimPrefix(strings.TrimSpace(b), "v")
 }
 
-// resolveLatest queries the GitHub releases API for repo's latest tag_name and
+// ResolveLatest queries the GitHub releases API for repo's latest tag_name and
 // returns it normalized (with a leading "v"). The /releases/latest endpoint
 // excludes prereleases by design, so this always resolves to the latest stable release.
-func resolveLatest(ctx context.Context, client *http.Client, apiBase, repo string) (string, error) {
+func ResolveLatest(ctx context.Context, client *http.Client, apiBase, repo string) (string, error) {
 	url := fmt.Sprintf("%s/repos/%s/releases/latest", apiBase, repo)
 	body, err := httpGet(ctx, client, url)
 	if err != nil {

--- a/pkg/selfupdate/selfupdate.go
+++ b/pkg/selfupdate/selfupdate.go
@@ -65,7 +65,7 @@ func (u *Updater) Run(ctx context.Context, requested string) (Result, error) {
 	var target string
 	if requested == "" {
 		fmt.Fprintln(u.Out, "resolving latest…")
-		v, err := resolveLatest(ctx, u.HTTP, u.APIBase, u.Repo)
+		v, err := ResolveLatest(ctx, u.HTTP, u.APIBase, u.Repo)
 		if err != nil {
 			return Result{}, err
 		}

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -13,12 +13,13 @@ import (
 	"github.com/diagridio/dev-dashboard/pkg/metadata"
 	"github.com/diagridio/dev-dashboard/pkg/news"
 	"github.com/diagridio/dev-dashboard/pkg/resources"
+	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
 	"github.com/diagridio/dev-dashboard/pkg/version"
 	"github.com/go-chi/chi/v5"
 )
 
 // apiRouter builds the JSON API surface served under /api.
-func apiRouter(v version.Info, apps discovery.Service, containerLogs func(context.Context, string) (<-chan string, error), backend WorkflowBackend, stores StoreRegistry, res resources.Service, newsSvc news.Service, cp controlplane.Manager) http.Handler {
+func apiRouter(v version.Info, apps discovery.Service, containerLogs func(context.Context, string) (<-chan string, error), backend WorkflowBackend, stores StoreRegistry, res resources.Service, newsSvc news.Service, cp controlplane.Manager, uc updatecheck.Service) http.Handler {
 	r := chi.NewRouter()
 	r.Get("/health", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
@@ -96,6 +97,7 @@ func apiRouter(v version.Info, apps discovery.Service, containerLogs func(contex
 	r.Mount("/resources", resourcesRouter(res, apps))
 	r.Mount("/news", newsRouter(newsSvc))
 	r.Mount("/controlplane", controlPlaneRouter(cp))
+	r.Mount("/update-check", updateCheckRouter(uc))
 	return r
 }
 

--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestHealthEndpoint(t *testing.T) {
-	srv := httptest.NewServer(apiRouter(version.Info{Version: "test"}, newFakeApps(), nil, newFakeBackend(fakeWF{}), nil, fakeResources{}, fakeNews{}, nil))
+	srv := httptest.NewServer(apiRouter(version.Info{Version: "test"}, newFakeApps(), nil, newFakeBackend(fakeWF{}), nil, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{}))
 	t.Cleanup(srv.Close)
 
 	resp, err := http.Get(srv.URL + "/health")
@@ -27,7 +27,7 @@ func TestHealthEndpoint(t *testing.T) {
 }
 
 func TestVersionEndpoint(t *testing.T) {
-	srv := httptest.NewServer(apiRouter(version.Info{Version: "1.2.3", Commit: "abc", Date: "d"}, newFakeApps(), nil, newFakeBackend(fakeWF{}), nil, fakeResources{}, fakeNews{}, nil))
+	srv := httptest.NewServer(apiRouter(version.Info{Version: "1.2.3", Commit: "abc", Date: "d"}, newFakeApps(), nil, newFakeBackend(fakeWF{}), nil, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{}))
 	t.Cleanup(srv.Close)
 
 	resp, err := http.Get(srv.URL + "/version")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/diagridio/dev-dashboard/pkg/discovery"
 	"github.com/diagridio/dev-dashboard/pkg/news"
 	"github.com/diagridio/dev-dashboard/pkg/resources"
+	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
 	"github.com/diagridio/dev-dashboard/pkg/version"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -31,6 +32,7 @@ type Options struct {
 	Resources     resources.Service
 	News          news.Service
 	ControlPlane  controlplane.Manager
+	UpdateCheck   updatecheck.Service
 	// TelemetryEnabled controls whether the served SPA loads Datadog RUM.
 	TelemetryEnabled bool
 }
@@ -45,7 +47,7 @@ func NewRouter(opts Options) http.Handler {
 	r.Use(localhostGuard)
 
 	mount := func(router chi.Router) {
-		router.Mount("/api", apiRouter(opts.Version, opts.Apps, opts.ContainerLogs, opts.Backend, opts.Stores, opts.Resources, opts.News, opts.ControlPlane))
+		router.Mount("/api", apiRouter(opts.Version, opts.Apps, opts.ContainerLogs, opts.Backend, opts.Stores, opts.Resources, opts.News, opts.ControlPlane, opts.UpdateCheck))
 		router.Handle("/*", SPAHandler(opts.DistFS, opts.BasePath, opts.TelemetryEnabled))
 	}
 

--- a/pkg/server/statestores_test.go
+++ b/pkg/server/statestores_test.go
@@ -57,7 +57,7 @@ func (m *mutableStoreRegistry) DeleteStore(id string) error {
 }
 
 func newAPI(stores StoreRegistry) http.Handler {
-	return apiRouter(version.Info{}, nil, nil, newFakeBackend(fakeWF{}), stores, fakeResources{}, fakeNews{}, nil)
+	return apiRouter(version.Info{}, nil, nil, newFakeBackend(fakeWF{}), stores, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{})
 }
 
 func doReq(t *testing.T, h http.Handler, req *http.Request) (*http.Response, string) {

--- a/pkg/server/updatecheck.go
+++ b/pkg/server/updatecheck.go
@@ -1,0 +1,18 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
+	"github.com/go-chi/chi/v5"
+)
+
+// updateCheckRouter returns an http.Handler for the /update-check sub-tree.
+// GET / returns whether a newer release is available as JSON.
+func updateCheckRouter(svc updatecheck.Service) http.Handler {
+	r := chi.NewRouter()
+	r.Get("/", func(w http.ResponseWriter, req *http.Request) {
+		writeJSON(w, http.StatusOK, svc.Check(req.Context()))
+	})
+	return r
+}

--- a/pkg/server/updatecheck_test.go
+++ b/pkg/server/updatecheck_test.go
@@ -1,0 +1,28 @@
+//go:build unit
+
+package server
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeUpdateCheck struct{ r updatecheck.Result }
+
+func (f fakeUpdateCheck) Check(context.Context) updatecheck.Result { return f.r }
+
+func TestUpdateCheckEndpoint(t *testing.T) {
+	h := updateCheckRouter(fakeUpdateCheck{r: updatecheck.Result{
+		Current: "v1.2.0", Latest: "v1.3.0", UpdateAvailable: true,
+		ReleaseURL: "https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0",
+	}})
+	res, body := get(t, h, "/")
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Contains(t, body, `"updateAvailable":true`)
+	require.Contains(t, body, `"latest":"v1.3.0"`)
+	require.Contains(t, body, `"releaseUrl":"https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0"`)
+}

--- a/pkg/server/workflows_test.go
+++ b/pkg/server/workflows_test.go
@@ -240,7 +240,7 @@ func TestStateStoresEndpoint(t *testing.T) {
 	stores := fakeStoreRegistry{stores: []StoreInfo{
 		{ID: "statestore-auto", Name: "statestore", Type: "state.redis", Source: "auto", Active: true, Connection: "localhost:6379"},
 	}}
-	h := apiRouter(version.Info{}, nil, nil, newFakeBackend(fakeWF{}), stores, fakeResources{}, fakeNews{}, nil)
+	h := apiRouter(version.Info{}, nil, nil, newFakeBackend(fakeWF{}), stores, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{})
 	res, body := get(t, h, "/statestores")
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Contains(t, body, `"name":"statestore"`)
@@ -251,7 +251,7 @@ func TestStateStoresEndpoint(t *testing.T) {
 }
 
 func TestStateStoresNilRegistry(t *testing.T) {
-	h := apiRouter(version.Info{}, nil, nil, newFakeBackend(fakeWF{}), nil, fakeResources{}, fakeNews{}, nil)
+	h := apiRouter(version.Info{}, nil, nil, newFakeBackend(fakeWF{}), nil, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{})
 	res, body := get(t, h, "/statestores")
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Contains(t, body, `[]`)

--- a/pkg/updatecheck/service.go
+++ b/pkg/updatecheck/service.go
@@ -53,6 +53,14 @@ func New(client *http.Client, apiBase, repo, current string, ttl time.Duration) 
 // error the last-good result is preserved (zero Result if none) and the failure
 // is negatively cached so the endpoint is not re-probed on every request.
 func (s *service) Check(ctx context.Context) Result {
+	// Dev/source builds have no comparable version: skip the network entirely
+	// (mirrors the CLI startup guard so the HTTP endpoint stays silent too).
+	if !IsReleaseVersion(s.current) {
+		return Result{Current: s.current}
+	}
+
+	// The mutex is held across the network call below: the cache is warmed at
+	// startup, so a waiter is bounded by the http.Client's 5s timeout.
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -64,6 +72,8 @@ func (s *service) Check(ctx context.Context) Result {
 		return s.cached
 	}
 
+	// On error the failure is negatively cached, so the endpoint may report
+	// "no update" for up to negTTL before retrying.
 	latest, err := selfupdate.ResolveLatest(ctx, s.client, s.apiBase, s.repo)
 	if err != nil {
 		s.failedAt = time.Now()

--- a/pkg/updatecheck/service.go
+++ b/pkg/updatecheck/service.go
@@ -1,0 +1,77 @@
+package updatecheck
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/diagridio/dev-dashboard/pkg/selfupdate"
+)
+
+// maxNegativeTTL caps how long a failed resolve suppresses retries.
+const maxNegativeTTL = 5 * time.Minute
+
+// Service reports whether a newer release exists, caching the result.
+type Service interface {
+	Check(ctx context.Context) Result
+}
+
+type service struct {
+	client  *http.Client
+	apiBase string
+	repo    string
+	current string
+	ttl     time.Duration
+	negTTL  time.Duration
+
+	mu        sync.Mutex
+	cached    Result
+	fetchedAt time.Time
+	failedAt  time.Time
+	hasResult bool
+}
+
+// New builds a caching update-check service. ttl is the positive cache lifetime;
+// failed resolves are negatively cached for half the ttl, capped at 5m.
+func New(client *http.Client, apiBase, repo, current string, ttl time.Duration) Service {
+	negTTL := ttl / 2
+	if negTTL > maxNegativeTTL {
+		negTTL = maxNegativeTTL
+	}
+	return &service{
+		client:  client,
+		apiBase: apiBase,
+		repo:    repo,
+		current: current,
+		ttl:     ttl,
+		negTTL:  negTTL,
+	}
+}
+
+// Check returns update availability, serving from cache when fresh. On a resolve
+// error the last-good result is preserved (zero Result if none) and the failure
+// is negatively cached so the endpoint is not re-probed on every request.
+func (s *service) Check(ctx context.Context) Result {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	if s.hasResult && now.Sub(s.fetchedAt) < s.ttl {
+		return s.cached
+	}
+	if !s.failedAt.IsZero() && now.Sub(s.failedAt) < s.negTTL {
+		return s.cached
+	}
+
+	latest, err := selfupdate.ResolveLatest(ctx, s.client, s.apiBase, s.repo)
+	if err != nil {
+		s.failedAt = time.Now()
+		return s.cached
+	}
+	s.cached = evaluate(s.current, latest, s.repo)
+	s.fetchedAt = time.Now()
+	s.failedAt = time.Time{}
+	s.hasResult = true
+	return s.cached
+}

--- a/pkg/updatecheck/service_test.go
+++ b/pkg/updatecheck/service_test.go
@@ -63,3 +63,33 @@ func TestServiceNegativeCacheOnError(t *testing.T) {
 	require.False(t, r2.UpdateAvailable)
 	require.Equal(t, int32(1), atomic.LoadInt32(&hits), "failed fetch should be negative-cached, not re-probed")
 }
+
+func TestServicePreservesLastGoodOnLaterFailure(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"tag_name":"v1.3.0"}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	// A tiny ttl forces the second Check to re-fetch (positive cache already
+	// expired) rather than serving the cached value, so we exercise the error
+	// path with a non-zero last-good already present.
+	svc := New(srv.Client(), srv.URL, "diagridio/dev-dashboard", "1.2.0", time.Microsecond)
+
+	first := svc.Check(context.Background())
+	require.True(t, first.UpdateAvailable)
+	require.Equal(t, "v1.3.0", first.Latest)
+
+	// Sleep to ensure positive cache expires before second Check.
+	time.Sleep(2 * time.Microsecond)
+
+	// The second fetch fails; the non-zero last-good result must be preserved.
+	second := svc.Check(context.Background())
+	require.Equal(t, first, second)
+	require.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(2), "second Check should have attempted a re-fetch")
+}

--- a/pkg/updatecheck/service_test.go
+++ b/pkg/updatecheck/service_test.go
@@ -64,6 +64,16 @@ func TestServiceNegativeCacheOnError(t *testing.T) {
 	require.Equal(t, int32(1), atomic.LoadInt32(&hits), "failed fetch should be negative-cached, not re-probed")
 }
 
+func TestServiceSkipsNetworkForDevBuild(t *testing.T) {
+	var hits int32
+	srv := latestServer(t, "v1.3.0", &hits)
+	svc := New(srv.Client(), srv.URL, "diagridio/dev-dashboard", "dev", time.Hour)
+
+	r := svc.Check(context.Background())
+	require.False(t, r.UpdateAvailable)
+	require.Equal(t, int32(0), atomic.LoadInt32(&hits), "dev build must not hit the network")
+}
+
 func TestServicePreservesLastGoodOnLaterFailure(t *testing.T) {
 	var calls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/updatecheck/service_test.go
+++ b/pkg/updatecheck/service_test.go
@@ -1,0 +1,65 @@
+//go:build unit
+
+package updatecheck
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// latestServer serves the GitHub /releases/latest shape and counts hits.
+func latestServer(t *testing.T, tag string, hits *int32) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(hits, 1)
+		require.Equal(t, "/repos/diagridio/dev-dashboard/releases/latest", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"` + tag + `"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestServiceCheckReportsUpdate(t *testing.T) {
+	var hits int32
+	srv := latestServer(t, "v1.3.0", &hits)
+	svc := New(srv.Client(), srv.URL, "diagridio/dev-dashboard", "1.2.0", time.Hour)
+
+	r := svc.Check(context.Background())
+	require.True(t, r.UpdateAvailable)
+	require.Equal(t, "v1.3.0", r.Latest)
+	require.Equal(t, "https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0", r.ReleaseURL)
+}
+
+func TestServiceCachesWithinTTL(t *testing.T) {
+	var hits int32
+	srv := latestServer(t, "v1.3.0", &hits)
+	svc := New(srv.Client(), srv.URL, "diagridio/dev-dashboard", "1.2.0", time.Hour)
+
+	_ = svc.Check(context.Background())
+	_ = svc.Check(context.Background())
+	require.Equal(t, int32(1), atomic.LoadInt32(&hits), "second Check should hit cache")
+}
+
+func TestServiceNegativeCacheOnError(t *testing.T) {
+	var hits int32
+	// Server that always 500s.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	svc := New(srv.Client(), srv.URL, "diagridio/dev-dashboard", "1.2.0", time.Hour)
+
+	r1 := svc.Check(context.Background())
+	require.False(t, r1.UpdateAvailable)
+	r2 := svc.Check(context.Background())
+	require.False(t, r2.UpdateAvailable)
+	require.Equal(t, int32(1), atomic.LoadInt32(&hits), "failed fetch should be negative-cached, not re-probed")
+}

--- a/pkg/updatecheck/updatecheck.go
+++ b/pkg/updatecheck/updatecheck.go
@@ -1,0 +1,50 @@
+// Package updatecheck reports whether a newer dev-dashboard release exists.
+package updatecheck
+
+import (
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+// Result is the update-availability payload shared by the CLI notice and the
+// GET /api/update-check endpoint. When UpdateAvailable is true, Current and
+// Latest are normalized with a leading "v" and ReleaseURL points at the release.
+type Result struct {
+	Current         string `json:"current"`
+	Latest          string `json:"latest"`
+	UpdateAvailable bool   `json:"updateAvailable"`
+	ReleaseURL      string `json:"releaseUrl"`
+}
+
+// IsReleaseVersion reports whether v is a real released version (valid semver
+// once a leading "v" is ensured). A source/dev build ("dev") is not.
+func IsReleaseVersion(v string) bool {
+	return semver.IsValid(withV(v))
+}
+
+// evaluate compares current against latest and builds the Result. An update is
+// available only when both are valid semver and latest is strictly greater.
+func evaluate(current, latest, repo string) Result {
+	cur := withV(current)
+	lat := withV(latest)
+	if semver.IsValid(cur) && semver.IsValid(lat) && semver.Compare(lat, cur) > 0 {
+		return Result{
+			Current:         cur,
+			Latest:          lat,
+			UpdateAvailable: true,
+			ReleaseURL:      "https://github.com/" + repo + "/releases/tag/" + lat,
+		}
+	}
+	return Result{Current: current, Latest: latest}
+}
+
+// withV normalizes a version to a single leading "v" (trimming space). Empty
+// stays empty. "1.2.0" -> "v1.2.0"; "v1.2.0" -> "v1.2.0".
+func withV(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	return "v" + strings.TrimPrefix(v, "v")
+}

--- a/pkg/updatecheck/updatecheck_test.go
+++ b/pkg/updatecheck/updatecheck_test.go
@@ -1,0 +1,46 @@
+//go:build unit
+
+package updatecheck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsReleaseVersion(t *testing.T) {
+	require.True(t, IsReleaseVersion("1.2.0"))
+	require.True(t, IsReleaseVersion("v1.2.0"))
+	require.False(t, IsReleaseVersion("dev"))
+	require.False(t, IsReleaseVersion(""))
+	require.False(t, IsReleaseVersion("garbage"))
+}
+
+func TestEvaluate(t *testing.T) {
+	const repo = "diagridio/dev-dashboard"
+
+	t.Run("newer available", func(t *testing.T) {
+		r := evaluate("1.2.0", "v1.3.0", repo)
+		require.True(t, r.UpdateAvailable)
+		require.Equal(t, "v1.2.0", r.Current)
+		require.Equal(t, "v1.3.0", r.Latest)
+		require.Equal(t, "https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0", r.ReleaseURL)
+	})
+
+	t.Run("equal", func(t *testing.T) {
+		r := evaluate("v1.3.0", "v1.3.0", repo)
+		require.False(t, r.UpdateAvailable)
+		require.Empty(t, r.ReleaseURL)
+	})
+
+	t.Run("current newer than latest", func(t *testing.T) {
+		r := evaluate("v1.4.0", "v1.3.0", repo)
+		require.False(t, r.UpdateAvailable)
+	})
+
+	t.Run("dev current is never an update", func(t *testing.T) {
+		r := evaluate("dev", "v1.3.0", repo)
+		require.False(t, r.UpdateAvailable)
+		require.Empty(t, r.ReleaseURL)
+	})
+}

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -37,6 +37,9 @@ beforeEach(() => {
     http.get('/api/news', () =>
       HttpResponse.json({ blog: null, report: null, webinar: null, event: null }),
     ),
+    http.get('/api/update-check', () =>
+      HttpResponse.json({ current: '9.9.9', latest: '9.9.9', updateAvailable: false, releaseUrl: '' }),
+    ),
   )
 })
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,7 @@ export function App() {
   const [theme, setTheme] = useState<Theme>(getTheme)
   const [collapsed, setCollapsed] = useState(getInitialCollapsed)
   const [hasNew, setHasNew] = useState(false)
+  const [updateAvailable, setUpdateAvailable] = useState(false)
   const matches = useMatches()
 
   const rumView = [...matches]
@@ -36,7 +37,9 @@ export function App() {
     if (rumView) trackView(rumView)
   }, [rumView])
 
-  const appClass = ['app', collapsed ? 'collapsed' : '', hasNew ? 'has-new' : ''].filter(Boolean).join(' ')
+  const appClass = ['app', collapsed ? 'collapsed' : '', hasNew ? 'has-new' : '', updateAvailable ? 'update-available' : '']
+    .filter(Boolean)
+    .join(' ')
 
   return (
     <SmallScreenGuard>
@@ -46,6 +49,7 @@ export function App() {
           collapsed={collapsed}
           onCollapsedChange={setCollapsed}
           onHasNewChange={setHasNew}
+          onUpdateAvailableChange={setUpdateAvailable}
         />
         <main className="body">
           <Outlet />

--- a/web/src/components/ResourcesSidebar.test.tsx
+++ b/web/src/components/ResourcesSidebar.test.tsx
@@ -21,13 +21,20 @@ const defaultNews = {
 function SidebarWrapper({ initialCollapsed = false }: { initialCollapsed?: boolean }) {
   const [collapsed, setCollapsed] = useState(initialCollapsed)
   const [hasNew, setHasNew] = useState(false)
+  const [updateAvailable, setUpdateAvailable] = useState(false)
   return (
     // Wrap in .app so CSS selectors (data-theme, has-new) resolve correctly
-    <div className={['app', collapsed ? 'collapsed' : '', hasNew ? 'has-new' : ''].filter(Boolean).join(' ')} data-theme="light">
+    <div
+      className={['app', collapsed ? 'collapsed' : '', hasNew ? 'has-new' : '', updateAvailable ? 'update-available' : '']
+        .filter(Boolean)
+        .join(' ')}
+      data-theme="light"
+    >
       <ResourcesSidebar
         collapsed={collapsed}
         onCollapsedChange={setCollapsed}
         onHasNewChange={setHasNew}
+        onUpdateAvailableChange={setUpdateAvailable}
       />
     </div>
   )
@@ -46,6 +53,11 @@ beforeEach(() => {
   localStorage.clear()
   server.use(http.get('/api/news', () => HttpResponse.json(defaultNews)))
   server.use(http.get('/api/version', () => HttpResponse.json({ version: '1.2.3', commit: 'abc', date: '2026-01-01' })))
+  server.use(
+    http.get('/api/update-check', () =>
+      HttpResponse.json({ current: 'v1.2.3', latest: 'v1.2.3', updateAvailable: false, releaseUrl: '' }),
+    ),
+  )
 })
 
 describe('ResourcesSidebar static links', () => {
@@ -357,6 +369,7 @@ describe('ResourcesSidebar onHasNewChange contract', () => {
             collapsed={false}
             onCollapsedChange={() => undefined}
             onHasNewChange={onHasNewChange}
+            onUpdateAvailableChange={() => undefined}
           />
         </div>
       </QueryProvider>,
@@ -393,6 +406,43 @@ describe('ResourcesSidebar onHasNewChange contract', () => {
       expect(spy).toHaveBeenCalledWith(false)
     })
     expect(spy).not.toHaveBeenCalledWith(true)
+  })
+})
+
+describe('ResourcesSidebar update indicator', () => {
+  const withUpdate = () =>
+    server.use(
+      http.get('/api/update-check', () =>
+        HttpResponse.json({
+          current: 'v1.2.0',
+          latest: 'v1.3.0',
+          updateAvailable: true,
+          releaseUrl: 'https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0',
+        }),
+      ),
+    )
+
+  it('shows an Update available link in the footer when an update exists', async () => {
+    withUpdate()
+    renderSidebar()
+    const link = await screen.findByRole('link', { name: /Update available/i })
+    expect(link).toHaveAttribute('href', 'https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('shows no update link when up to date', async () => {
+    // default beforeEach mock has updateAvailable:false
+    renderSidebar()
+    await screen.findByRole('link', { name: 'Diagrid' })
+    expect(screen.queryByRole('link', { name: /Update available/i })).not.toBeInTheDocument()
+  })
+
+  it('renders the collapsed update indicator linking to the release', async () => {
+    withUpdate()
+    renderSidebar({ initialCollapsed: true })
+    const link = await screen.findByRole('link', { name: /version .* is available/i })
+    expect(link).toHaveAttribute('href', 'https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0')
   })
 })
 

--- a/web/src/components/ResourcesSidebar.tsx
+++ b/web/src/components/ResourcesSidebar.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useNews } from '../hooks/useNews'
 import { newsUrls, getSeen, markSeen } from '../lib/newsSeen'
-import { useVersion } from '../hooks/useMeta'
+import { useVersion, useUpdateCheck } from '../hooks/useMeta'
 import type { NewsResponse, NewsItem } from '../types/logs'
 import { trackAction } from '../lib/telemetry'
 
@@ -154,18 +154,25 @@ interface ResourcesSidebarProps {
   collapsed: boolean
   onCollapsedChange: (v: boolean) => void
   onHasNewChange: (v: boolean) => void
+  onUpdateAvailableChange: (v: boolean) => void
 }
 
-export function ResourcesSidebar({ collapsed, onCollapsedChange, onHasNewChange }: ResourcesSidebarProps) {
+export function ResourcesSidebar({ collapsed, onCollapsedChange, onHasNewChange, onUpdateAvailableChange }: ResourcesSidebarProps) {
   const [seen, setSeen] = useState<Set<string>>(() => getSeen())
   const { data: news } = useNews()
   const { data: versionData } = useVersion()
+  const { data: update } = useUpdateCheck()
 
   // Derive unseen → bubble up has-new to parent
   const unseen = news != null && newsUrls(news).some((url) => !seen.has(url))
   useEffect(() => {
     onHasNewChange(unseen)
   }, [unseen, onHasNewChange])
+
+  const updateAvailable = update?.updateAvailable ?? false
+  useEffect(() => {
+    onUpdateAvailableChange(updateAvailable)
+  }, [updateAvailable, onUpdateAvailableChange])
 
   function toggle() {
     const next = !collapsed
@@ -227,6 +234,18 @@ export function ResourcesSidebar({ collapsed, onCollapsedChange, onHasNewChange 
 
       {/* Collapsed vertical panel */}
       <div className="sbvert" data-testid="sidebar-collapsed-label">
+        {updateAvailable && update && (
+          <a
+            className="updot"
+            id="update-v"
+            href={update.releaseUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`Version ${update.latest} is available — update`}
+            title={`${update.latest} is available — update`}
+            onClick={() => trackAction('update_click', { placement: 'collapsed', latest: update.latest })}
+          />
+        )}
         <button
           className="bellbtn"
           id="bell-v"
@@ -258,6 +277,21 @@ export function ResourcesSidebar({ collapsed, onCollapsedChange, onHasNewChange 
             Diagrid
           </a>
           {' · '}v{version}
+          {updateAvailable && update && (
+            <>
+              {'  '}
+              <a
+                className="upbadge"
+                href={update.releaseUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={`${update.latest} is available`}
+                onClick={() => trackAction('update_click', { placement: 'footer', latest: update.latest })}
+              >
+                <span className="updot" aria-hidden="true" /> Update available <span className="ext">↗</span>
+              </a>
+            </>
+          )}
         </span>
         <span className="pw">
           <a

--- a/web/src/components/RouteError.test.tsx
+++ b/web/src/components/RouteError.test.tsx
@@ -35,6 +35,9 @@ beforeEach(() => {
     http.get('/api/news', () =>
       HttpResponse.json({ blog: null, report: null, webinar: null, event: null }),
     ),
+    http.get('/api/update-check', () =>
+      HttpResponse.json({ current: '9.9.9', latest: '9.9.9', updateAvailable: false, releaseUrl: '' }),
+    ),
   )
 })
 

--- a/web/src/hooks/useMeta.test.tsx
+++ b/web/src/hooks/useMeta.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { http, HttpResponse } from 'msw'
 import { server } from '../test/setup'
 import { QueryProvider, makeQueryClient } from '../lib/query'
-import { useVersion } from './useMeta'
+import { useVersion, useUpdateCheck } from './useMeta'
 
 // Wrap hooks in a fresh QueryProvider each test to avoid cross-test cache contamination
 function makeWrapper() {
@@ -36,5 +36,31 @@ describe('useVersion', () => {
   it('starts in a pending state', () => {
     const { result } = renderHook(() => useVersion(), { wrapper: makeWrapper() })
     expect(result.current.isPending).toBe(true)
+  })
+})
+
+describe('useUpdateCheck', () => {
+  beforeEach(() => {
+    server.use(
+      http.get('/api/update-check', () =>
+        HttpResponse.json({
+          current: 'v1.2.0',
+          latest: 'v1.3.0',
+          updateAvailable: true,
+          releaseUrl: 'https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0',
+        }),
+      ),
+    )
+  })
+
+  it('returns update info from /api/update-check', async () => {
+    const { result } = renderHook(() => useUpdateCheck(), { wrapper: makeWrapper() })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual({
+      current: 'v1.2.0',
+      latest: 'v1.3.0',
+      updateAvailable: true,
+      releaseUrl: 'https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0',
+    })
   })
 })

--- a/web/src/hooks/useMeta.ts
+++ b/web/src/hooks/useMeta.ts
@@ -16,3 +16,21 @@ export function useVersion() {
     refetchInterval: 60_000,
   })
 }
+
+/** Shape returned by GET /api/update-check */
+export interface UpdateInfo {
+  current: string
+  latest: string
+  updateAvailable: boolean
+  releaseUrl: string
+}
+
+/** Fetch update availability from /api/update-check. Refreshes every 5 min. */
+export function useUpdateCheck() {
+  return useQuery<UpdateInfo>({
+    queryKey: ['update-check'],
+    queryFn: () => fetchJSON<UpdateInfo>('/update-check'),
+    staleTime: 5 * 60 * 1000,
+    refetchInterval: 5 * 60 * 1000,
+  })
+}

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -107,6 +107,14 @@ body {
 .bellbtn .bellico { display: block; }
 .app.has-new:not(.collapsed) #bell-h { display: inline-flex; }
 .app.has-new.collapsed #bell-v { display: inline-flex; }
+
+/* Update-available indicator (footer badge + collapsed dot) */
+.upbadge { color: var(--primary); text-decoration: none; white-space: nowrap; display: inline-flex; align-items: center; gap: 4px; }
+.upbadge:hover { text-decoration: underline; }
+.updot { width: 7px; height: 7px; border-radius: 50%; background: var(--primary); display: inline-block; }
+.sbvert #update-v { display: none; }
+.app.update-available.collapsed #update-v { display: inline-block; margin-bottom: 8px; }
+
 .sbvert { display: none; }
 .app.collapsed .sbvert { display: flex; flex-direction: column; align-items: center; flex: 1; padding: 8px 0 14px; }
 .sbvert .vtext { margin: auto 0; transform: rotate(-90deg); white-space: nowrap; font-family: var(--mono); font-size: 11px; letter-spacing: .18em; text-transform: uppercase; color: var(--muted); cursor: pointer; }


### PR DESCRIPTION
## Summary

Makes it obvious when a newer dashboard release exists:

- **CLI startup notice** — on startup the CLI resolves the latest GitHub release, compares it to the running version, and (if newer) prints a first-line notice with the upgrade command. A spinner (`Checking for new versions…`) shows while the 2s-bounded check runs on a TTY.
- **Web indicator** — the Resources panel shows a clickable **Update available** badge next to the version (expanded footer) and a dot (collapsed strip), both linking to the GitHub release, mirroring the existing news `has-new` pattern.
- Both surfaces read from **one shared `pkg/updatecheck` service** (1h cache + negative cache), so the web indicator reuses the startup check's warmed result — no duplicate GitHub calls.

## Behavior

- Skipped entirely for `dev`/source builds (invalid semver) — no spinner, no network call, no badge — on both the CLI and the `GET /api/update-check` endpoint.
- **Fail-silent:** offline / rate-limited / errored checks yield "no update"; never surfaced as an error. Prereleases excluded (`/releases/latest`).
- No opt-out (the check is cheap and degrades gracefully).

Notice format:

```
A new version of the Dapr Dev Dashboard is available: v1.2.0 → v1.3.0
Run `dev-dashboard update` to upgrade.
```

## Changes

- `pkg/selfupdate`: export `ResolveLatest` (was `resolveLatest`) for reuse.
- `pkg/updatecheck` (new): `Result`, `IsReleaseVersion`, semver comparison, and a caching `Service`.
- `pkg/server`: `GET /api/update-check` + `Options.UpdateCheck`.
- `cmd`: startup spinner/notice wired into `runServe`, sharing one service instance with the server.
- `web`: `useUpdateCheck` hook + Resources-panel indicators (expanded + collapsed).
- Docs: README "Updating the dashboard" + ARCHITECTURE.

## Testing

- Go unit tests for `pkg/updatecheck` (semver/URL logic, caching, negative-cache, dev-build skip), `pkg/server` endpoint, `cmd` notice formatting + service propagation, and the `selfupdate` rename.
- Web: `useUpdateCheck` hook test + `ResourcesSidebar` indicator tests (expanded/collapsed/absent). Full web suite green (637 tests).
- `go build ./...` clean.

> **Note for reviewers:** please run `go test -tags unit -race ./...` in CI — `-race` could not be exercised in the dev environment (CGO disabled). Two pre-existing Windows-only `cmd` test failures (`TestDerivePaths_AutoDetect`, `TestRegistry_SaveLoadRoundTrip_WindowsPath`) are unrelated to this branch (reproduce on `main`).

Design + plan: `docs/superpowers/specs/2026-07-08-version-update-awareness-design.md`, `docs/superpowers/plans/2026-07-08-version-update-awareness.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)