### PR TITLE
Compose apps: container-name identity and runtime detection

### DIFF
--- a/docs/superpowers/plans/2026-07-09-compose-container-identity.md
+++ b/docs/superpowers/plans/2026-07-09-compose-container-identity.md
@@ -1,0 +1,1017 @@
+# Compose App Instance Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make each compose-run Dapr app instance individually addressable by its container name (`InstanceKey`), so multiple sidecars sharing one `-app-id` get distinct rows, detail pages, and log streams.
+
+**Architecture:** A new routing identity (`InstanceKey`) lives alongside the Dapr identity (`AppID`). It is derived per scan result — compose: app container name → daprd container name → app-id; standalone: always app-id — and resolved in `service.Get` via a two-pass lookup (exact key match first, app-id fallback). The frontend links every per-instance surface by `instanceKey` and keeps Dapr-keyed data (workflows) on `appId`.
+
+**Tech Stack:** Go 1.x (chi, testify, `-tags unit`), React + TypeScript (vite, vitest, msw, testing-library).
+
+**Spec:** `docs/superpowers/specs/2026-07-09-compose-container-identity-design.md`
+
+## Global Constraints
+
+- Zero observable change for `dapr run` / Aspire apps: their `instanceKey` equals `appId`, URLs and UI render identically to today.
+- `InstanceKey` fallback order for compose: `AppContainerName` → `DaprdContainerName` → `AppID`.
+- `Get` resolution order: exact InstanceKey match across ALL results first, then first AppID match. Unknown key → `ErrNotFound`.
+- Workflow pages keep linking by `appId` — do NOT touch `WorkflowDetail.tsx`, `workflows.go`, or `statestore` keys.
+- Spec note: the spec describes `InstanceKey` as a field on `ScanResult`; we implement it as a computed method `ScanResult.Key()` (same semantics, no scanner changes) plus a serialized `Instance.InstanceKey` field.
+- Go tests: `go test -tags unit -race ./pkg/... ` (or `make test-go`). Web tests: `cd web && npm test`.
+- Vitest does NOT typecheck: any `.ts/.tsx` change (test files included) must also pass `cd web && npm run build` (runs `tsc -b`).
+- Commit after every green task.
+
+---
+
+### Task 1: Backend — `ScanResult.Key()` + `Instance.InstanceKey` + stable sort
+
+**Files:**
+- Modify: `pkg/discovery/service.go` (add `Key()` after the `ScanResult` struct ~line 50; set `InstanceKey` in `enrich` ~line 109; sort ~line 89)
+- Modify: `pkg/discovery/types.go` (add field after `AppID`, line 15)
+- Test: `pkg/discovery/service_test.go` (append)
+
+**Interfaces:**
+- Consumes: existing `ScanResult`, `Instance`, `service.List`/`enrich`.
+- Produces: `func (r ScanResult) Key() string` and `Instance.InstanceKey string` with JSON tag `instanceKey` — Tasks 2–3 call `r.Key()` / read `in.InstanceKey`; the frontend (Tasks 4–7) reads the `instanceKey` JSON field.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `pkg/discovery/service_test.go`:
+
+```go
+func TestScanResultKey(t *testing.T) {
+	t.Run("compose uses app container name", func(t *testing.T) {
+		r := ScanResult{AppID: "daprmq-service", Source: SourceCompose, AppContainerName: "daprmq-host-1", DaprdContainerName: "daprmq-host-1-dapr"}
+		require.Equal(t, "daprmq-host-1", r.Key())
+	})
+	t.Run("compose falls back to daprd container name", func(t *testing.T) {
+		r := ScanResult{AppID: "daprmq-service", Source: SourceCompose, DaprdContainerName: "daprmq-host-1-dapr"}
+		require.Equal(t, "daprmq-host-1-dapr", r.Key())
+	})
+	t.Run("compose falls back to app id", func(t *testing.T) {
+		r := ScanResult{AppID: "daprmq-service", Source: SourceCompose}
+		require.Equal(t, "daprmq-service", r.Key())
+	})
+	t.Run("standalone always keys by app id", func(t *testing.T) {
+		r := ScanResult{AppID: "order", Source: SourceStandalone, AppContainerName: "ignored"}
+		require.Equal(t, "order", r.Key())
+	})
+	t.Run("empty source keys by app id", func(t *testing.T) {
+		require.Equal(t, "order", ScanResult{AppID: "order"}.Key())
+	})
+}
+
+func TestListSetsInstanceKeyAndSortsWithinAppID(t *testing.T) {
+	scan := func() ([]ScanResult, error) {
+		return []ScanResult{
+			{AppID: "daprmq-service", Source: SourceCompose, SidecarReachable: false, AppContainerName: "daprmq-host-2"},
+			{AppID: "daprmq-service", Source: SourceCompose, SidecarReachable: false, AppContainerName: "daprmq-gateway-1"},
+			{AppID: "aaa-app"},
+		}, nil
+	}
+	svc := New(scan, &http.Client{Timeout: time.Millisecond})
+	list, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, list, 3)
+	require.Equal(t, "aaa-app", list[0].AppID)
+	require.Equal(t, "aaa-app", list[0].InstanceKey) // standalone: key == app id
+	require.Equal(t, "daprmq-gateway-1", list[1].InstanceKey)
+	require.Equal(t, "daprmq-host-2", list[2].InstanceKey)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit -race ./pkg/discovery/ -run 'TestScanResultKey|TestListSetsInstanceKey' -v`
+Expected: FAIL — `r.Key undefined` / `list[0].InstanceKey undefined` (compile errors).
+
+- [ ] **Step 3: Implement**
+
+In `pkg/discovery/service.go`, immediately after the `ScanResult` struct (after line 50):
+
+```go
+// Key returns the routing identity for this scan result. Compose sidecars can
+// share one -app-id (scaled instances), so they key by container name — the
+// app container when paired, else the daprd container; everything else keys
+// by AppID. Container names are unique per host, so keys are unique whenever
+// a container name is available.
+func (r ScanResult) Key() string {
+	if r.Source == SourceCompose {
+		if r.AppContainerName != "" {
+			return r.AppContainerName
+		}
+		if r.DaprdContainerName != "" {
+			return r.DaprdContainerName
+		}
+	}
+	return r.AppID
+}
+```
+
+In `pkg/discovery/types.go`, add after `AppID` (line 15):
+
+```go
+	// InstanceKey is the routing identity: container name for compose apps
+	// (falling back to app id), app id otherwise. Unique per instance even
+	// when several compose sidecars share one -app-id.
+	InstanceKey string `json:"instanceKey"`
+```
+
+In `pkg/discovery/service.go` `enrich` (line 109), add `InstanceKey: r.Key(),` to the `Instance` literal, right after `AppID: r.AppID,`:
+
+```go
+	in := Instance{
+		AppID: r.AppID, InstanceKey: r.Key(), HTTPPort: r.HTTPPort, GRPCPort: r.GRPCPort, AppPort: r.AppPort,
+```
+
+In `service.List` (line 89), replace the sort:
+
+```go
+	sort.SliceStable(out, func(a, b int) bool {
+		if out[a].AppID != out[b].AppID {
+			return out[a].AppID < out[b].AppID
+		}
+		return out[a].InstanceKey < out[b].InstanceKey
+	})
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -tags unit -race ./pkg/discovery/ -v`
+Expected: PASS (all discovery tests, including pre-existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/discovery/service.go pkg/discovery/types.go pkg/discovery/service_test.go
+git commit -m "feat(discovery): add InstanceKey routing identity for compose apps"
+```
+
+---
+
+### Task 2: Backend — two-pass `Get` resolution
+
+**Files:**
+- Modify: `pkg/discovery/service.go:94-106` (`Get`), `pkg/discovery/service.go:52-55` (`Service` interface doc)
+- Test: `pkg/discovery/service_test.go` (append)
+
+**Interfaces:**
+- Consumes: `ScanResult.Key()` from Task 1.
+- Produces: `Get(ctx, key string)` semantics — exact InstanceKey match first, AppID fallback. All existing callers (`pkg/server/apps.go`, `pkg/server/logs.go`, `cmd/workflow.go`) pass a string and need NO changes.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `pkg/discovery/service_test.go`:
+
+```go
+func TestGetResolvesInstanceKeyThenAppID(t *testing.T) {
+	scan := func() ([]ScanResult, error) {
+		return []ScanResult{
+			{AppID: "daprmq-service", Source: SourceCompose, SidecarReachable: false, AppContainerName: "daprmq-gateway-1", DaprdContainerID: "aaa"},
+			{AppID: "daprmq-service", Source: SourceCompose, SidecarReachable: false, AppContainerName: "daprmq-host-1", DaprdContainerID: "bbb"},
+		}, nil
+	}
+	svc := New(scan, &http.Client{Timeout: time.Millisecond})
+
+	// Exact instance-key hit returns that instance, not the first app-id match.
+	in, err := svc.Get(context.Background(), "daprmq-host-1")
+	require.NoError(t, err)
+	require.Equal(t, "bbb", in.DaprdContainerID)
+	require.Equal(t, "daprmq-host-1", in.InstanceKey)
+
+	// A plain app id falls back to the first matching instance (legacy links).
+	in, err = svc.Get(context.Background(), "daprmq-service")
+	require.NoError(t, err)
+	require.Equal(t, "aaa", in.DaprdContainerID)
+
+	// Unknown key still errors.
+	_, err = svc.Get(context.Background(), "nope")
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestGetInstanceKeyMatchBeatsAppIDMatch(t *testing.T) {
+	// "orders" is app-id of the FIRST result but instance key of the SECOND;
+	// the key pass must win even though the app-id match appears earlier.
+	scan := func() ([]ScanResult, error) {
+		return []ScanResult{
+			{AppID: "orders", Source: SourceCompose, SidecarReachable: false, AppContainerName: "orders-ctr", DaprdContainerID: "first"},
+			{AppID: "other", Source: SourceCompose, SidecarReachable: false, AppContainerName: "orders", DaprdContainerID: "second"},
+		}, nil
+	}
+	svc := New(scan, &http.Client{Timeout: time.Millisecond})
+	in, err := svc.Get(context.Background(), "orders")
+	require.NoError(t, err)
+	require.Equal(t, "second", in.DaprdContainerID)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit -race ./pkg/discovery/ -run TestGet -v`
+Expected: `TestGetResolvesInstanceKeyThenAppID` FAILS — `Get("daprmq-host-1")` returns ErrNotFound (only app-id matching exists today). `TestGetInstanceKeyMatchBeatsAppIDMatch` FAILS — returns "first".
+
+- [ ] **Step 3: Implement**
+
+Replace `Get` in `pkg/discovery/service.go:94-106`:
+
+```go
+// Get resolves key as an instance key first (container name for compose
+// apps), then as an app id. The app-id fallback keeps legacy links working —
+// e.g. workflow pages, which only know the daprd app id — and resolves
+// duplicates to the first instance in scan order.
+func (s *service) Get(ctx context.Context, key string) (Instance, error) {
+	results, err := s.scan()
+	if err != nil {
+		logger().Error("app scan failed", "err", err)
+		return Instance{}, err
+	}
+	for _, r := range results {
+		if r.Key() == key {
+			return s.enrich(ctx, r), nil
+		}
+	}
+	for _, r := range results {
+		if r.AppID == key {
+			return s.enrich(ctx, r), nil
+		}
+	}
+	return Instance{}, fmt.Errorf("%w: %s", ErrNotFound, key)
+}
+```
+
+Update the interface (line 52-55) to document the semantics:
+
+```go
+type Service interface {
+	List(ctx context.Context) ([]Instance, error)
+	// Get resolves key as an InstanceKey first, then as an AppID (first match).
+	Get(ctx context.Context, key string) (Instance, error)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -tags unit -race ./pkg/discovery/ -v`
+Expected: PASS. (Note: for standalone results `Key() == AppID`, so pass 1 already satisfies every pre-existing `Get` test.)
+
+- [ ] **Step 5: Run the full Go suite (callers compile, server tests green)**
+
+Run: `go test -tags unit -race ./...`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/discovery/service.go pkg/discovery/service_test.go
+git commit -m "feat(discovery): Get resolves InstanceKey first, AppID as fallback"
+```
+
+---
+
+### Task 3: Backend — `instanceKey` on actor/subscription rows; loadedBy uses instance keys
+
+**Files:**
+- Modify: `pkg/server/actors.go` (row struct line 12-17, loop line 29-36)
+- Modify: `pkg/server/subscriptions.go` (row struct line 12-19, loop line 31-45)
+- Modify: `pkg/server/resources.go` (`loadedByFor` line 64-80, `loadedByIndex` line 82-98)
+- Test: `pkg/server/actors_test.go`, `pkg/server/subscriptions_test.go`, `pkg/server/resources_test.go` (append)
+
+**Interfaces:**
+- Consumes: `Instance.InstanceKey` from Task 1 (empty in old test fixtures — fall back to `AppID`).
+- Produces: JSON `instanceKey` on every `/api/actors` and `/api/subscriptions` row; `loadedBy` arrays contain instance keys (== app ids for non-compose). Tasks 4/7 consume these.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `pkg/server/actors_test.go`:
+
+```go
+func TestActorsRowsCarryInstanceKey(t *testing.T) {
+	apps := &fakeApps{instances: []discovery.Instance{
+		{AppID: "daprmq-service", InstanceKey: "daprmq-host-1", Actors: []discovery.ActorType{{Type: "QueueActor", Count: 1}}},
+		{AppID: "daprmq-service", InstanceKey: "daprmq-host-2", Actors: []discovery.ActorType{{Type: "QueueActor", Count: 2}}},
+		// Fixture without InstanceKey (pre-existing shape) falls back to app id.
+		{AppID: "cart", Actors: []discovery.ActorType{{Type: "CartActor", Count: 1}}},
+	}}
+	h := actorsRouter(apps)
+	res, body := get(t, h, "/")
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Contains(t, body, `"instanceKey":"daprmq-host-1"`)
+	require.Contains(t, body, `"instanceKey":"daprmq-host-2"`)
+	require.Contains(t, body, `"instanceKey":"cart"`)
+}
+```
+
+Append to `pkg/server/subscriptions_test.go`:
+
+```go
+func TestSubscriptionsRowsCarryInstanceKey(t *testing.T) {
+	apps := &fakeApps{instances: []discovery.Instance{
+		{AppID: "daprmq-service", InstanceKey: "daprmq-host-1", Subscriptions: []discovery.Subscription{{PubsubName: "kafka-pubsub", Topic: "orders"}}},
+		{AppID: "cart", Subscriptions: []discovery.Subscription{{PubsubName: "pubsub", Topic: "carts"}}},
+	}}
+	h := subscriptionsRouter(apps)
+	res, body := get(t, h, "/")
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Contains(t, body, `"instanceKey":"daprmq-host-1"`)
+	require.Contains(t, body, `"instanceKey":"cart"`)
+}
+```
+
+Append to `pkg/server/resources_test.go`:
+
+```go
+func TestLoadedByUsesInstanceKeys(t *testing.T) {
+	res := fakeResources{items: []resources.Resource{{Name: "statestore", Kind: resources.KindComponent, Type: "state.postgresql"}}}
+	apps := &fakeApps{instances: []discovery.Instance{
+		{AppID: "daprmq-service", InstanceKey: "daprmq-host-1", Components: []discovery.Component{{Name: "statestore"}}},
+		{AppID: "daprmq-service", InstanceKey: "daprmq-host-2", Components: []discovery.Component{{Name: "statestore"}}},
+	}}
+	h := resourcesRouter(res, apps)
+
+	r1, body := get(t, h, "/component/statestore")
+	require.Equal(t, http.StatusOK, r1.StatusCode)
+	require.Contains(t, body, `"loadedBy":["daprmq-host-1","daprmq-host-2"]`)
+
+	r2, body2 := get(t, h, "/?kind=component")
+	require.Equal(t, http.StatusOK, r2.StatusCode)
+	require.Contains(t, body2, `"loadedBy":["daprmq-host-1","daprmq-host-2"]`)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit -race ./pkg/server/ -run 'TestActorsRowsCarryInstanceKey|TestSubscriptionsRowsCarryInstanceKey|TestLoadedByUsesInstanceKeys' -v`
+Expected: FAIL — `unknown field InstanceKey` is NOT an error (Instance has it from Task 1); the assertions on `"instanceKey":` fail because rows don't serialize it yet, and `loadedBy` contains `["daprmq-service","daprmq-service"]`.
+
+- [ ] **Step 3: Implement**
+
+In `pkg/server/actors.go`, add the field and a shared helper:
+
+```go
+// ActorRow is a single actor-type entry returned by GET /api/actors.
+type ActorRow struct {
+	AppID       string `json:"appId"`
+	InstanceKey string `json:"instanceKey"`
+	Type        string `json:"type"`
+	Count       int    `json:"count"`
+	Placement   string `json:"placement,omitempty"`
+}
+
+// instanceKey returns the instance's routing identity, tolerating fixtures
+// (and any pre-InstanceKey producer) that only set AppID.
+func instanceKey(in discovery.Instance) string {
+	if in.InstanceKey != "" {
+		return in.InstanceKey
+	}
+	return in.AppID
+}
+```
+
+and in the row-building loop (line ~34):
+
+```go
+			for _, a := range in.Actors {
+				rows = append(rows, ActorRow{AppID: in.AppID, InstanceKey: instanceKey(in), Type: a.Type, Count: a.Count, Placement: in.Placement})
+			}
+```
+
+In `pkg/server/subscriptions.go`:
+
+```go
+// SubscriptionRow is a single subscription entry returned by GET /api/subscriptions.
+type SubscriptionRow struct {
+	AppID           string              `json:"appId"`
+	InstanceKey     string              `json:"instanceKey"`
+	PubsubName      string              `json:"pubsubName"`
+	Topic           string              `json:"topic"`
+	Rules           []discovery.SubRule `json:"rules,omitempty"`
+	DeadLetterTopic string              `json:"deadLetterTopic,omitempty"`
+	Type            string              `json:"type,omitempty"`
+}
+```
+
+and in its loop (line ~36):
+
+```go
+				rows = append(rows, SubscriptionRow{
+					AppID:           in.AppID,
+					InstanceKey:     instanceKey(in),
+					PubsubName:      s.PubsubName,
+					Topic:           s.Topic,
+					Rules:           s.Rules,
+					DeadLetterTopic: s.DeadLetterTopic,
+					Type:            s.Type,
+				})
+```
+
+In `pkg/server/resources.go`, switch both helpers to instance keys (update their doc comments too):
+
+```go
+// loadedByFor returns the sorted instance keys whose instance contains component name.
+// It lists apps once and scans only for the requested name, avoiding a full index build.
+func loadedByFor(ctx context.Context, apps discovery.Service, name string) []string {
+	list, err := apps.List(ctx)
+	if err != nil {
+		return nil
+	}
+	var ids []string
+	for _, in := range list {
+		for _, c := range in.Components {
+			if c.Name == name {
+				ids = append(ids, instanceKey(in))
+				break
+			}
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// loadedByIndex maps component name -> sorted instance keys that loaded it.
+func loadedByIndex(ctx context.Context, apps discovery.Service) map[string][]string {
+	idx := map[string][]string{}
+	list, err := apps.List(ctx)
+	if err != nil {
+		return idx
+	}
+	for _, in := range list {
+		for _, c := range in.Components {
+			idx[c.Name] = append(idx[c.Name], instanceKey(in))
+		}
+	}
+	for k := range idx {
+		sort.Strings(idx[k])
+	}
+	return idx
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -tags unit -race ./pkg/server/ -v`
+Expected: PASS — including the pre-existing `TestResourcesListWithLoadedBy` (`loadedBy:["order"]` still holds via the AppID fallback) and `TestActorsAggregate`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/server/actors.go pkg/server/subscriptions.go pkg/server/resources.go pkg/server/actors_test.go pkg/server/subscriptions_test.go pkg/server/resources_test.go
+git commit -m "feat(server): expose instanceKey on actor/subscription rows and loadedBy"
+```
+
+---
+
+### Task 4: Frontend — types, `appKey` helper, Applications overview
+
+**Files:**
+- Modify: `web/src/types/api.ts` (AppSummary, line 8-30)
+- Create: `web/src/lib/appKey.ts`
+- Modify: `web/src/pages/Applications.tsx` (list loop line 97-99, `AppRow` line 109-148)
+- Test: `web/src/pages/Applications.test.tsx` (append)
+
+**Interfaces:**
+- Consumes: `instanceKey` JSON field from Task 1.
+- Produces: `AppSummary.instanceKey?: string`; `export function appKey(app: Pick<AppSummary, 'appId' | 'instanceKey'>): string` in `web/src/lib/appKey.ts` — Tasks 5 and 6 import `appKey` from `'../lib/appKey'`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the `describe('Applications', ...)` block in `web/src/pages/Applications.test.tsx`:
+
+```tsx
+  it('compose apps with duplicate app ids link by container name with the app id underneath', async () => {
+    mockApps([
+      { ...baseApp, appId: 'daprmq-service', instanceKey: 'daprmq-host-1', source: 'compose', composeProject: 'dapr-mq', sidecarReachable: true, runTemplate: '' },
+      { ...baseApp, appId: 'daprmq-service', instanceKey: 'daprmq-host-2', source: 'compose', composeProject: 'dapr-mq', sidecarReachable: true, runTemplate: '' },
+    ])
+    renderAt()
+    const link1 = await screen.findByRole('link', { name: /daprmq-host-1/ })
+    expect(link1).toHaveAttribute('href', '/apps/daprmq-host-1')
+    expect(screen.getByRole('link', { name: /daprmq-host-2/ })).toHaveAttribute('href', '/apps/daprmq-host-2')
+    // The app id renders as a secondary line in each of the two rows.
+    expect(screen.getAllByText('daprmq-service')).toHaveLength(2)
+  })
+
+  it('non-compose apps render a single-line app id and link by app id', async () => {
+    mockApps([{ ...baseApp, instanceKey: 'order' }])
+    renderAt()
+    const link = await screen.findByRole('link', { name: 'order' })
+    expect(link).toHaveAttribute('href', '/apps/order')
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd web && npx vitest run src/pages/Applications.test.tsx`
+Expected: FAIL — links still `href="/apps/daprmq-service"`, no secondary app-id line (`getAllByText('daprmq-service')` finds links, not 2 secondary spans; the href assertion fails first).
+
+- [ ] **Step 3: Implement**
+
+`web/src/types/api.ts` — add to `AppSummary` after `appId`:
+
+```ts
+  /** routing identity: container name for compose apps, appId otherwise */
+  instanceKey?: string
+```
+
+Create `web/src/lib/appKey.ts`:
+
+```ts
+import type { AppSummary } from '../types/api'
+
+/**
+ * Routing identity for an app instance: instanceKey (container name for
+ * compose apps) with appId fallback for older payloads and test fixtures.
+ */
+export function appKey(app: Pick<AppSummary, 'appId' | 'instanceKey'>): string {
+  return app.instanceKey || app.appId
+}
+```
+
+`web/src/pages/Applications.tsx` — import the helper:
+
+```tsx
+import { appKey } from '../lib/appKey'
+```
+
+Replace the list loop (line 97-99):
+
+```tsx
+              {apps.map((app) => (
+                <AppRow key={appKey(app)} app={app} onOpen={() => navigate(`/apps/${appKey(app)}`)} />
+              ))}
+```
+
+In `AppRow`, replace the App ID cell (line 125-129). Compose apps with a distinct key show the container name as the primary line and the app id as a smaller muted line; everything else is unchanged:
+
+```tsx
+  const key = appKey(app)
+  const hasContainerName = key !== app.appId
+```
+
+(place these two lines at the top of `AppRow`, after the `unreachable` const), then:
+
+```tsx
+      <td className="b">
+        <Link className="celllink" to={`/apps/${key}`} onClick={(e) => e.stopPropagation()}>
+          {hasContainerName ? (
+            <>
+              {key}
+              <span className="muted" style={{ display: 'block', fontSize: 11, fontWeight: 400 }}>
+                {app.appId}
+              </span>
+            </>
+          ) : (
+            app.appId
+          )}
+        </Link>
+      </td>
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd web && npx vitest run src/pages/Applications.test.tsx`
+Expected: PASS (new tests and all pre-existing ones — old fixtures have no `instanceKey`, so `appKey` falls back to `appId`).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd web && npm run build`
+Expected: exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/types/api.ts web/src/lib/appKey.ts web/src/pages/Applications.tsx web/src/pages/Applications.test.tsx
+git commit -m "feat(web): Applications rows keyed and linked by instanceKey"
+```
+
+---
+
+### Task 5: Frontend — App detail shows container name, links logs by key
+
+**Files:**
+- Modify: `web/src/pages/AppDetail.tsx` (header lines 36-51, logs link line 49, doc title line 15)
+- Test: `web/src/pages/AppDetail.test.tsx` (append)
+
+**Interfaces:**
+- Consumes: `appKey` from `'../lib/appKey'` (Task 4); `instanceKey` on the `/api/apps/:key` payload (Task 1). The `:appId` route param needs no rename — the backend resolves keys and app ids alike (Task 2).
+- Produces: nothing consumed downstream.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `describe('AppDetail', ...)` in `web/src/pages/AppDetail.test.tsx`:
+
+```tsx
+  it('shows the container name under the title and links logs by instance key', async () => {
+    server.use(
+      http.get('/api/apps/order', () =>
+        HttpResponse.json({
+          appId: 'daprmq-service',
+          instanceKey: 'daprmq-host-1',
+          health: 'healthy',
+          runtime: 'dotnet',
+          httpPort: 3502,
+          grpcPort: 50003,
+          appPort: 8080,
+          metadataOk: true,
+          source: 'compose',
+          composeProject: 'dapr-mq',
+          sidecarReachable: true,
+          daprdContainerId: 'aaa111bbb222',
+          daprdContainerName: 'daprmq-host-1-dapr',
+          appContainerId: 'ccc333ddd444',
+          appContainerName: 'daprmq-host-1',
+        }),
+      ),
+    )
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'daprmq-service' })).toBeInTheDocument())
+    // Container name appears as the header sub-line (also as the Container kv value).
+    expect(screen.getAllByText('daprmq-host-1').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getByRole('link', { name: /view logs/i })).toHaveAttribute(
+      'href',
+      '/logs?app=daprmq-host-1&source=daprd',
+    )
+  })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/pages/AppDetail.test.tsx`
+Expected: FAIL — logs link href is `/logs?app=daprmq-service&source=daprd` and only one `daprmq-host-1` text node exists (the Container kv value).
+
+- [ ] **Step 3: Implement**
+
+In `web/src/pages/AppDetail.tsx`, import the helper:
+
+```tsx
+import { appKey } from '../lib/appKey'
+```
+
+At the top of `AppDetailContent`, next to the existing consts (line 22-24):
+
+```tsx
+  const key = appKey(app)
+  const hasContainerName = key !== app.appId
+```
+
+Replace the page-header block (lines 36-51) so the container name renders as a sub-line under the title, and the logs link carries the key:
+
+```tsx
+      {/* Page header */}
+      <div className="phead">
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+            <h1>{app.appId}</h1>
+            <span className="health">
+              <span className={`led ${ledClass(app.health)}`} /> {app.health}
+            </span>
+            <span className="lang">
+              <span className="sw" style={{ background: runtimeSwatch(app.runtime) }} />
+              {app.runtime}
+            </span>
+          </div>
+          {hasContainerName && <div className="sub mono">{key}</div>}
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button className="tbtn" onClick={() => navigate('/')}>← Back</button>
+          <Link className="tbtn" to={`/logs?app=${key}&source=daprd`}>View logs</Link>
+        </div>
+      </div>
+```
+
+Update the document title (line 15) so browser tabs distinguish instances:
+
+```tsx
+  useDocumentTitle(appKey(app))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd web && npx vitest run src/pages/AppDetail.test.tsx`
+Expected: PASS — including `sets the document title to the app id` (fixture has no `instanceKey`, so `appKey` returns `order`).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd web && npm run build`
+Expected: exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/pages/AppDetail.tsx web/src/pages/AppDetail.test.tsx
+git commit -m "feat(web): AppDetail shows container name and links logs by instanceKey"
+```
+
+---
+
+### Task 6: Frontend — Logs dropdown distinguishes instances
+
+**Files:**
+- Modify: `web/src/pages/Logs.tsx` (line 389-390 `appIds`, line 501-507 options)
+- Test: `web/src/pages/Logs.test.tsx` (append)
+
+**Interfaces:**
+- Consumes: `appKey` from `'../lib/appKey'`; `instanceKey` on `/api/apps` summaries. `useApp(appId)` / `useLogStream` already accept any identifier string — the backend resolves it (Task 2); no hook changes.
+- Produces: dropdown option values are instance keys; labels read `appId (instanceKey)` when they differ.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the top-level `describe` in `web/src/pages/Logs.test.tsx` (reuse the existing `COMPOSE_SUMMARY`/`COMPOSE_DETAIL` fixtures and `renderAt` helper):
+
+```tsx
+  it('app dropdown lists duplicate-app-id compose instances as distinct options keyed by instanceKey', async () => {
+    const host1 = { ...COMPOSE_SUMMARY, appId: 'daprmq-service', instanceKey: 'daprmq-host-1' }
+    const host2 = { ...COMPOSE_SUMMARY, appId: 'daprmq-service', instanceKey: 'daprmq-host-2' }
+    server.use(
+      http.get('/api/apps', () => HttpResponse.json([host1, host2])),
+      http.get('/api/apps/daprmq-host-1', () =>
+        HttpResponse.json({ ...COMPOSE_DETAIL, appId: 'daprmq-service', instanceKey: 'daprmq-host-1' }),
+      ),
+    )
+    renderAt('/logs?app=daprmq-host-1&source=daprd')
+    const select = await screen.findByLabelText('App')
+    const values = Array.from(select.querySelectorAll('option')).map(o => o.value)
+    expect(values).toContain('daprmq-host-1')
+    expect(values).toContain('daprmq-host-2')
+    // Labels disambiguate: app id + container name.
+    expect(screen.getByRole('option', { name: 'daprmq-service (daprmq-host-1)' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'daprmq-service (daprmq-host-2)' })).toBeInTheDocument()
+  })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/pages/Logs.test.tsx`
+Expected: FAIL — option values are `daprmq-service` twice.
+
+- [ ] **Step 3: Implement**
+
+In `web/src/pages/Logs.tsx`, import the helper:
+
+```tsx
+import { appKey } from '../lib/appKey'
+```
+
+Replace line 390 (`const appIds = ...`):
+
+```tsx
+  const appOptions = (apps ?? []).map(a => {
+    const key = appKey(a)
+    return { key, label: key !== a.appId ? `${a.appId} (${key})` : a.appId }
+  })
+```
+
+Replace the options render (lines 502-506):
+
+```tsx
+          {appOptions.map(o => (
+            <option key={o.key} value={o.key}>
+              {o.label}
+            </option>
+          ))}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd web && npx vitest run src/pages/Logs.test.tsx`
+Expected: PASS (all pre-existing Logs tests too — non-compose fixtures produce `key === appId`, identical options).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd web && npm run build`
+Expected: exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/pages/Logs.tsx web/src/pages/Logs.test.tsx
+git commit -m "feat(web): Logs app selector keys options by instanceKey"
+```
+
+---
+
+### Task 7: Frontend — Actors & Subscriptions link by instance key
+
+**Files:**
+- Modify: `web/src/types/resources.ts` (Actor line 1-6, Subscription line 13-21)
+- Modify: `web/src/pages/Actors.tsx` (row key line 107, `ActorRow` line 122-147, hosting-apps stat line 65)
+- Modify: `web/src/pages/Subscriptions.tsx` (row key line 79, `SubscriptionRow` line 92-125)
+- Test: `web/src/pages/Actors.test.tsx`, `web/src/pages/Subscriptions.test.tsx` (append)
+
+Note: `ResourceDetail.tsx` needs NO change — `loadedBy` values are already instance keys after Task 3 and the existing `to={'/apps/' + appId}` link renders them correctly.
+
+**Interfaces:**
+- Consumes: `instanceKey` on actor/subscription rows (Task 3).
+- Produces: nothing consumed downstream.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `web/src/pages/Actors.test.tsx` inside its `describe` (both test files define `function renderAt(entry = …)` and mock via `server.use(http.get(...))`):
+
+```tsx
+  it('duplicate-app-id instances render distinct rows linking by instanceKey', async () => {
+    server.use(
+      http.get('/api/actors', () =>
+        HttpResponse.json([
+          { appId: 'daprmq-service', instanceKey: 'daprmq-host-1', type: 'QueueActor', count: 1, placement: 'connected' },
+          { appId: 'daprmq-service', instanceKey: 'daprmq-host-2', type: 'QueueActor', count: 2, placement: 'connected' },
+        ]),
+      ),
+    )
+    renderAt()
+    const links = await screen.findAllByRole('link', { name: /daprmq-service/ })
+    expect(links.map(l => l.getAttribute('href'))).toEqual(['/apps/daprmq-host-1', '/apps/daprmq-host-2'])
+    // Container names shown to tell the rows apart.
+    expect(screen.getByText('(daprmq-host-1)')).toBeInTheDocument()
+    expect(screen.getByText('(daprmq-host-2)')).toBeInTheDocument()
+  })
+```
+
+Append to `web/src/pages/Subscriptions.test.tsx` inside its `describe` (same `renderAt()` pattern, mocking `GET /api/subscriptions`):
+
+```tsx
+  it('duplicate-app-id instances render distinct rows linking by instanceKey', async () => {
+    server.use(
+      http.get('/api/subscriptions', () =>
+        HttpResponse.json([
+          { appId: 'daprmq-service', instanceKey: 'daprmq-host-1', pubsubName: 'kafka-pubsub', topic: 'orders' },
+          { appId: 'daprmq-service', instanceKey: 'daprmq-host-2', pubsubName: 'kafka-pubsub', topic: 'orders' },
+        ]),
+      ),
+    )
+    renderAt()
+    const links = await screen.findAllByRole('link', { name: /daprmq-service/ })
+    expect(links.map(l => l.getAttribute('href'))).toEqual(['/apps/daprmq-host-1', '/apps/daprmq-host-2'])
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd web && npx vitest run src/pages/Actors.test.tsx src/pages/Subscriptions.test.tsx`
+Expected: FAIL — hrefs are `/apps/daprmq-service` for both rows (and Actors may render only via duplicate React keys).
+
+- [ ] **Step 3: Implement**
+
+`web/src/types/resources.ts` — add to both interfaces after `appId`:
+
+```ts
+  /** routing identity: container name for compose apps, appId otherwise */
+  instanceKey?: string
+```
+
+`web/src/pages/Actors.tsx`:
+
+Row keys (line 107):
+
+```tsx
+              {actors.map((actor) => (
+                <ActorRow key={`${actor.instanceKey ?? actor.appId}/${actor.type}`} actor={actor} />
+              ))}
+```
+
+Hosting-apps stat counts instances (line 65):
+
+```tsx
+  const hostingApps = new Set(actors.map((a) => a.instanceKey ?? a.appId)).size
+```
+
+`ActorRow` host-app cell (line 126-128):
+
+```tsx
+function ActorRow({ actor }: { actor: Actor }) {
+  const isInternal = actor.type.toLowerCase().includes(INTERNAL_PREFIX)
+  const key = actor.instanceKey ?? actor.appId
+  return (
+    <tr>
+      <td className="b">
+        <Link className="celllink" to={`/apps/${key}`}>
+          {actor.appId}
+          {key !== actor.appId && (
+            <span className="muted" style={{ fontSize: 11, fontWeight: 400, marginLeft: 6 }}>({key})</span>
+          )}
+        </Link>
+      </td>
+```
+
+(rest of the row unchanged)
+
+`web/src/pages/Subscriptions.tsx`:
+
+Row keys (line 79):
+
+```tsx
+              {subscriptions.map((sub) => (
+                <SubscriptionRow key={`${sub.instanceKey ?? sub.appId}/${sub.pubsubName}/${sub.topic}`} sub={sub} />
+              ))}
+```
+
+`SubscriptionRow` app cell (line 100-102):
+
+```tsx
+function SubscriptionRow({ sub }: { sub: Subscription }) {
+  const rules = sub.rules ?? []
+  const firstPath = rules[0]?.path
+  const hasMultipleRules = rules.length > 1
+  const scopes = sub.scopes ?? []
+  const key = sub.instanceKey ?? sub.appId
+
+  return (
+    <tr>
+      <td className="b">
+        <Link to={`/apps/${key}`}>
+          {sub.appId}
+          {key !== sub.appId && (
+            <span className="muted" style={{ fontSize: 11, fontWeight: 400, marginLeft: 6 }}>({key})</span>
+          )}
+        </Link>
+      </td>
+```
+
+(rest of the row unchanged)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd web && npx vitest run src/pages/Actors.test.tsx src/pages/Subscriptions.test.tsx src/pages/ResourceDetail.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd web && npm run build`
+Expected: exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/types/resources.ts web/src/pages/Actors.tsx web/src/pages/Subscriptions.tsx web/src/pages/Actors.test.tsx web/src/pages/Subscriptions.test.tsx
+git commit -m "feat(web): Actors and Subscriptions link app instances by instanceKey"
+```
+
+---
+
+### Task 8: Full verification — suites, build, live daprmq stack
+
+**Files:**
+- No source changes expected (fix anything the suites surface).
+
+**Interfaces:**
+- Consumes: everything above.
+
+- [ ] **Step 1: Run the complete test matrix**
+
+```bash
+make lint && make test
+```
+
+Expected: gofmt/vet/eslint clean; all Go unit tests and all vitest suites PASS.
+
+- [ ] **Step 2: Build the binary (includes web tsc + vite build)**
+
+```bash
+make build
+```
+
+Expected: `bin/dev-dashboard` produced, exit 0.
+
+- [ ] **Step 3: Verify live against the running dapr-mq stack (4 sidecars share app-id `daprmq-service`)**
+
+The stack from `/Users/marcduiker/dev/temp/dapr-mq/docker-compose.yml` must be up (`docker ps` shows `daprmq-host-1..3` and `daprmq-gateway-1` plus their `-dapr` sidecars). Stop the user's running dev-dashboard instance first if it holds the port, then:
+
+```bash
+./bin/dev-dashboard &
+sleep 3
+curl -s http://localhost:9090/api/apps | python3 -c "import json,sys; [print(a['instanceKey'], a['appId']) for a in json.load(sys.stdin)]"
+```
+
+Expected output — four distinct keys, one shared app id:
+
+```
+daprmq-gateway-1 daprmq-service
+daprmq-host-1 daprmq-service
+daprmq-host-2 daprmq-service
+daprmq-host-3 daprmq-service
+```
+
+Then per-instance detail resolves precisely:
+
+```bash
+curl -s http://localhost:9090/api/apps/daprmq-host-2 | python3 -c "import json,sys; a=json.load(sys.stdin); print(a['instanceKey'], a['appContainerName'], a['httpPort'])"
+```
+
+Expected: `daprmq-host-2 daprmq-host-2 3503` — and the app-id fallback still resolves:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:9090/api/apps/daprmq-service
+```
+
+Expected: `200`.
+
+- [ ] **Step 4: Browser spot-check**
+
+Open `http://localhost:9090`: the Applications page shows 4 rows (container name primary, `daprmq-service` muted underneath); clicking each row opens a distinct detail page; "View logs" streams that instance's logs; the Logs dropdown offers `daprmq-service (daprmq-host-1)` … `(daprmq-gateway-1)`.
+
+- [ ] **Step 5: Commit (only if fixes were needed) and report**
+
+```bash
+git status
+```
+
+Report suite results and live-check findings to the user before merging/PR.

--- a/docs/superpowers/plans/2026-07-09-compose-runtime-detection.md
+++ b/docs/superpowers/plans/2026-07-09-compose-runtime-detection.md
@@ -1,0 +1,697 @@
+# Compose App Runtime Detection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compose Dapr apps show a real runtime (go/dotnet/node/…) on the App overview and detail pages instead of "unknown", detected from signals the discovery scan already has plus a local build-context fallback.
+
+**Architecture:** A short-circuiting chain computed at scan time in `ComposeSource` — app-container argv → base-image env markers → image name → marker files in the service's local compose `build.context` — stored as `ScanResult.AppRuntime` and consumed by `enrich` only when runtime is otherwise unknown. All signals except the last come from the batched `docker inspect` discovery already performs.
+
+**Tech Stack:** Go (testify, `-tags unit -race`), `sigs.k8s.io/yaml` (existing direct dependency). No frontend changes.
+
+**Spec:** `docs/superpowers/specs/2026-07-09-compose-runtime-detection-design.md`
+
+## Global Constraints
+
+- Zero extra container-runtime calls: only reuse fields from the existing batched `docker inspect`.
+- Chain order (stop at first non-"unknown"): argv → env → image → build-context marker files. File I/O only when 1–3 all fail.
+- Best-effort and silent: every failure path (missing/foreign compose file, YAML error, no `build:` section, unreadable dir) returns `"unknown"` — no error returns, no log noise on the 2s scan cadence.
+- Env markers: `DOTNET_VERSION`/`ASPNET_VERSION` → dotnet; `NODE_VERSION` → node; `PYTHON_VERSION` → python; `JAVA_VERSION`/`JAVA_HOME` → java; `GOLANG_VERSION` → go; `RUST_VERSION`/`CARGO_HOME` → rust.
+- Marker files (top level of context dir only): `go.mod` → go; `*.csproj`/`*.fsproj`/`*.sln`/`global.json` → dotnet; `Cargo.toml` → rust; `pom.xml`/`build.gradle`/`build.gradle.kts` → java; `pyproject.toml`/`requirements.txt`/`setup.py` → python; `package.json` → node (checked in that fixed priority order, not directory order).
+- `enrich` treats `AppRuntime` of `""` OR `"unknown"` as absent and falls back to the existing `InferRuntimeFromImage(r.AppImage)` — keeps `TestEnrichComposeCarriesContainerFields` green.
+- Standalone/Aspire paths untouched. No new Go dependencies. No frontend changes.
+- Go tests: `go test -tags unit -race ./pkg/discovery/`. Commit after every green task.
+- Work happens on branch `worktree-compose-container-identity` (PR #50) in `/Users/marcduiker/dev/diagrid/dev-dashboard/.claude/worktrees/compose-container-identity`.
+
+---
+
+### Task 1: `InferRuntimeFromEnv`
+
+**Files:**
+- Modify: `pkg/discovery/infer.go` (append)
+- Test: `pkg/discovery/infer_test.go` (append)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `func InferRuntimeFromEnv(env []string) string` — returns a runtime name or `"unknown"`. Task 3's chain calls it with `composeContainer.Env`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/discovery/infer_test.go`:
+
+```go
+func TestInferRuntimeFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		env  []string
+		want string
+	}{
+		{"dotnet version", []string{"PATH=/usr/bin", "DOTNET_VERSION=10.0.9"}, "dotnet"},
+		{"aspnet version", []string{"ASPNET_VERSION=10.0.9"}, "dotnet"},
+		{"node", []string{"NODE_VERSION=22.1.0"}, "node"},
+		{"python", []string{"PYTHON_VERSION=3.12.4"}, "python"},
+		{"java version", []string{"JAVA_VERSION=21"}, "java"},
+		{"java home", []string{"JAVA_HOME=/opt/java"}, "java"},
+		{"golang", []string{"GOLANG_VERSION=1.23.4"}, "go"},
+		{"rust", []string{"RUST_VERSION=1.79"}, "rust"},
+		{"cargo home", []string{"CARGO_HOME=/usr/local/cargo"}, "rust"},
+		{"no markers", []string{"PATH=/usr/bin", "HOME=/root"}, "unknown"},
+		{"empty", nil, "unknown"},
+		{"value not name", []string{"FOO=NODE_VERSION"}, "unknown"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { require.Equal(t, tc.want, InferRuntimeFromEnv(tc.env)) })
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -tags unit -race ./pkg/discovery/ -run TestInferRuntimeFromEnv -v`
+Expected: FAIL to compile — `undefined: InferRuntimeFromEnv`.
+
+- [ ] **Step 3: Implement**
+
+Append to `pkg/discovery/infer.go`:
+
+```go
+// InferRuntimeFromEnv guesses the app's language from environment variables
+// inherited from official base images (best-effort, conservative — only
+// well-known variable names count, never values).
+func InferRuntimeFromEnv(env []string) string {
+	for _, kv := range env {
+		name, _, _ := strings.Cut(kv, "=")
+		switch name {
+		case "DOTNET_VERSION", "ASPNET_VERSION":
+			return "dotnet"
+		case "NODE_VERSION":
+			return "node"
+		case "PYTHON_VERSION":
+			return "python"
+		case "JAVA_VERSION", "JAVA_HOME":
+			return "java"
+		case "GOLANG_VERSION":
+			return "go"
+		case "RUST_VERSION", "CARGO_HOME":
+			return "rust"
+		}
+	}
+	return "unknown"
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -tags unit -race ./pkg/discovery/ -run TestInferRuntime -v`
+Expected: PASS (new test plus the pre-existing `TestInferRuntime`/`TestInferRuntimeFromImage`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/discovery/infer.go pkg/discovery/infer_test.go
+git commit -m "feat(discovery): infer runtime from base-image env markers"
+```
+
+---
+
+### Task 2: Build-context marker resolver
+
+**Files:**
+- Create: `pkg/discovery/compose_runtime.go`
+- Test: `pkg/discovery/compose_runtime_test.go` (new)
+
+**Interfaces:**
+- Consumes: `InferRuntime`, `InferRuntimeFromEnv`, `InferRuntimeFromImage` (all in `pkg/discovery/infer.go`); `composeContainer` (Task 3 adds `Env`/`ConfigFiles`/`WorkingDir` fields — this task does NOT touch it yet).
+- Produces:
+  - `func runtimeFromBuildContext(configFiles, workingDir, service string) string`
+  - `func runtimeFromMarkerFiles(dir string) string` (internal helper, tested directly)
+  Task 3's chain calls `runtimeFromBuildContext`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `pkg/discovery/compose_runtime_test.go`:
+
+```go
+//go:build unit
+
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeFile creates path (and parents) with content.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func TestRuntimeFromMarkerFiles(t *testing.T) {
+	cases := []struct {
+		name    string
+		files   []string
+		want    string
+	}{
+		{"go", []string{"go.mod"}, "go"},
+		{"dotnet sln and global.json (dapr-mq layout)", []string{"DaprMQ.sln", "global.json", "NuGet.config"}, "dotnet"},
+		{"dotnet csproj", []string{"App.csproj"}, "dotnet"},
+		{"node", []string{"package.json"}, "node"},
+		{"python", []string{"requirements.txt"}, "python"},
+		{"java", []string{"pom.xml"}, "java"},
+		{"rust", []string{"Cargo.toml"}, "rust"},
+		{"priority: go.mod beats package.json", []string{"package.json", "go.mod"}, "go"},
+		{"no markers", []string{"README.md"}, "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, f := range tc.files {
+				writeFile(t, filepath.Join(dir, f), "x")
+			}
+			require.Equal(t, tc.want, runtimeFromMarkerFiles(dir))
+		})
+	}
+	t.Run("nonexistent dir", func(t *testing.T) {
+		require.Equal(t, "unknown", runtimeFromMarkerFiles(filepath.Join(t.TempDir(), "nope")))
+	})
+	t.Run("markers in subdirs do not count", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "src", "go.mod"), "x")
+		require.Equal(t, "unknown", runtimeFromMarkerFiles(dir))
+	})
+}
+
+func TestRuntimeFromBuildContext(t *testing.T) {
+	t.Run("string build shorthand", func(t *testing.T) {
+		proj := t.TempDir()
+		writeFile(t, filepath.Join(proj, "dotnet", "global.json"), "{}")
+		cf := filepath.Join(proj, "docker-compose.yml")
+		writeFile(t, cf, "services:\n  web:\n    build: ./dotnet\n")
+		require.Equal(t, "dotnet", runtimeFromBuildContext(cf, proj, "web"))
+	})
+	t.Run("object build with context", func(t *testing.T) {
+		proj := t.TempDir()
+		writeFile(t, filepath.Join(proj, "svc", "go.mod"), "module x")
+		cf := filepath.Join(proj, "docker-compose.yml")
+		writeFile(t, cf, "services:\n  web:\n    build:\n      context: ./svc\n      dockerfile: Dockerfile\n")
+		require.Equal(t, "go", runtimeFromBuildContext(cf, proj, "web"))
+	})
+	t.Run("service without build section (pulled image)", func(t *testing.T) {
+		proj := t.TempDir()
+		cf := filepath.Join(proj, "docker-compose.yml")
+		writeFile(t, cf, "services:\n  web:\n    image: nginx\n")
+		require.Equal(t, "unknown", runtimeFromBuildContext(cf, proj, "web"))
+	})
+	t.Run("unknown service", func(t *testing.T) {
+		proj := t.TempDir()
+		cf := filepath.Join(proj, "docker-compose.yml")
+		writeFile(t, cf, "services:\n  web:\n    build: .\n")
+		require.Equal(t, "unknown", runtimeFromBuildContext(cf, proj, "other"))
+	})
+	t.Run("comma-separated config files, second resolves", func(t *testing.T) {
+		proj := t.TempDir()
+		writeFile(t, filepath.Join(proj, "app", "Cargo.toml"), "[package]")
+		cf1 := filepath.Join(proj, "missing.yml") // does not exist
+		cf2 := filepath.Join(proj, "docker-compose.yml")
+		writeFile(t, cf2, "services:\n  web:\n    build: ./app\n")
+		require.Equal(t, "rust", runtimeFromBuildContext(cf1+","+cf2, proj, "web"))
+	})
+	t.Run("dangling context path", func(t *testing.T) {
+		proj := t.TempDir()
+		cf := filepath.Join(proj, "docker-compose.yml")
+		writeFile(t, cf, "services:\n  web:\n    build: ./gone\n")
+		require.Equal(t, "unknown", runtimeFromBuildContext(cf, proj, "web"))
+	})
+	t.Run("invalid yaml", func(t *testing.T) {
+		proj := t.TempDir()
+		cf := filepath.Join(proj, "docker-compose.yml")
+		writeFile(t, cf, "services: [not: valid: yaml")
+		require.Equal(t, "unknown", runtimeFromBuildContext(cf, proj, "web"))
+	})
+	t.Run("empty inputs", func(t *testing.T) {
+		require.Equal(t, "unknown", runtimeFromBuildContext("", "", "web"))
+		require.Equal(t, "unknown", runtimeFromBuildContext("x.yml", "", ""))
+	})
+	t.Run("relative context resolved against workingDir not cwd", func(t *testing.T) {
+		proj := t.TempDir()
+		writeFile(t, filepath.Join(proj, "js", "package.json"), "{}")
+		// compose file lives elsewhere; workingDir is the project dir
+		other := t.TempDir()
+		cf := filepath.Join(other, "compose.yml")
+		writeFile(t, cf, "services:\n  web:\n    build: ./js\n")
+		require.Equal(t, "node", runtimeFromBuildContext(cf, proj, "web"))
+	})
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit -race ./pkg/discovery/ -run 'TestRuntimeFrom' -v`
+Expected: FAIL to compile — `undefined: runtimeFromMarkerFiles`, `undefined: runtimeFromBuildContext`.
+
+- [ ] **Step 3: Implement**
+
+Create `pkg/discovery/compose_runtime.go`:
+
+```go
+package discovery
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// composeFileServices is the minimal compose-file subset we consume: only
+// each service's build key, which compose allows as either a string
+// (context shorthand) or an object. sigs.k8s.io/yaml converts YAML to JSON
+// first, so json tags and json.RawMessage apply.
+type composeFileServices struct {
+	Services map[string]struct {
+		Build json.RawMessage `json:"build,omitempty"`
+	} `json:"services"`
+}
+
+// runtimeFromBuildContext infers the app language from marker files in the
+// service's local build context, located via the compose project labels
+// (com.docker.compose.project.config_files / .working_dir). configFiles is
+// the raw label value — comma-separated when the project was started with
+// multiple -f files; the first file that yields a runtime wins. Best-effort:
+// any failure (missing/foreign compose file, YAML error, no build section,
+// unreadable dir) yields "unknown". Display-only enrichment — discovery
+// correctness never depends on it (see the design doc for why compose-file
+// parsing is otherwise avoided).
+func runtimeFromBuildContext(configFiles, workingDir, service string) string {
+	if configFiles == "" || service == "" {
+		return "unknown"
+	}
+	for _, cf := range strings.Split(configFiles, ",") {
+		dir, ok := buildContextDir(strings.TrimSpace(cf), workingDir, service)
+		if !ok {
+			continue
+		}
+		if rt := runtimeFromMarkerFiles(dir); rt != "unknown" {
+			return rt
+		}
+	}
+	return "unknown"
+}
+
+// buildContextDir resolves the local build-context directory for service
+// from one compose file, or ok=false when it cannot.
+func buildContextDir(configFile, workingDir, service string) (string, bool) {
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		return "", false
+	}
+	var doc composeFileServices
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return "", false
+	}
+	svc, ok := doc.Services[service]
+	if !ok || len(svc.Build) == 0 {
+		return "", false
+	}
+	var ctx string
+	if err := json.Unmarshal(svc.Build, &ctx); err != nil {
+		var obj struct {
+			Context string `json:"context"`
+		}
+		if err := json.Unmarshal(svc.Build, &obj); err != nil {
+			return "", false
+		}
+		ctx = obj.Context
+	}
+	if ctx == "" {
+		ctx = "."
+	}
+	if !filepath.IsAbs(ctx) {
+		base := workingDir
+		if base == "" {
+			base = filepath.Dir(configFile)
+		}
+		ctx = filepath.Join(base, ctx)
+	}
+	return ctx, true
+}
+
+// runtimeFromMarkerFiles inspects the top level of dir for well-known
+// project marker files. Markers are checked in a fixed priority order (not
+// directory order) so polyglot contexts resolve deterministically —
+// package.json last, since it shows up in many non-Node repos.
+func runtimeFromMarkerFiles(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "unknown"
+	}
+	names := map[string]bool{}
+	dotnetProj := false
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		n := strings.ToLower(e.Name())
+		names[n] = true
+		if strings.HasSuffix(n, ".csproj") || strings.HasSuffix(n, ".fsproj") || strings.HasSuffix(n, ".sln") {
+			dotnetProj = true
+		}
+	}
+	switch {
+	case names["go.mod"]:
+		return "go"
+	case dotnetProj, names["global.json"]:
+		return "dotnet"
+	case names["cargo.toml"]:
+		return "rust"
+	case names["pom.xml"], names["build.gradle"], names["build.gradle.kts"]:
+		return "java"
+	case names["pyproject.toml"], names["requirements.txt"], names["setup.py"]:
+		return "python"
+	case names["package.json"]:
+		return "node"
+	}
+	return "unknown"
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -tags unit -race ./pkg/discovery/ -run 'TestRuntimeFrom' -v`
+Expected: PASS (all subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/discovery/compose_runtime.go pkg/discovery/compose_runtime_test.go
+git commit -m "feat(discovery): infer runtime from compose build-context marker files"
+```
+
+---
+
+### Task 3: Capture signals in the compose scan and wire the chain
+
+**Files:**
+- Modify: `pkg/discovery/compose_inspect.go` (labels ~line 11-14, `composeContainer` ~line 18-29, `rawComposeContainer.Config` ~line 39-44, `parseComposeContainers` ~line 70-80)
+- Modify: `pkg/discovery/compose_runtime.go` (append the chain function)
+- Modify: `pkg/discovery/scan_compose.go` (app pairing block ~line 193-197)
+- Modify: `pkg/discovery/service.go` (`ScanResult` struct — add field after `AppImage`)
+- Modify: `pkg/discovery/testdata/compose_inspect.json` (add `Env` to the app container)
+- Test: `pkg/discovery/compose_runtime_test.go`, `pkg/discovery/scan_compose_test.go` (append)
+
+**Interfaces:**
+- Consumes: `runtimeFromBuildContext` (Task 2), `InferRuntimeFromEnv` (Task 1), existing `InferRuntime`/`InferRuntimeFromImage`.
+- Produces:
+  - `composeContainer` gains `Env []string`, `ConfigFiles string`, `WorkingDir string`
+  - `func composeAppRuntime(app composeContainer) string` in `compose_runtime.go`
+  - `ScanResult.AppRuntime string` — Task 4's `enrich` reads it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `pkg/discovery/compose_runtime_test.go`:
+
+```go
+func TestComposeAppRuntimeChainPrecedence(t *testing.T) {
+	// Build-context fixture that would say "go" if reached.
+	proj := t.TempDir()
+	writeFile(t, filepath.Join(proj, "svc", "go.mod"), "module x")
+	cf := filepath.Join(proj, "docker-compose.yml")
+	writeFile(t, cf, "services:\n  web:\n    build: ./svc\n")
+
+	base := composeContainer{Service: "web", ConfigFiles: cf, WorkingDir: proj}
+
+	t.Run("argv beats everything", func(t *testing.T) {
+		app := base
+		app.Argv = []string{"dotnet", "App.dll"}
+		app.Env = []string{"NODE_VERSION=22"}
+		app.Image = "python:3.12"
+		require.Equal(t, "dotnet", composeAppRuntime(app))
+	})
+	t.Run("env beats image and files", func(t *testing.T) {
+		app := base
+		app.Argv = []string{"/entrypoint.sh"}
+		app.Env = []string{"NODE_VERSION=22"}
+		app.Image = "python:3.12"
+		require.Equal(t, "node", composeAppRuntime(app))
+	})
+	t.Run("image beats files", func(t *testing.T) {
+		app := base
+		app.Argv = []string{"/app/server"}
+		app.Image = "python:3.12"
+		require.Equal(t, "python", composeAppRuntime(app))
+	})
+	t.Run("build context is the last resort", func(t *testing.T) {
+		app := base
+		app.Argv = []string{"/app/server"}
+		app.Image = "custom-app"
+		require.Equal(t, "go", composeAppRuntime(app))
+	})
+	t.Run("all unknown", func(t *testing.T) {
+		app := composeContainer{Service: "web", Argv: []string{"/app/server"}, Image: "custom-app"}
+		require.Equal(t, "unknown", composeAppRuntime(app))
+	})
+}
+```
+
+Append to `pkg/discovery/scan_compose_test.go`, inside `TestComposeSourceScan` after the `r.AppImage` check (line ~83):
+
+```go
+	// App runtime: fixture app container has entrypoint /app/server (no
+	// command signal), image saga-primes-go (no image signal), and
+	// GOLANG_VERSION in env — the env marker resolves it.
+	if r.AppRuntime != "go" {
+		t.Fatalf("app runtime from env marker: %+v", r)
+	}
+```
+
+- [ ] **Step 2: Update the fixture**
+
+In `pkg/discovery/testdata/compose_inspect.json`, find the app container object (`"Name": "/saga-primes-go-1"`) and add an `Env` array to its `Config` (next to `"Entrypoint": ["/app/server"]`):
+
+```json
+"Env": ["PATH=/usr/local/bin:/usr/bin", "GOLANG_VERSION=1.23.4"],
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `go test -tags unit -race ./pkg/discovery/ -run 'TestComposeAppRuntimeChainPrecedence|TestComposeSourceScan' -v`
+Expected: FAIL to compile — `unknown field Env/ConfigFiles/WorkingDir in composeContainer`, `undefined: composeAppRuntime`, `r.AppRuntime undefined`.
+
+- [ ] **Step 4: Implement**
+
+`pkg/discovery/compose_inspect.go` — extend the label constants (line 11-14):
+
+```go
+const (
+	labelComposeProject     = "com.docker.compose.project"
+	labelComposeService     = "com.docker.compose.service"
+	labelComposeConfigFiles = "com.docker.compose.project.config_files"
+	labelComposeWorkingDir  = "com.docker.compose.project.working_dir"
+)
+```
+
+Extend `composeContainer` (after `Argv`):
+
+```go
+	Env         []string // Config.Env — carries base-image markers like DOTNET_VERSION
+	ConfigFiles string   // host path(s) of the compose file(s), comma-separated
+	WorkingDir  string   // host project dir; base for relative build contexts
+```
+
+Extend `rawComposeContainer.Config` (after `Cmd`):
+
+```go
+		Env []string `json:"Env"`
+```
+
+Populate in `parseComposeContainers` (inside the `composeContainer{...}` literal, after `Argv`):
+
+```go
+			Env:         r.Config.Env,
+			ConfigFiles: r.Config.Labels[labelComposeConfigFiles],
+			WorkingDir:  r.Config.Labels[labelComposeWorkingDir],
+```
+
+`pkg/discovery/compose_runtime.go` — append the chain:
+
+```go
+// composeAppRuntime resolves the app's language from scan data, cheapest
+// signal first: launch command, base-image env markers, image name, and
+// finally marker files in the service's local build context (the only step
+// that touches the filesystem).
+func composeAppRuntime(app composeContainer) string {
+	if rt := InferRuntime(strings.Join(app.Argv, " ")); rt != "unknown" {
+		return rt
+	}
+	if rt := InferRuntimeFromEnv(app.Env); rt != "unknown" {
+		return rt
+	}
+	if rt := InferRuntimeFromImage(app.Image); rt != "unknown" {
+		return rt
+	}
+	return runtimeFromBuildContext(app.ConfigFiles, app.WorkingDir, app.Service)
+}
+```
+
+`pkg/discovery/service.go` — add to `ScanResult` after `AppImage`:
+
+```go
+	// AppRuntime is the compose scanner's language inference for the app
+	// container ("" for other sources; possibly "unknown").
+	AppRuntime string
+```
+
+`pkg/discovery/scan_compose.go` — in the app-pairing block (line ~193-197), add one line:
+
+```go
+			if app, ok := byProjSvc[c.Project+"/"+appSvc]; ok {
+				r.AppContainerID = app.ID
+				r.AppContainerName = app.Name
+				r.AppImage = app.Image
+				r.AppRuntime = composeAppRuntime(app)
+			}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test -tags unit -race ./pkg/discovery/ -v`
+Expected: PASS — including the pre-existing scan/cache tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/discovery/compose_inspect.go pkg/discovery/compose_runtime.go pkg/discovery/scan_compose.go pkg/discovery/service.go pkg/discovery/testdata/compose_inspect.json pkg/discovery/compose_runtime_test.go pkg/discovery/scan_compose_test.go
+git commit -m "feat(discovery): compose scan computes app runtime via signal chain"
+```
+
+---
+
+### Task 4: `enrich` consumes `AppRuntime`
+
+**Files:**
+- Modify: `pkg/discovery/service.go` (`enrich`, the compose runtime fallback — currently `if in.Source == SourceCompose && in.Runtime == "unknown" { in.Runtime = InferRuntimeFromImage(r.AppImage) }`)
+- Test: `pkg/discovery/service_test.go` (append)
+
+**Interfaces:**
+- Consumes: `ScanResult.AppRuntime` (Task 3).
+- Produces: `Instance.Runtime` populated for compose apps — no API shape change; the frontend already renders it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/discovery/service_test.go`:
+
+```go
+func TestEnrichComposeUsesAppRuntime(t *testing.T) {
+	scan := func() ([]ScanResult, error) {
+		return []ScanResult{
+			// Scanner chain resolved: wins over image inference.
+			{AppID: "a", Source: SourceCompose, SidecarReachable: false, AppRuntime: "dotnet", AppImage: "python:3.12"},
+			// Chain exhausted ("unknown"): image fallback still applies.
+			{AppID: "b", Source: SourceCompose, SidecarReachable: false, AppRuntime: "unknown", AppImage: "python:3.12"},
+			// Field absent (older fixtures): image fallback still applies.
+			{AppID: "c", Source: SourceCompose, SidecarReachable: false, AppImage: "node:22"},
+		}, nil
+	}
+	svc := New(scan, http.DefaultClient)
+	apps, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, apps, 3)
+	require.Equal(t, "dotnet", apps[0].Runtime)
+	require.Equal(t, "python", apps[1].Runtime)
+	require.Equal(t, "node", apps[2].Runtime)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -tags unit -race ./pkg/discovery/ -run TestEnrichComposeUsesAppRuntime -v`
+Expected: FAIL — `apps[0].Runtime` is `"python"` (image inference ignores `AppRuntime` today).
+
+- [ ] **Step 3: Implement**
+
+In `pkg/discovery/service.go` `enrich`, replace:
+
+```go
+	if in.Source == SourceCompose && in.Runtime == "unknown" {
+		in.Runtime = InferRuntimeFromImage(r.AppImage)
+	}
+```
+
+with:
+
+```go
+	if in.Source == SourceCompose && in.Runtime == "unknown" {
+		// Prefer the scanner's signal chain (argv → env → image → build
+		// context); fall back to image inference for scan results that
+		// predate AppRuntime (test fixtures).
+		in.Runtime = r.AppRuntime
+		if in.Runtime == "" || in.Runtime == "unknown" {
+			in.Runtime = InferRuntimeFromImage(r.AppImage)
+		}
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -tags unit -race ./pkg/discovery/ -v`
+Expected: PASS — including `TestEnrichComposeCarriesContainerFields` (its fixture has no `AppRuntime`, so the image fallback still yields `"python"`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/discovery/service.go pkg/discovery/service_test.go
+git commit -m "feat(discovery): enrich prefers scanner AppRuntime for compose apps"
+```
+
+---
+
+### Task 5: Full verification — suites, build, live daprmq stack
+
+**Files:**
+- No source changes expected (fix anything the suites surface).
+
+**Interfaces:**
+- Consumes: everything above.
+
+- [ ] **Step 1: Run the complete matrix**
+
+```bash
+make lint && make test && make build
+```
+
+Expected: all green; `bin/dev-dashboard` produced.
+
+- [ ] **Step 2: Live verification (dapr-mq stack, 4 dotnet services)**
+
+The user's own dashboard runs on port 9090 — do NOT stop it or use its port. Run the new build on 9091 and kill only that process afterwards:
+
+```bash
+./bin/dev-dashboard --port 9091 > /tmp/dd-runtime-check.log 2>&1 &
+sleep 3
+curl -s http://localhost:9091/api/apps | python3 -c "import json,sys; [print(a['instanceKey'], a['runtime']) for a in json.load(sys.stdin)]"
+```
+
+Expected — env/argv signals resolve all four:
+
+```
+daprmq-gateway-1 dotnet
+daprmq-host-1 dotnet
+daprmq-host-2 dotnet
+daprmq-host-3 dotnet
+```
+
+Then stop the test instance (only the PID you started):
+
+```bash
+kill %1
+```
+
+- [ ] **Step 3: Report**
+
+Report suite results and the live runtime values. Commit only if fixes were needed.

--- a/docs/superpowers/specs/2026-07-09-compose-container-identity-design.md
+++ b/docs/superpowers/specs/2026-07-09-compose-container-identity-design.md
@@ -107,8 +107,9 @@ same-app-id instances have a stable order.
 
 **App detail** (`web/src/pages/AppDetail.tsx`): the `:appId` route param is
 treated as the instance key — `useApp(key)` fetches `/api/apps/${key}`. The
-page title/breadcrumb keeps the **app-id as the primary line** with the
-container name underneath. "View logs" links pass `?app=${instanceKey}`.
+page title (h1) and breadcrumb leaf show the **instance key** (container
+name), with the app-id underneath as the sub-line — same hierarchy as the
+overview. "View logs" links pass `?app=${instanceKey}`.
 
 **Logs page** (`web/src/pages/Logs.tsx`, `web/src/hooks/useLogStream.ts`):
 dropdown option *value* is `instanceKey`; label shows `appId (container-name)`

--- a/docs/superpowers/specs/2026-07-09-compose-container-identity-design.md
+++ b/docs/superpowers/specs/2026-07-09-compose-container-identity-design.md
@@ -1,0 +1,145 @@
+# Compose App Instance Identity (Container Name as Key) — Design
+
+**Date:** 2026-07-09
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+Compose discovery (PR #34) identifies apps solely by the daprd `-app-id`.
+`AppID` is simultaneously the list key, the `/apps/:appId` route param, the
+`service.Get` lookup key, and the display label. When several compose sidecars
+share one app-id — a normal Dapr pattern for scaled instances (reference
+workload: `dapr-mq`'s `docker-compose.yml`, four sidecars all running
+`-app-id daprmq-service`) — the Applications page shows four identical rows
+that all drill into the same first-matching instance. Logs, app detail, and
+the Logs-page dropdown collapse the same way.
+
+The data to tell instances apart is already captured per instance
+(`appContainerName`, `daprdContainerName`, ports, container IDs); only the
+identity is missing.
+
+## Goals
+
+1. Each compose-run app instance is individually addressable: distinct row,
+   distinct detail URL, distinct log stream.
+2. The container name is the instance identifier for compose apps, with
+   fallback to the app-id when absent.
+3. Container name is shown alongside the app-id on the App overview and App
+   detail pages; the Logs dropdown distinguishes instances.
+4. Zero observable change for apps started with `dapr run` or Aspire.
+
+## Chosen approach
+
+Add a new **`InstanceKey`** field alongside `AppID` — routing identity
+separate from Dapr identity. Rejected alternatives:
+
+- **Overwrite `AppID` with the container name for compose apps:** smallest
+  frontend diff, but breaks every join that needs the real app-id (workflow
+  state-store key parsing, actor metadata, `?appId=` filters) and misreports
+  the sidecar's actual identity. High regression risk.
+- **Query-param disambiguator (`/apps/{appId}?instance=…`):** keeps AppID as
+  the route but leaks a two-part identity into every link and still needs a
+  unique value for dropdowns — Approach A with worse ergonomics.
+
+## Design
+
+### 1. Identity model (backend)
+
+`ScanResult` (`pkg/discovery/service.go`) and `Instance`
+(`pkg/discovery/types.go`) gain `InstanceKey string` (`json:"instanceKey"`),
+computed at scan time:
+
+- **Compose scanner** (`pkg/discovery/scan_compose.go`, after app-container
+  pairing): `AppContainerName` → fallback `DaprdContainerName` → fallback
+  `AppID`. Docker/podman container names are unique per host, so the key is
+  unique whenever a container name is available.
+- **Standalone scanner** (`dapr run` / Aspire,
+  `pkg/discovery/scan_standalone.go`): always `AppID`.
+
+### 2. Lookup resolution
+
+`service.Get(key)` (`pkg/discovery/service.go:94-106`) resolves in two
+passes over the scan results:
+
+1. Exact `InstanceKey` match (checked across **all** apps first).
+2. First `AppID` match, as fallback.
+
+Consequences:
+
+- `/api/apps/daprmq-host-1` resolves the exact instance.
+- Legacy/ambiguous links such as `/api/apps/daprmq-service` (e.g. from a
+  workflow page) resolve to the first matching instance instead of 404ing —
+  same behavior as today.
+- The two-pass order makes a collision (some container named identically to
+  another app's app-id) resolve deterministically in favor of the instance
+  key.
+- All `Get`-based paths — app detail, log streaming
+  (`pkg/server/logs.go`), workflow purge/removal target resolution
+  (`cmd/workflow.go`) — are fixed through this single chokepoint.
+
+### 3. Per-instance rows on derived endpoints
+
+Actor, Subscription, and Components-"loaded by" rows are built by iterating
+the discovered app list (`pkg/server/actors.go`, `pkg/server/subscriptions.go`,
+`pkg/server/resources.go`), so each row DTO gains `instanceKey` next to its
+existing `appId`. This lets those pages link precisely to one instance.
+
+Workflows are excluded: workflow instances live in the state store keyed by
+the daprd app-id, and cannot be attributed to a single compose instance.
+Workflow pages keep linking by `appId` (resolved via the `Get` fallback).
+
+### 4. Sorting
+
+The app list sort (`service.List`) becomes `AppID, then InstanceKey` so
+same-app-id instances have a stable order.
+
+### 5. Frontend
+
+**Types** (`web/src/types/api.ts`): `instanceKey` on `AppSummary` and
+`AppDetail`; also on actor, subscription, and loaded-by row types.
+
+**App overview** (`web/src/pages/Applications.tsx`):
+
+- Rows keyed and linked by `app.instanceKey` (`/apps/${app.instanceKey}`).
+- When `instanceKey !== appId` (compose apps): the **container name is the
+  primary line**, with the app-id underneath in smaller muted text.
+- When `instanceKey === appId` (dapr run / Aspire): single line, unchanged.
+
+**App detail** (`web/src/pages/AppDetail.tsx`): the `:appId` route param is
+treated as the instance key — `useApp(key)` fetches `/api/apps/${key}`. The
+page title/breadcrumb keeps the **app-id as the primary line** with the
+container name underneath. "View logs" links pass `?app=${instanceKey}`.
+
+**Logs page** (`web/src/pages/Logs.tsx`, `web/src/hooks/useLogStream.ts`):
+dropdown option *value* is `instanceKey`; label shows `appId (container-name)`
+when they differ. Stream URL becomes `/apps/${key}/logs`.
+
+**Links from other pages**: Actors (`Actors.tsx`), Subscriptions
+(`Subscriptions.tsx`), and ResourceDetail's "loaded by" use their row's
+`instanceKey` for `/apps/…` links. `WorkflowDetail.tsx` keeps linking by
+`appId`.
+
+## Edge cases
+
+| Case | Behavior |
+| --- | --- |
+| No explicit `container_name` in compose | Docker generates `project-service-1`; still unique per host — works unchanged. |
+| App-container pairing fails (no service matches `-app-channel-address`) | Falls back to daprd container name, then app-id. |
+| Container name collides with another app's app-id | Deterministic: instance-key pass wins over app-id fallback. |
+| Container recreated under a new name | URL changes; stale links resolve via the app-id fallback. Acceptable for a live dev tool. |
+| Duplicate app-id across compose + `dapr run` | Compose instances get distinct keys; the `dapr run` app keeps its app-id key. App-id fallback resolves to first in scan order — same as today, no regression. |
+| Non-compose apps | `instanceKey === appId`; no sub-line rendered, URLs identical to today. |
+
+## Testing
+
+- **Backend unit tests:** `InstanceKey` computation (all three fallback
+  tiers); `Get` resolution (exact key hit, app-id fallback, precedence when
+  both could match); a duplicate-app-id compose scenario yields four distinct,
+  individually retrievable instances.
+- **Frontend tests:** overview renders container name as primary line with
+  muted app-id for compose rows and links by key; Logs dropdown offers
+  distinct options per instance; AppDetail fetches by key.
+- **Build:** `tsc -b` / `make build` in addition to vitest (vitest does not
+  typecheck).
+- **Manual verification** against the live `dapr-mq` stack: drill into all
+  four apps, stream logs from each.

--- a/docs/superpowers/specs/2026-07-09-compose-runtime-detection-design.md
+++ b/docs/superpowers/specs/2026-07-09-compose-runtime-detection-design.md
@@ -1,0 +1,134 @@
+# Compose App Runtime Detection — Design
+
+**Date:** 2026-07-09
+**Status:** Approved design, pending implementation plan
+**Delivery:** follow-up commits on PR #50 (branch worktree-compose-container-identity)
+
+## Problem
+
+The App overview and App detail pages show `runtime: unknown` for
+docker-compose Dapr apps whenever the app image is a locally built one
+(e.g. `dapr-mq-daprmq-host-1`). Today's only compose signal is
+`InferRuntimeFromImage(AppImage)`, which needs a recognizable base-image
+name. The four reference services (`dapr-mq` stack, .NET) all show
+"unknown".
+
+## Goals
+
+1. Compose apps show a real runtime on the overview and detail pages
+   whenever any local signal reveals it.
+2. Zero extra container-runtime calls: reuse the batched `docker inspect`
+   discovery already performs.
+3. Best-effort and silent: no signal → "unknown", never an error or log
+   noise on the 2s scan cadence.
+4. No frontend changes — both pages already render `runtime`.
+
+## Chosen approach (B)
+
+Container signals first, compose build-context marker files as the last
+fallback. Rejected alternatives:
+
+- **Container signals only:** zero file I/O, but misses Go apps in
+  scratch/distroless images with a bare-binary entrypoint and no env
+  markers.
+- **Compose-file/local-paths only:** misses services that use pulled
+  images (no `build:` section, no local path) — exactly the case container
+  signals handle for free — and does file I/O even when the entrypoint
+  already says `dotnet`.
+
+## Design
+
+### 1. Signal capture
+
+`pkg/discovery/compose_inspect.go` — `composeContainer` gains:
+
+- `Env []string` from `Config.Env`
+- label reads: `com.docker.compose.project.config_files` and
+  `com.docker.compose.project.working_dir`
+
+`pkg/discovery/scan_compose.go` — when the app container is paired,
+`ScanResult` gains `AppRuntime string`, computed at scan time by a
+short-circuiting chain (stop at the first non-"unknown"):
+
+1. `InferRuntime(app container argv, joined)` — existing; catches
+   `dotnet X.dll`, `python app.py`, `node server.js`, `java -jar`.
+2. `InferRuntimeFromEnv(app container env)` — new in
+   `pkg/discovery/infer.go`. Env-name markers inherited from official base
+   images: `DOTNET_VERSION`/`ASPNET_VERSION` → dotnet; `NODE_VERSION` →
+   node; `PYTHON_VERSION` → python; `JAVA_VERSION`/`JAVA_HOME` → java;
+   `GOLANG_VERSION` → go; `RUST_VERSION`/`CARGO_HOME` → rust.
+3. `InferRuntimeFromImage(app image)` — existing.
+4. `runtimeFromBuildContext(...)` — section 2; only reached when 1–3 all
+   fail, so file I/O happens only for bare-binary/scratch cases. The
+   scan's existing 2s cache TTL bounds how often it can run.
+
+### 2. Build-context marker resolver
+
+New file `pkg/discovery/compose_runtime.go`:
+
+```go
+runtimeFromBuildContext(configFiles, workingDir, service string) string
+```
+
+- `configFiles` is the raw label value — comma-separated when the project
+  was started with multiple `-f` files; parse each in order, first hit
+  wins. Files must exist locally; a stack started on another host silently
+  yields "unknown".
+- Minimal YAML parse (`sigs.k8s.io/yaml`, existing direct dependency):
+  only `services.<service>.build`, honoring both compose forms — string
+  shorthand (`build: ./dotnet`) and object (`build: {context: ./dotnet}`).
+  No `build:` section (pulled image) → "unknown" immediately.
+- Resolve the context path relative to `workingDir` (the
+  `project.working_dir` label — the same base compose itself uses).
+- Marker scan, top level of the context directory only (one
+  `os.ReadDir`):
+  - `go.mod` → go
+  - `*.csproj` / `*.fsproj` / `*.sln` / `global.json` → dotnet
+  - `package.json` → node
+  - `pyproject.toml` / `requirements.txt` / `setup.py` → python
+  - `pom.xml` / `build.gradle` / `build.gradle.kts` → java
+  - `Cargo.toml` → rust
+- All failures (unreadable file, YAML error, missing service, dangling
+  context path) return "unknown" silently, matching `infer.go`'s
+  best-effort idiom.
+
+**Deliberate exception:** the compose-discovery design
+(`2026-07-04-compose-discovery-design.md`) ruled out compose-file parsing
+*as a discovery source*. This feature reads the file only as a
+display-only enrichment hint after runtime-truth signals (the running
+container) have failed; discovery correctness never depends on it.
+
+### 3. Consumption
+
+`pkg/discovery/service.go` `enrich`, compose branch: if `Runtime` is
+"unknown", use `r.AppRuntime`; if that is empty (fixtures/scanners
+predating the field), fall back to the existing
+`InferRuntimeFromImage(r.AppImage)` call. Standalone/Aspire paths
+untouched.
+
+## Edge cases
+
+| Case | Behavior |
+| --- | --- |
+| Locally built image, `dotnet X.dll` entrypoint (dapr-mq) | Step 1 resolves "dotnet"; no file I/O. |
+| Official base image, script entrypoint | Step 2 env markers or step 3 image name. |
+| Go binary in scratch image, `build:` context with `go.mod` | Step 4 resolves "go". |
+| Pulled image, unrecognizable name, no env markers | "unknown" (no `build:` to follow). |
+| Compose file moved/deleted since `up` | Step 4 fails silently → "unknown". |
+| Multiple `-f` config files | Each parsed in order; first service match with a `build:` wins. |
+| App container not paired | No argv/env/image signals; `AppRuntime` empty → "unknown". |
+
+## Testing
+
+- `InferRuntimeFromEnv`: table test over marker env names + empty/no-match.
+- `runtimeFromBuildContext`: temp-dir fixtures — string and object
+  `build:` forms, comma-separated `configFiles`, service without `build:`,
+  nonexistent context path, one marker case per runtime including the
+  `.sln` + `global.json` dotnet layout mirroring dapr-mq.
+- Scanner chain precedence: argv beats env beats image beats
+  build-context; all-unknown stays "unknown"; the file step is not reached
+  when argv resolves (fixture whose context dir would answer differently).
+- `enrich`: compose + unknown → `AppRuntime` used; empty `AppRuntime` →
+  image fallback (keeps `TestEnrichComposeCarriesContainerFields` green).
+- Full matrix (`make lint` / `make test` / `make build`) plus live check:
+  all four dapr-mq apps show **dotnet** on overview and detail.

--- a/pkg/discovery/compose_inspect.go
+++ b/pkg/discovery/compose_inspect.go
@@ -9,8 +9,10 @@ import (
 )
 
 const (
-	labelComposeProject = "com.docker.compose.project"
-	labelComposeService = "com.docker.compose.service"
+	labelComposeProject     = "com.docker.compose.project"
+	labelComposeService     = "com.docker.compose.service"
+	labelComposeConfigFiles = "com.docker.compose.project.config_files"
+	labelComposeWorkingDir  = "com.docker.compose.project.working_dir"
 )
 
 // composeContainer is the parsed subset of `docker inspect` for one
@@ -26,6 +28,10 @@ type composeContainer struct {
 	Argv      []string          // entrypoint + cmd
 	Ports     map[int]int       // container tcp port -> published host port
 	Mounts    map[string]string // container destination -> host source (bind only)
+
+	Env         []string // Config.Env — carries base-image markers like DOTNET_VERSION
+	ConfigFiles string   // host path(s) of the compose file(s), comma-separated
+	WorkingDir  string   // host project dir; base for relative build contexts
 }
 
 // rawComposeContainer mirrors the subset of `<runtime> inspect` we consume.
@@ -41,6 +47,7 @@ type rawComposeContainer struct {
 		Labels     map[string]string `json:"Labels"`
 		Entrypoint []string          `json:"Entrypoint"`
 		Cmd        []string          `json:"Cmd"`
+		Env        []string          `json:"Env"`
 	} `json:"Config"`
 	NetworkSettings struct {
 		Ports map[string][]struct {
@@ -77,6 +84,10 @@ func parseComposeContainers(data []byte) ([]composeContainer, error) {
 			Argv:    append(append([]string{}, r.Config.Entrypoint...), r.Config.Cmd...),
 			Ports:   map[int]int{},
 			Mounts:  map[string]string{},
+
+			Env:         r.Config.Env,
+			ConfigFiles: r.Config.Labels[labelComposeConfigFiles],
+			WorkingDir:  r.Config.Labels[labelComposeWorkingDir],
 		}
 		c.StartedAt, _ = time.Parse(time.RFC3339Nano, r.State.StartedAt)
 		for spec, bindings := range r.NetworkSettings.Ports {

--- a/pkg/discovery/compose_runtime.go
+++ b/pkg/discovery/compose_runtime.go
@@ -1,0 +1,146 @@
+package discovery
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// composeFileServices is the minimal compose-file subset we consume: only
+// each service's build key, which compose allows as either a string
+// (context shorthand) or an object. sigs.k8s.io/yaml converts YAML to JSON
+// first, so json tags and json.RawMessage apply.
+type composeFileServices struct {
+	Services map[string]struct {
+		Build json.RawMessage `json:"build,omitempty"`
+	} `json:"services"`
+}
+
+// runtimeFromBuildContext infers the app language from marker files in the
+// service's local build context, located via the compose project labels
+// (com.docker.compose.project.config_files / .working_dir). configFiles is
+// the raw label value — comma-separated when the project was started with
+// multiple -f files; the first file that yields a runtime wins. Best-effort:
+// any failure (missing/foreign compose file, YAML error, no build section,
+// unreadable dir) yields "unknown". Display-only enrichment — discovery
+// correctness never depends on it (see the design doc for why compose-file
+// parsing is otherwise avoided).
+func runtimeFromBuildContext(configFiles, workingDir, service string) string {
+	if configFiles == "" || service == "" {
+		return "unknown"
+	}
+
+	parts := strings.Split(configFiles, ",")
+
+	// Try each comma-separated part. If it fails and there's a next part,
+	// try merging with the next part (handles paths that contain commas).
+	for i := 0; i < len(parts); {
+		cf := strings.TrimSpace(parts[i])
+
+		dir, ok := buildContextDir(cf, workingDir, service)
+		if ok {
+			if rt := runtimeFromMarkerFiles(dir); rt != "unknown" {
+				return rt
+			}
+			i++
+			continue
+		}
+
+		// If this part failed and there's a next part, try merging
+		if i+1 < len(parts) {
+			mergedCF := cf + "," + strings.TrimSpace(parts[i+1])
+			dir, ok := buildContextDir(mergedCF, workingDir, service)
+			if ok {
+				if rt := runtimeFromMarkerFiles(dir); rt != "unknown" {
+					return rt
+				}
+				// Skip the next part since we merged it
+				i += 2
+				continue
+			}
+		}
+
+		i++
+	}
+
+	return "unknown"
+}
+
+// buildContextDir resolves the local build-context directory for service
+// from one compose file, or ok=false when it cannot.
+func buildContextDir(configFile, workingDir, service string) (string, bool) {
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		return "", false
+	}
+	var doc composeFileServices
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return "", false
+	}
+	svc, ok := doc.Services[service]
+	if !ok || len(svc.Build) == 0 {
+		return "", false
+	}
+	var ctx string
+	if err := json.Unmarshal(svc.Build, &ctx); err != nil {
+		var obj struct {
+			Context string `json:"context"`
+		}
+		if err := json.Unmarshal(svc.Build, &obj); err != nil {
+			return "", false
+		}
+		ctx = obj.Context
+	}
+	if ctx == "" {
+		ctx = "."
+	}
+	if !filepath.IsAbs(ctx) {
+		base := workingDir
+		if base == "" {
+			base = filepath.Dir(configFile)
+		}
+		ctx = filepath.Join(base, ctx)
+	}
+	return ctx, true
+}
+
+// runtimeFromMarkerFiles inspects the top level of dir for well-known
+// project marker files. Markers are checked in a fixed priority order (not
+// directory order) so polyglot contexts resolve deterministically —
+// package.json last, since it shows up in many non-Node repos.
+func runtimeFromMarkerFiles(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "unknown"
+	}
+	names := map[string]bool{}
+	dotnetProj := false
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		n := strings.ToLower(e.Name())
+		names[n] = true
+		if strings.HasSuffix(n, ".csproj") || strings.HasSuffix(n, ".fsproj") || strings.HasSuffix(n, ".sln") {
+			dotnetProj = true
+		}
+	}
+	switch {
+	case names["go.mod"]:
+		return "go"
+	case dotnetProj, names["global.json"]:
+		return "dotnet"
+	case names["cargo.toml"]:
+		return "rust"
+	case names["pom.xml"], names["build.gradle"], names["build.gradle.kts"]:
+		return "java"
+	case names["pyproject.toml"], names["requirements.txt"], names["setup.py"]:
+		return "python"
+	case names["package.json"]:
+		return "node"
+	}
+	return "unknown"
+}

--- a/pkg/discovery/compose_runtime.go
+++ b/pkg/discovery/compose_runtime.go
@@ -32,40 +32,15 @@ func runtimeFromBuildContext(configFiles, workingDir, service string) string {
 	if configFiles == "" || service == "" {
 		return "unknown"
 	}
-
-	parts := strings.Split(configFiles, ",")
-
-	// Try each comma-separated part. If it fails and there's a next part,
-	// try merging with the next part (handles paths that contain commas).
-	for i := 0; i < len(parts); {
-		cf := strings.TrimSpace(parts[i])
-
-		dir, ok := buildContextDir(cf, workingDir, service)
-		if ok {
-			if rt := runtimeFromMarkerFiles(dir); rt != "unknown" {
-				return rt
-			}
-			i++
+	for _, cf := range strings.Split(configFiles, ",") {
+		dir, ok := buildContextDir(strings.TrimSpace(cf), workingDir, service)
+		if !ok {
 			continue
 		}
-
-		// If this part failed and there's a next part, try merging
-		if i+1 < len(parts) {
-			mergedCF := cf + "," + strings.TrimSpace(parts[i+1])
-			dir, ok := buildContextDir(mergedCF, workingDir, service)
-			if ok {
-				if rt := runtimeFromMarkerFiles(dir); rt != "unknown" {
-					return rt
-				}
-				// Skip the next part since we merged it
-				i += 2
-				continue
-			}
+		if rt := runtimeFromMarkerFiles(dir); rt != "unknown" {
+			return rt
 		}
-
-		i++
 	}
-
 	return "unknown"
 }
 

--- a/pkg/discovery/compose_runtime.go
+++ b/pkg/discovery/compose_runtime.go
@@ -119,3 +119,20 @@ func runtimeFromMarkerFiles(dir string) string {
 	}
 	return "unknown"
 }
+
+// composeAppRuntime resolves the app's language from scan data, cheapest
+// signal first: launch command, base-image env markers, image name, and
+// finally marker files in the service's local build context (the only step
+// that touches the filesystem).
+func composeAppRuntime(app composeContainer) string {
+	if rt := InferRuntime(strings.Join(app.Argv, " ")); rt != "unknown" {
+		return rt
+	}
+	if rt := InferRuntimeFromEnv(app.Env); rt != "unknown" {
+		return rt
+	}
+	if rt := InferRuntimeFromImage(app.Image); rt != "unknown" {
+		return rt
+	}
+	return runtimeFromBuildContext(app.ConfigFiles, app.WorkingDir, app.Service)
+}

--- a/pkg/discovery/compose_runtime_test.go
+++ b/pkg/discovery/compose_runtime_test.go
@@ -79,7 +79,9 @@ func TestRuntimeFromBuildContext(t *testing.T) {
 		writeFile(t, cf, "services:\n  web:\n    build: .\n")
 		require.Equal(t, "unknown", runtimeFromBuildContext(cf, proj, "other"))
 	})
-	t.Run("comma-separated config files, second resolves", func(t *testing.T) {
+	// No comma in the subtest name: t.TempDir embeds the name in the path,
+	// and a comma there would collide with the label's comma separator.
+	t.Run("comma-separated config files - second resolves", func(t *testing.T) {
 		proj := t.TempDir()
 		writeFile(t, filepath.Join(proj, "app", "Cargo.toml"), "[package]")
 		cf1 := filepath.Join(proj, "missing.yml") // does not exist

--- a/pkg/discovery/compose_runtime_test.go
+++ b/pkg/discovery/compose_runtime_test.go
@@ -115,3 +115,44 @@ func TestRuntimeFromBuildContext(t *testing.T) {
 		require.Equal(t, "node", runtimeFromBuildContext(cf, proj, "web"))
 	})
 }
+
+func TestComposeAppRuntimeChainPrecedence(t *testing.T) {
+	// Build-context fixture that would say "go" if reached.
+	proj := t.TempDir()
+	writeFile(t, filepath.Join(proj, "svc", "go.mod"), "module x")
+	cf := filepath.Join(proj, "docker-compose.yml")
+	writeFile(t, cf, "services:\n  web:\n    build: ./svc\n")
+
+	base := composeContainer{Service: "web", ConfigFiles: cf, WorkingDir: proj}
+
+	t.Run("argv beats everything", func(t *testing.T) {
+		app := base
+		app.Argv = []string{"dotnet", "App.dll"}
+		app.Env = []string{"NODE_VERSION=22"}
+		app.Image = "python:3.12"
+		require.Equal(t, "dotnet", composeAppRuntime(app))
+	})
+	t.Run("env beats image and files", func(t *testing.T) {
+		app := base
+		app.Argv = []string{"/entrypoint.sh"}
+		app.Env = []string{"NODE_VERSION=22"}
+		app.Image = "python:3.12"
+		require.Equal(t, "node", composeAppRuntime(app))
+	})
+	t.Run("image beats files", func(t *testing.T) {
+		app := base
+		app.Argv = []string{"/app/server"}
+		app.Image = "python:3.12"
+		require.Equal(t, "python", composeAppRuntime(app))
+	})
+	t.Run("build context is the last resort", func(t *testing.T) {
+		app := base
+		app.Argv = []string{"/app/server"}
+		app.Image = "custom-app"
+		require.Equal(t, "go", composeAppRuntime(app))
+	})
+	t.Run("all unknown", func(t *testing.T) {
+		app := composeContainer{Service: "web", Argv: []string{"/app/server"}, Image: "custom-app"}
+		require.Equal(t, "unknown", composeAppRuntime(app))
+	})
+}

--- a/pkg/discovery/compose_runtime_test.go
+++ b/pkg/discovery/compose_runtime_test.go
@@ -1,0 +1,115 @@
+//go:build unit
+
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeFile creates path (and parents) with content.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func TestRuntimeFromMarkerFiles(t *testing.T) {
+	cases := []struct {
+		name  string
+		files []string
+		want  string
+	}{
+		{"go", []string{"go.mod"}, "go"},
+		{"dotnet sln and global.json (dapr-mq layout)", []string{"DaprMQ.sln", "global.json", "NuGet.config"}, "dotnet"},
+		{"dotnet csproj", []string{"App.csproj"}, "dotnet"},
+		{"node", []string{"package.json"}, "node"},
+		{"python", []string{"requirements.txt"}, "python"},
+		{"java", []string{"pom.xml"}, "java"},
+		{"rust", []string{"Cargo.toml"}, "rust"},
+		{"priority: go.mod beats package.json", []string{"package.json", "go.mod"}, "go"},
+		{"no markers", []string{"README.md"}, "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, f := range tc.files {
+				writeFile(t, filepath.Join(dir, f), "x")
+			}
+			require.Equal(t, tc.want, runtimeFromMarkerFiles(dir))
+		})
+	}
+	t.Run("nonexistent dir", func(t *testing.T) {
+		require.Equal(t, "unknown", runtimeFromMarkerFiles(filepath.Join(t.TempDir(), "nope")))
+	})
+	t.Run("markers in subdirs do not count", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "src", "go.mod"), "x")
+		require.Equal(t, "unknown", runtimeFromMarkerFiles(dir))
+	})
+}
+
+func TestRuntimeFromBuildContext(t *testing.T) {
+	t.Run("string build shorthand", func(t *testing.T) {
+		proj := t.TempDir()
+		writeFile(t, filepath.Join(proj, "dotnet", "global.json"), "{}")
+		cf := filepath.Join(proj, "docker-compose.yml")
+		writeFile(t, cf, "services:\n  web:\n    build: ./dotnet\n")
+		require.Equal(t, "dotnet", runtimeFromBuildContext(cf, proj, "web"))
+	})
+	t.Run("object build with context", func(t *testing.T) {
+		proj := t.TempDir()
+		writeFile(t, filepath.Join(proj, "svc", "go.mod"), "module x")
+		cf := filepath.Join(proj, "docker-compose.yml")
+		writeFile(t, cf, "services:\n  web:\n    build:\n      context: ./svc\n      dockerfile: Dockerfile\n")
+		require.Equal(t, "go", runtimeFromBuildContext(cf, proj, "web"))
+	})
+	t.Run("service without build section (pulled image)", func(t *testing.T) {
+		proj := t.TempDir()
+		cf := filepath.Join(proj, "docker-compose.yml")
+		writeFile(t, cf, "services:\n  web:\n    image: nginx\n")
+		require.Equal(t, "unknown", runtimeFromBuildContext(cf, proj, "web"))
+	})
+	t.Run("unknown service", func(t *testing.T) {
+		proj := t.TempDir()
+		cf := filepath.Join(proj, "docker-compose.yml")
+		writeFile(t, cf, "services:\n  web:\n    build: .\n")
+		require.Equal(t, "unknown", runtimeFromBuildContext(cf, proj, "other"))
+	})
+	t.Run("comma-separated config files, second resolves", func(t *testing.T) {
+		proj := t.TempDir()
+		writeFile(t, filepath.Join(proj, "app", "Cargo.toml"), "[package]")
+		cf1 := filepath.Join(proj, "missing.yml") // does not exist
+		cf2 := filepath.Join(proj, "docker-compose.yml")
+		writeFile(t, cf2, "services:\n  web:\n    build: ./app\n")
+		require.Equal(t, "rust", runtimeFromBuildContext(cf1+","+cf2, proj, "web"))
+	})
+	t.Run("dangling context path", func(t *testing.T) {
+		proj := t.TempDir()
+		cf := filepath.Join(proj, "docker-compose.yml")
+		writeFile(t, cf, "services:\n  web:\n    build: ./gone\n")
+		require.Equal(t, "unknown", runtimeFromBuildContext(cf, proj, "web"))
+	})
+	t.Run("invalid yaml", func(t *testing.T) {
+		proj := t.TempDir()
+		cf := filepath.Join(proj, "docker-compose.yml")
+		writeFile(t, cf, "services: [not: valid: yaml")
+		require.Equal(t, "unknown", runtimeFromBuildContext(cf, proj, "web"))
+	})
+	t.Run("empty inputs", func(t *testing.T) {
+		require.Equal(t, "unknown", runtimeFromBuildContext("", "", "web"))
+		require.Equal(t, "unknown", runtimeFromBuildContext("x.yml", "", ""))
+	})
+	t.Run("relative context resolved against workingDir not cwd", func(t *testing.T) {
+		proj := t.TempDir()
+		writeFile(t, filepath.Join(proj, "js", "package.json"), "{}")
+		// compose file lives elsewhere; workingDir is the project dir
+		other := t.TempDir()
+		cf := filepath.Join(other, "compose.yml")
+		writeFile(t, cf, "services:\n  web:\n    build: ./js\n")
+		require.Equal(t, "node", runtimeFromBuildContext(cf, proj, "web"))
+	})
+}

--- a/pkg/discovery/infer.go
+++ b/pkg/discovery/infer.go
@@ -47,3 +47,27 @@ func InferRuntimeFromImage(image string) string {
 		return "unknown"
 	}
 }
+
+// InferRuntimeFromEnv guesses the app's language from environment variables
+// inherited from official base images (best-effort, conservative — only
+// well-known variable names count, never values).
+func InferRuntimeFromEnv(env []string) string {
+	for _, kv := range env {
+		name, _, _ := strings.Cut(kv, "=")
+		switch name {
+		case "DOTNET_VERSION", "ASPNET_VERSION":
+			return "dotnet"
+		case "NODE_VERSION":
+			return "node"
+		case "PYTHON_VERSION":
+			return "python"
+		case "JAVA_VERSION", "JAVA_HOME":
+			return "java"
+		case "GOLANG_VERSION":
+			return "go"
+		case "RUST_VERSION", "CARGO_HOME":
+			return "rust"
+		}
+	}
+	return "unknown"
+}

--- a/pkg/discovery/infer_test.go
+++ b/pkg/discovery/infer_test.go
@@ -42,3 +42,27 @@ func TestInferRuntimeFromImage(t *testing.T) {
 		}
 	}
 }
+
+func TestInferRuntimeFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		env  []string
+		want string
+	}{
+		{"dotnet version", []string{"PATH=/usr/bin", "DOTNET_VERSION=10.0.9"}, "dotnet"},
+		{"aspnet version", []string{"ASPNET_VERSION=10.0.9"}, "dotnet"},
+		{"node", []string{"NODE_VERSION=22.1.0"}, "node"},
+		{"python", []string{"PYTHON_VERSION=3.12.4"}, "python"},
+		{"java version", []string{"JAVA_VERSION=21"}, "java"},
+		{"java home", []string{"JAVA_HOME=/opt/java"}, "java"},
+		{"golang", []string{"GOLANG_VERSION=1.23.4"}, "go"},
+		{"rust", []string{"RUST_VERSION=1.79"}, "rust"},
+		{"cargo home", []string{"CARGO_HOME=/usr/local/cargo"}, "rust"},
+		{"no markers", []string{"PATH=/usr/bin", "HOME=/root"}, "unknown"},
+		{"empty", nil, "unknown"},
+		{"value not name", []string{"FOO=NODE_VERSION"}, "unknown"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { require.Equal(t, tc.want, InferRuntimeFromEnv(tc.env)) })
+	}
+}

--- a/pkg/discovery/scan_compose.go
+++ b/pkg/discovery/scan_compose.go
@@ -194,6 +194,7 @@ func (s *ComposeSource) scanOnce() ([]ScanResult, ComposeEnv, error) {
 			r.AppContainerID = app.ID
 			r.AppContainerName = app.Name
 			r.AppImage = app.Image
+			r.AppRuntime = composeAppRuntime(app)
 		}
 		results = append(results, r)
 	}

--- a/pkg/discovery/scan_compose_test.go
+++ b/pkg/discovery/scan_compose_test.go
@@ -81,6 +81,12 @@ func TestComposeSourceScan(t *testing.T) {
 	if r.AppImage != "saga-primes-go" {
 		t.Fatalf("app image: %+v", r)
 	}
+	// App runtime: fixture app container has entrypoint /app/server (no
+	// command signal), image saga-primes-go (no image signal), and
+	// GOLANG_VERSION in env — the env marker resolves it.
+	if r.AppRuntime != "go" {
+		t.Fatalf("app runtime from env marker: %+v", r)
+	}
 	if len(r.ResourcePaths) != 1 || r.ResourcePaths[0] != "/Users/dev/saga/components" {
 		t.Fatalf("host resource path: %+v", r.ResourcePaths)
 	}

--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -68,7 +68,8 @@ func (r ScanResult) Key() string {
 
 type Service interface {
 	List(ctx context.Context) ([]Instance, error)
-	Get(ctx context.Context, appID string) (Instance, error)
+	// Get resolves key as an InstanceKey first, then as an AppID (first match).
+	Get(ctx context.Context, key string) (Instance, error)
 }
 
 type service struct {
@@ -113,18 +114,27 @@ func (s *service) List(ctx context.Context) ([]Instance, error) {
 	return out, nil
 }
 
-func (s *service) Get(ctx context.Context, appID string) (Instance, error) {
+// Get resolves key as an instance key first (container name for compose
+// apps), then as an app id. The app-id fallback keeps legacy links working —
+// e.g. workflow pages, which only know the daprd app id — and resolves
+// duplicates to the first instance in scan order.
+func (s *service) Get(ctx context.Context, key string) (Instance, error) {
 	results, err := s.scan()
 	if err != nil {
 		logger().Error("app scan failed", "err", err)
 		return Instance{}, err
 	}
 	for _, r := range results {
-		if r.AppID == appID {
+		if r.Key() == key {
 			return s.enrich(ctx, r), nil
 		}
 	}
-	return Instance{}, fmt.Errorf("%w: %s", ErrNotFound, appID)
+	for _, r := range results {
+		if r.AppID == key {
+			return s.enrich(ctx, r), nil
+		}
+	}
+	return Instance{}, fmt.Errorf("%w: %s", ErrNotFound, key)
 }
 
 func (s *service) enrich(ctx context.Context, r ScanResult) Instance {

--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -49,6 +49,23 @@ type ScanResult struct {
 	SidecarReachable bool
 }
 
+// Key returns the routing identity for this scan result. Compose sidecars can
+// share one -app-id (scaled instances), so they key by container name — the
+// app container when paired, else the daprd container; everything else keys
+// by AppID. Container names are unique per host, so keys are unique whenever
+// a container name is available.
+func (r ScanResult) Key() string {
+	if r.Source == SourceCompose {
+		if r.AppContainerName != "" {
+			return r.AppContainerName
+		}
+		if r.DaprdContainerName != "" {
+			return r.DaprdContainerName
+		}
+	}
+	return r.AppID
+}
+
 type Service interface {
 	List(ctx context.Context) ([]Instance, error)
 	Get(ctx context.Context, appID string) (Instance, error)
@@ -86,7 +103,12 @@ func (s *service) List(ctx context.Context) ([]Instance, error) {
 		}(i, r)
 	}
 	wg.Wait()
-	sort.SliceStable(out, func(a, b int) bool { return out[a].AppID < out[b].AppID })
+	sort.SliceStable(out, func(a, b int) bool {
+		if out[a].AppID != out[b].AppID {
+			return out[a].AppID < out[b].AppID
+		}
+		return out[a].InstanceKey < out[b].InstanceKey
+	})
 	logger().Info("discovered Dapr apps", "count", len(out))
 	return out, nil
 }
@@ -107,7 +129,7 @@ func (s *service) Get(ctx context.Context, appID string) (Instance, error) {
 
 func (s *service) enrich(ctx context.Context, r ScanResult) Instance {
 	in := Instance{
-		AppID: r.AppID, HTTPPort: r.HTTPPort, GRPCPort: r.GRPCPort, AppPort: r.AppPort,
+		AppID: r.AppID, InstanceKey: r.Key(), HTTPPort: r.HTTPPort, GRPCPort: r.GRPCPort, AppPort: r.AppPort,
 		DaprdPID: r.DaprdPID, CLIPID: r.CLIPID, RunTemplate: r.RunTemplate,
 		ResourcePaths: r.ResourcePaths, ConfigPath: r.ConfigPath, Command: r.Command,
 		Created: r.Created.Local().Format("15:04:05"), Age: humanAge(r.Created),

--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -157,7 +157,13 @@ func (s *service) enrich(ctx context.Context, r ScanResult) Instance {
 		in.SidecarReachable = true
 	}
 	if in.Source == SourceCompose && in.Runtime == "unknown" {
-		in.Runtime = InferRuntimeFromImage(r.AppImage)
+		// Prefer the scanner's signal chain (argv → env → image → build
+		// context); fall back to image inference for scan results that
+		// predate AppRuntime (test fixtures).
+		in.Runtime = r.AppRuntime
+		if in.Runtime == "" || in.Runtime == "unknown" {
+			in.Runtime = InferRuntimeFromImage(r.AppImage)
+		}
 	}
 	// An unreachable sidecar (compose, HTTP port unpublished) cannot answer
 	// health or metadata — skip both probes instead of burning their timeouts.

--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -44,6 +44,9 @@ type ScanResult struct {
 	AppContainerID     string
 	AppContainerName   string
 	AppImage           string
+	// AppRuntime is the compose scanner's language inference for the app
+	// container ("" for other sources; possibly "unknown").
+	AppRuntime string
 	// SidecarReachable is false only for compose sidecars whose HTTP port is
 	// not published to the host (metadata/health enrichment impossible).
 	SidecarReachable bool

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -323,3 +323,43 @@ func TestListSetsInstanceKeyAndSortsWithinAppID(t *testing.T) {
 	require.Equal(t, "daprmq-gateway-1", list[1].InstanceKey)
 	require.Equal(t, "daprmq-host-2", list[2].InstanceKey)
 }
+
+func TestGetResolvesInstanceKeyThenAppID(t *testing.T) {
+	scan := func() ([]ScanResult, error) {
+		return []ScanResult{
+			{AppID: "daprmq-service", Source: SourceCompose, SidecarReachable: false, AppContainerName: "daprmq-gateway-1", DaprdContainerID: "aaa"},
+			{AppID: "daprmq-service", Source: SourceCompose, SidecarReachable: false, AppContainerName: "daprmq-host-1", DaprdContainerID: "bbb"},
+		}, nil
+	}
+	svc := New(scan, &http.Client{Timeout: time.Millisecond})
+
+	// Exact instance-key hit returns that instance, not the first app-id match.
+	in, err := svc.Get(context.Background(), "daprmq-host-1")
+	require.NoError(t, err)
+	require.Equal(t, "bbb", in.DaprdContainerID)
+	require.Equal(t, "daprmq-host-1", in.InstanceKey)
+
+	// A plain app id falls back to the first matching instance (legacy links).
+	in, err = svc.Get(context.Background(), "daprmq-service")
+	require.NoError(t, err)
+	require.Equal(t, "aaa", in.DaprdContainerID)
+
+	// Unknown key still errors.
+	_, err = svc.Get(context.Background(), "nope")
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestGetInstanceKeyMatchBeatsAppIDMatch(t *testing.T) {
+	// "orders" is app-id of the FIRST result but instance key of the SECOND;
+	// the key pass must win even though the app-id match appears earlier.
+	scan := func() ([]ScanResult, error) {
+		return []ScanResult{
+			{AppID: "orders", Source: SourceCompose, SidecarReachable: false, AppContainerName: "orders-ctr", DaprdContainerID: "first"},
+			{AppID: "other", Source: SourceCompose, SidecarReachable: false, AppContainerName: "orders", DaprdContainerID: "second"},
+		}, nil
+	}
+	svc := New(scan, &http.Client{Timeout: time.Millisecond})
+	in, err := svc.Get(context.Background(), "orders")
+	require.NoError(t, err)
+	require.Equal(t, "second", in.DaprdContainerID)
+}

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -363,3 +363,23 @@ func TestGetInstanceKeyMatchBeatsAppIDMatch(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "second", in.DaprdContainerID)
 }
+
+func TestEnrichComposeUsesAppRuntime(t *testing.T) {
+	scan := func() ([]ScanResult, error) {
+		return []ScanResult{
+			// Scanner chain resolved: wins over image inference.
+			{AppID: "a", Source: SourceCompose, SidecarReachable: false, AppRuntime: "dotnet", AppImage: "python:3.12"},
+			// Chain exhausted ("unknown"): image fallback still applies.
+			{AppID: "b", Source: SourceCompose, SidecarReachable: false, AppRuntime: "unknown", AppImage: "python:3.12"},
+			// Field absent (older fixtures): image fallback still applies.
+			{AppID: "c", Source: SourceCompose, SidecarReachable: false, AppImage: "node:22"},
+		}, nil
+	}
+	svc := New(scan, http.DefaultClient)
+	apps, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, apps, 3)
+	require.Equal(t, "dotnet", apps[0].Runtime)
+	require.Equal(t, "python", apps[1].Runtime)
+	require.Equal(t, "node", apps[2].Runtime)
+}

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -283,3 +283,43 @@ func TestHumanAge(t *testing.T) {
 		require.Equal(t, "0s", humanAge(now.Add(5*time.Second)))
 	})
 }
+
+func TestScanResultKey(t *testing.T) {
+	t.Run("compose uses app container name", func(t *testing.T) {
+		r := ScanResult{AppID: "daprmq-service", Source: SourceCompose, AppContainerName: "daprmq-host-1", DaprdContainerName: "daprmq-host-1-dapr"}
+		require.Equal(t, "daprmq-host-1", r.Key())
+	})
+	t.Run("compose falls back to daprd container name", func(t *testing.T) {
+		r := ScanResult{AppID: "daprmq-service", Source: SourceCompose, DaprdContainerName: "daprmq-host-1-dapr"}
+		require.Equal(t, "daprmq-host-1-dapr", r.Key())
+	})
+	t.Run("compose falls back to app id", func(t *testing.T) {
+		r := ScanResult{AppID: "daprmq-service", Source: SourceCompose}
+		require.Equal(t, "daprmq-service", r.Key())
+	})
+	t.Run("standalone always keys by app id", func(t *testing.T) {
+		r := ScanResult{AppID: "order", Source: SourceStandalone, AppContainerName: "ignored"}
+		require.Equal(t, "order", r.Key())
+	})
+	t.Run("empty source keys by app id", func(t *testing.T) {
+		require.Equal(t, "order", ScanResult{AppID: "order"}.Key())
+	})
+}
+
+func TestListSetsInstanceKeyAndSortsWithinAppID(t *testing.T) {
+	scan := func() ([]ScanResult, error) {
+		return []ScanResult{
+			{AppID: "daprmq-service", Source: SourceCompose, SidecarReachable: false, AppContainerName: "daprmq-host-2"},
+			{AppID: "daprmq-service", Source: SourceCompose, SidecarReachable: false, AppContainerName: "daprmq-gateway-1"},
+			{AppID: "aaa-app"},
+		}, nil
+	}
+	svc := New(scan, &http.Client{Timeout: time.Millisecond})
+	list, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, list, 3)
+	require.Equal(t, "aaa-app", list[0].AppID)
+	require.Equal(t, "aaa-app", list[0].InstanceKey) // standalone: key == app id
+	require.Equal(t, "daprmq-gateway-1", list[1].InstanceKey)
+	require.Equal(t, "daprmq-host-2", list[2].InstanceKey)
+}

--- a/pkg/discovery/testdata/compose_inspect.json
+++ b/pkg/discovery/testdata/compose_inspect.json
@@ -27,7 +27,8 @@
       "Image": "saga-primes-go",
       "Labels": { "com.docker.compose.project": "saga", "com.docker.compose.service": "primes-go" },
       "Entrypoint": ["/app/server"],
-      "Cmd": null
+      "Cmd": null,
+      "Env": ["PATH=/usr/local/bin:/usr/bin", "GOLANG_VERSION=1.23.4"]
     },
     "NetworkSettings": { "Ports": { "8080/tcp": [ { "HostIp": "0.0.0.0", "HostPort": "8081" } ] } },
     "Mounts": []

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -12,7 +12,11 @@ const (
 
 // Instance represents a running application instance with Dapr
 type Instance struct {
-	AppID              string         `json:"appId"`
+	AppID string `json:"appId"`
+	// InstanceKey is the routing identity: container name for compose apps
+	// (falling back to app id), app id otherwise. Unique per instance even
+	// when several compose sidecars share one -app-id.
+	InstanceKey        string         `json:"instanceKey"`
 	Health             Health         `json:"health"`
 	Runtime            string         `json:"runtime"`            // e.g. "go", "python", "node", "dotnet", "java", "rust", "unknown"
 	IsAspire           bool           `json:"isAspire,omitempty"` // true when the app is .NET Aspire-managed

--- a/pkg/server/actors.go
+++ b/pkg/server/actors.go
@@ -10,10 +10,20 @@ import (
 
 // ActorRow is a single actor-type entry returned by GET /api/actors.
 type ActorRow struct {
-	AppID     string `json:"appId"`
-	Type      string `json:"type"`
-	Count     int    `json:"count"`
-	Placement string `json:"placement,omitempty"`
+	AppID       string `json:"appId"`
+	InstanceKey string `json:"instanceKey"`
+	Type        string `json:"type"`
+	Count       int    `json:"count"`
+	Placement   string `json:"placement,omitempty"`
+}
+
+// instanceKey returns the instance's routing identity, tolerating fixtures
+// (and any pre-InstanceKey producer) that only set AppID.
+func instanceKey(in discovery.Instance) string {
+	if in.InstanceKey != "" {
+		return in.InstanceKey
+	}
+	return in.AppID
 }
 
 func actorsRouter(apps discovery.Service) http.Handler {
@@ -31,7 +41,7 @@ func actorsRouter(apps discovery.Service) http.Handler {
 				continue
 			}
 			for _, a := range in.Actors {
-				rows = append(rows, ActorRow{AppID: in.AppID, Type: a.Type, Count: a.Count, Placement: in.Placement})
+				rows = append(rows, ActorRow{AppID: in.AppID, InstanceKey: instanceKey(in), Type: a.Type, Count: a.Count, Placement: in.Placement})
 			}
 		}
 		sort.SliceStable(rows, func(i, j int) bool {

--- a/pkg/server/actors_test.go
+++ b/pkg/server/actors_test.go
@@ -28,3 +28,18 @@ func TestActorsAggregate(t *testing.T) {
 	require.Contains(t, body, `"type":"OrderActor"`)
 	require.NotContains(t, body, `"type":"CartActor"`)
 }
+
+func TestActorsRowsCarryInstanceKey(t *testing.T) {
+	apps := &fakeApps{instances: []discovery.Instance{
+		{AppID: "daprmq-service", InstanceKey: "daprmq-host-1", Actors: []discovery.ActorType{{Type: "QueueActor", Count: 1}}},
+		{AppID: "daprmq-service", InstanceKey: "daprmq-host-2", Actors: []discovery.ActorType{{Type: "QueueActor", Count: 2}}},
+		// Fixture without InstanceKey (pre-existing shape) falls back to app id.
+		{AppID: "cart", Actors: []discovery.ActorType{{Type: "CartActor", Count: 1}}},
+	}}
+	h := actorsRouter(apps)
+	res, body := get(t, h, "/")
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Contains(t, body, `"instanceKey":"daprmq-host-1"`)
+	require.Contains(t, body, `"instanceKey":"daprmq-host-2"`)
+	require.Contains(t, body, `"instanceKey":"cart"`)
+}

--- a/pkg/server/resources.go
+++ b/pkg/server/resources.go
@@ -59,7 +59,7 @@ func resourcesRouter(res resources.Service, apps discovery.Service) http.Handler
 	return r
 }
 
-// loadedByFor returns the sorted app ids whose instance contains component name.
+// loadedByFor returns the sorted instance keys whose instance contains component name.
 // It lists apps once and scans only for the requested name, avoiding a full index build.
 func loadedByFor(ctx context.Context, apps discovery.Service, name string) []string {
 	list, err := apps.List(ctx)
@@ -70,7 +70,7 @@ func loadedByFor(ctx context.Context, apps discovery.Service, name string) []str
 	for _, in := range list {
 		for _, c := range in.Components {
 			if c.Name == name {
-				ids = append(ids, in.AppID)
+				ids = append(ids, instanceKey(in))
 				break
 			}
 		}
@@ -79,7 +79,7 @@ func loadedByFor(ctx context.Context, apps discovery.Service, name string) []str
 	return ids
 }
 
-// loadedByIndex maps component name -> sorted app ids that loaded it.
+// loadedByIndex maps component name -> sorted instance keys that loaded it.
 func loadedByIndex(ctx context.Context, apps discovery.Service) map[string][]string {
 	idx := map[string][]string{}
 	list, err := apps.List(ctx)
@@ -88,7 +88,7 @@ func loadedByIndex(ctx context.Context, apps discovery.Service) map[string][]str
 	}
 	for _, in := range list {
 		for _, c := range in.Components {
-			idx[c.Name] = append(idx[c.Name], in.AppID)
+			idx[c.Name] = append(idx[c.Name], instanceKey(in))
 		}
 	}
 	for k := range idx {

--- a/pkg/server/resources_test.go
+++ b/pkg/server/resources_test.go
@@ -56,3 +56,20 @@ func TestResourcesListWithLoadedBy(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, r5.StatusCode)
 	require.Contains(t, body5, `"error":"kind must be component or configuration"`)
 }
+
+func TestLoadedByUsesInstanceKeys(t *testing.T) {
+	res := fakeResources{items: []resources.Resource{{Name: "statestore", Kind: resources.KindComponent, Type: "state.postgresql"}}}
+	apps := &fakeApps{instances: []discovery.Instance{
+		{AppID: "daprmq-service", InstanceKey: "daprmq-host-1", Components: []discovery.Component{{Name: "statestore"}}},
+		{AppID: "daprmq-service", InstanceKey: "daprmq-host-2", Components: []discovery.Component{{Name: "statestore"}}},
+	}}
+	h := resourcesRouter(res, apps)
+
+	r1, body := get(t, h, "/component/statestore")
+	require.Equal(t, http.StatusOK, r1.StatusCode)
+	require.Contains(t, body, `"loadedBy":["daprmq-host-1","daprmq-host-2"]`)
+
+	r2, body2 := get(t, h, "/?kind=component")
+	require.Equal(t, http.StatusOK, r2.StatusCode)
+	require.Contains(t, body2, `"loadedBy":["daprmq-host-1","daprmq-host-2"]`)
+}

--- a/pkg/server/subscriptions.go
+++ b/pkg/server/subscriptions.go
@@ -11,6 +11,7 @@ import (
 // SubscriptionRow is a single subscription entry returned by GET /api/subscriptions.
 type SubscriptionRow struct {
 	AppID           string              `json:"appId"`
+	InstanceKey     string              `json:"instanceKey"`
 	PubsubName      string              `json:"pubsubName"`
 	Topic           string              `json:"topic"`
 	Rules           []discovery.SubRule `json:"rules,omitempty"`
@@ -35,6 +36,7 @@ func subscriptionsRouter(apps discovery.Service) http.Handler {
 			for _, s := range in.Subscriptions {
 				rows = append(rows, SubscriptionRow{
 					AppID:           in.AppID,
+					InstanceKey:     instanceKey(in),
 					PubsubName:      s.PubsubName,
 					Topic:           s.Topic,
 					Rules:           s.Rules,

--- a/pkg/server/subscriptions_test.go
+++ b/pkg/server/subscriptions_test.go
@@ -27,3 +27,15 @@ func TestSubscriptionsAggregate(t *testing.T) {
 	require.Contains(t, body, `"carts"`)
 	require.NotContains(t, body, `"orders"`)
 }
+
+func TestSubscriptionsRowsCarryInstanceKey(t *testing.T) {
+	apps := &fakeApps{instances: []discovery.Instance{
+		{AppID: "daprmq-service", InstanceKey: "daprmq-host-1", Subscriptions: []discovery.Subscription{{PubsubName: "kafka-pubsub", Topic: "orders"}}},
+		{AppID: "cart", Subscriptions: []discovery.Subscription{{PubsubName: "pubsub", Topic: "carts"}}},
+	}}
+	h := subscriptionsRouter(apps)
+	res, body := get(t, h, "/")
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Contains(t, body, `"instanceKey":"daprmq-host-1"`)
+	require.Contains(t, body, `"instanceKey":"cart"`)
+}

--- a/web/src/lib/appKey.ts
+++ b/web/src/lib/appKey.ts
@@ -1,0 +1,9 @@
+import type { AppSummary } from '../types/api'
+
+/**
+ * Routing identity for an app instance: instanceKey (container name for
+ * compose apps) with appId fallback for older payloads and test fixtures.
+ */
+export function appKey(app: Pick<AppSummary, 'appId' | 'instanceKey'>): string {
+  return app.instanceKey || app.appId
+}

--- a/web/src/pages/Actors.test.tsx
+++ b/web/src/pages/Actors.test.tsx
@@ -102,4 +102,21 @@ describe('Actors', () => {
     expect(screen.getByText(/loading/i)).toBeInTheDocument()
     await screen.findByText('OrderActor')
   })
+
+  it('duplicate-app-id instances render distinct rows linking by instanceKey', async () => {
+    server.use(
+      http.get('/api/actors', () =>
+        HttpResponse.json([
+          { appId: 'daprmq-service', instanceKey: 'daprmq-host-1', type: 'QueueActor', count: 1, placement: 'connected' },
+          { appId: 'daprmq-service', instanceKey: 'daprmq-host-2', type: 'QueueActor', count: 2, placement: 'connected' },
+        ]),
+      ),
+    )
+    renderAt()
+    const links = await screen.findAllByRole('link', { name: /daprmq-service/ })
+    expect(links.map(l => l.getAttribute('href'))).toEqual(['/apps/daprmq-host-1', '/apps/daprmq-host-2'])
+    // Container names shown to tell the rows apart.
+    expect(screen.getByText('(daprmq-host-1)')).toBeInTheDocument()
+    expect(screen.getByText('(daprmq-host-2)')).toBeInTheDocument()
+  })
 })

--- a/web/src/pages/Actors.tsx
+++ b/web/src/pages/Actors.tsx
@@ -62,7 +62,7 @@ export function Actors() {
 
   const activeActors = actors.reduce((sum, a) => sum + (a.count || 0), 0)
   const actorTypes = new Set(actors.map((a) => a.type)).size
-  const hostingApps = new Set(actors.map((a) => a.appId)).size
+  const hostingApps = new Set(actors.map((a) => a.instanceKey ?? a.appId)).size
 
   return (
     <div className="page">
@@ -104,7 +104,7 @@ export function Actors() {
             </thead>
             <tbody>
               {actors.map((actor) => (
-                <ActorRow key={`${actor.appId}/${actor.type}`} actor={actor} />
+                <ActorRow key={`${actor.instanceKey ?? actor.appId}/${actor.type}`} actor={actor} />
               ))}
             </tbody>
           </table>
@@ -121,10 +121,16 @@ export function Actors() {
 
 function ActorRow({ actor }: { actor: Actor }) {
   const isInternal = actor.type.toLowerCase().includes(INTERNAL_PREFIX)
+  const key = actor.instanceKey ?? actor.appId
   return (
     <tr>
       <td className="b">
-        <Link className="celllink" to={`/apps/${actor.appId}`}>{actor.appId}</Link>
+        <Link className="celllink" to={`/apps/${key}`}>
+          {actor.appId}
+          {key !== actor.appId && (
+            <span className="muted" style={{ fontSize: 11, fontWeight: 400, marginLeft: 6 }}>({key})</span>
+          )}
+        </Link>
       </td>
       <td className="mono">
         {actor.type}

--- a/web/src/pages/AppDetail.test.tsx
+++ b/web/src/pages/AppDetail.test.tsx
@@ -203,7 +203,7 @@ describe('AppDetail', () => {
     await waitFor(() => expect(document.title).toBe('order | Diagrid Dev Dashboard'))
   })
 
-  it('shows the container name under the title and links logs by instance key', async () => {
+  it('titles compose apps by container name with the app id underneath and links logs by instance key', async () => {
     server.use(
       http.get('/api/apps/order', () =>
         HttpResponse.json({
@@ -225,10 +225,12 @@ describe('AppDetail', () => {
         }),
       ),
     )
-    renderDetail()
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'daprmq-service' })).toBeInTheDocument())
-    // Container name appears as the header sub-line (also as the Container kv value).
-    expect(screen.getAllByText('daprmq-host-1').length).toBeGreaterThanOrEqual(2)
+    const { container } = renderDetail()
+    // Container name is the title; the app id renders as the sub-line under it.
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'daprmq-host-1' })).toBeInTheDocument())
+    expect(container.querySelector('.phead .sub')).toHaveTextContent('daprmq-service')
+    // Breadcrumb leaf shows the instance key too.
+    expect(container.querySelector('.crumbs .cur')).toHaveTextContent('daprmq-host-1')
     expect(screen.getByRole('link', { name: /view logs/i })).toHaveAttribute(
       'href',
       '/logs?app=daprmq-host-1&source=daprd',

--- a/web/src/pages/AppDetail.test.tsx
+++ b/web/src/pages/AppDetail.test.tsx
@@ -202,4 +202,36 @@ describe('AppDetail', () => {
     renderDetail()
     await waitFor(() => expect(document.title).toBe('order | Diagrid Dev Dashboard'))
   })
+
+  it('shows the container name under the title and links logs by instance key', async () => {
+    server.use(
+      http.get('/api/apps/order', () =>
+        HttpResponse.json({
+          appId: 'daprmq-service',
+          instanceKey: 'daprmq-host-1',
+          health: 'healthy',
+          runtime: 'dotnet',
+          httpPort: 3502,
+          grpcPort: 50003,
+          appPort: 8080,
+          metadataOk: true,
+          source: 'compose',
+          composeProject: 'dapr-mq',
+          sidecarReachable: true,
+          daprdContainerId: 'aaa111bbb222',
+          daprdContainerName: 'daprmq-host-1-dapr',
+          appContainerId: 'ccc333ddd444',
+          appContainerName: 'daprmq-host-1',
+        }),
+      ),
+    )
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'daprmq-service' })).toBeInTheDocument())
+    // Container name appears as the header sub-line (also as the Container kv value).
+    expect(screen.getAllByText('daprmq-host-1').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getByRole('link', { name: /view logs/i })).toHaveAttribute(
+      'href',
+      '/logs?app=daprmq-host-1&source=daprd',
+    )
+  })
 })

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -33,14 +33,14 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
       <div className="crumbs">
         <Link to="/">Applications</Link>
         <span className="sep">/</span>
-        <span className="cur">{app.appId}</span>
+        <span className="cur">{key}</span>
       </div>
 
       {/* Page header */}
       <div className="phead">
         <div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
-            <h1>{app.appId}</h1>
+            <h1>{key}</h1>
             <span className="health">
               <span className={`led ${ledClass(app.health)}`} /> {app.health}
             </span>
@@ -49,7 +49,7 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
               {app.runtime}
             </span>
           </div>
-          {hasContainerName && <div className="sub mono">{key}</div>}
+          {hasContainerName && <div className="sub mono">{app.appId}</div>}
         </div>
         <div style={{ display: 'flex', gap: 8 }}>
           <button className="tbtn" onClick={() => navigate('/')}>← Back</button>

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -5,6 +5,7 @@ import { copyText } from '../lib/clipboard'
 import { ledClass, runtimeSwatch } from '../lib/runtimeSwatch'
 import { useToast } from '../lib/toast'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
+import { appKey } from '../lib/appKey'
 
 // ---------- content ----------
 
@@ -12,12 +13,15 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
   const navigate = useNavigate()
   const { toast, toastNode } = useToast()
 
-  useDocumentTitle(app.appId)
+  useDocumentTitle(appKey(app))
 
   const copyPath = (path: string) => {
     copyText(path)
     toast.show('Path copied')
   }
+
+  const key = appKey(app)
+  const hasContainerName = key !== app.appId
 
   const appPidDisplay = !app.metadataOk ? 'unknown' : app.appPid ? String(app.appPid) : '—'
   const isCompose = app.source === 'compose'
@@ -34,19 +38,22 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
 
       {/* Page header */}
       <div className="phead">
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
-          <h1>{app.appId}</h1>
-          <span className="health">
-            <span className={`led ${ledClass(app.health)}`} /> {app.health}
-          </span>
-          <span className="lang">
-            <span className="sw" style={{ background: runtimeSwatch(app.runtime) }} />
-            {app.runtime}
-          </span>
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+            <h1>{app.appId}</h1>
+            <span className="health">
+              <span className={`led ${ledClass(app.health)}`} /> {app.health}
+            </span>
+            <span className="lang">
+              <span className="sw" style={{ background: runtimeSwatch(app.runtime) }} />
+              {app.runtime}
+            </span>
+          </div>
+          {hasContainerName && <div className="sub mono">{key}</div>}
         </div>
         <div style={{ display: 'flex', gap: 8 }}>
           <button className="tbtn" onClick={() => navigate('/')}>← Back</button>
-          <Link className="tbtn" to={`/logs?app=${app.appId}&source=daprd`}>View logs</Link>
+          <Link className="tbtn" to={`/logs?app=${key}&source=daprd`}>View logs</Link>
         </div>
       </div>
 

--- a/web/src/pages/Applications.test.tsx
+++ b/web/src/pages/Applications.test.tsx
@@ -131,4 +131,24 @@ describe('Applications', () => {
     renderAt()
     await waitFor(() => expect(document.title).toBe('Applications | Diagrid Dev Dashboard'))
   })
+
+  it('compose apps with duplicate app ids link by container name with the app id underneath', async () => {
+    mockApps([
+      { ...baseApp, appId: 'daprmq-service', instanceKey: 'daprmq-host-1', source: 'compose', composeProject: 'dapr-mq', sidecarReachable: true, runTemplate: '' },
+      { ...baseApp, appId: 'daprmq-service', instanceKey: 'daprmq-host-2', source: 'compose', composeProject: 'dapr-mq', sidecarReachable: true, runTemplate: '' },
+    ])
+    renderAt()
+    const link1 = await screen.findByRole('link', { name: /daprmq-host-1/ })
+    expect(link1).toHaveAttribute('href', '/apps/daprmq-host-1')
+    expect(screen.getByRole('link', { name: /daprmq-host-2/ })).toHaveAttribute('href', '/apps/daprmq-host-2')
+    // The app id renders as a secondary line in each of the two rows.
+    expect(screen.getAllByText('daprmq-service')).toHaveLength(2)
+  })
+
+  it('non-compose apps render a single-line app id and link by app id', async () => {
+    mockApps([{ ...baseApp, instanceKey: 'order' }])
+    renderAt()
+    const link = await screen.findByRole('link', { name: 'order' })
+    expect(link).toHaveAttribute('href', '/apps/order')
+  })
 })

--- a/web/src/pages/Applications.tsx
+++ b/web/src/pages/Applications.tsx
@@ -2,6 +2,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import { useApps } from '../hooks/useApps'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { ledClass, runtimeSwatch } from '../lib/runtimeSwatch'
+import { appKey } from '../lib/appKey'
 import type { AppSummary } from '../types/api'
 
 const PAGE_HEADER = (
@@ -95,7 +96,7 @@ export function Applications() {
             </thead>
             <tbody>
               {apps.map((app) => (
-                <AppRow key={app.appId} app={app} onOpen={() => navigate(`/apps/${app.appId}`)} />
+                <AppRow key={appKey(app)} app={app} onOpen={() => navigate(`/apps/${appKey(app)}`)} />
               ))}
             </tbody>
           </table>
@@ -111,6 +112,8 @@ function AppRow({ app, onOpen }: { app: AppSummary; onOpen: () => void }) {
     v ? <td className="mono tabnum">{v}</td> : <td className="mono tabnum faint">—</td>
   const sourceLabel = app.runTemplate || (app.isAspire ? 'Aspire' : app.source === 'compose' ? 'Compose' : '—')
   const unreachable = app.source === 'compose' && app.sidecarReachable === false
+  const key = appKey(app)
+  const hasContainerName = key !== app.appId
   return (
     <tr onClick={onOpen}>
       <td>
@@ -123,8 +126,17 @@ function AppRow({ app, onOpen }: { app: AppSummary; onOpen: () => void }) {
         </span>
       </td>
       <td className="b">
-        <Link className="celllink" to={`/apps/${app.appId}`} onClick={(e) => e.stopPropagation()}>
-          {app.appId}
+        <Link className="celllink" to={`/apps/${key}`} onClick={(e) => e.stopPropagation()}>
+          {hasContainerName ? (
+            <>
+              {key}
+              <span className="muted" style={{ display: 'block', fontSize: 11, fontWeight: 400 }}>
+                {app.appId}
+              </span>
+            </>
+          ) : (
+            app.appId
+          )}
         </Link>
       </td>
       <td>

--- a/web/src/pages/Logs.test.tsx
+++ b/web/src/pages/Logs.test.tsx
@@ -988,4 +988,25 @@ describe('Logs', () => {
     const logfoot = document.querySelector('.logfoot')
     expect(logfoot?.textContent).toMatch(/tail \d+ KB/)
   })
+
+  it('app dropdown lists duplicate-app-id compose instances as distinct options keyed by instanceKey', async () => {
+    const host1 = { ...COMPOSE_SUMMARY, appId: 'daprmq-service', instanceKey: 'daprmq-host-1' }
+    const host2 = { ...COMPOSE_SUMMARY, appId: 'daprmq-service', instanceKey: 'daprmq-host-2' }
+    server.use(
+      http.get('/api/apps', () => HttpResponse.json([host1, host2])),
+      http.get('/api/apps/daprmq-host-1', () =>
+        HttpResponse.json({ ...COMPOSE_DETAIL, appId: 'daprmq-service', instanceKey: 'daprmq-host-1' }),
+      ),
+    )
+    renderAt('/logs?app=daprmq-host-1&source=daprd')
+    const select = await screen.findByLabelText('App')
+    await waitFor(() => {
+      const values = Array.from(select.querySelectorAll('option')).map(o => o.value)
+      expect(values).toContain('daprmq-host-1')
+      expect(values).toContain('daprmq-host-2')
+    })
+    // Labels disambiguate: app id + container name.
+    expect(screen.getByRole('option', { name: 'daprmq-service (daprmq-host-1)' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'daprmq-service (daprmq-host-2)' })).toBeInTheDocument()
+  })
 })

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -8,6 +8,7 @@ import type { LogLine, LogLevel } from '../types/logs'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { parseLogTime } from '../lib/logtime'
 import { parseEnum } from '../lib/parseEnum'
+import { appKey } from '../lib/appKey'
 
 // LogSource is wider than the hook's 'daprd' | 'app'; 'both' composes two streams.
 const LOG_SOURCES = ['both', 'daprd', 'app'] as const
@@ -387,7 +388,10 @@ export function Logs() {
   const [following, setFollowing] = useState(true)
 
   const { data: apps } = useApps()
-  const appIds = (apps ?? []).map(a => a.appId)
+  const appOptions = (apps ?? []).map(a => {
+    const key = appKey(a)
+    return { key, label: key !== a.appId ? `${a.appId} (${key})` : a.appId }
+  })
 
   const { data: app, isLoading } = useApp(appId)
 
@@ -499,9 +503,9 @@ export function Logs() {
           aria-label="App"
         >
           <option value="">— select app —</option>
-          {appIds.map(id => (
-            <option key={id} value={id}>
-              {id}
+          {appOptions.map(o => (
+            <option key={o.key} value={o.key}>
+              {o.label}
             </option>
           ))}
         </select>

--- a/web/src/pages/Subscriptions.test.tsx
+++ b/web/src/pages/Subscriptions.test.tsx
@@ -165,4 +165,18 @@ describe('Subscriptions', () => {
     // Wait for data to settle
     await screen.findByText('orders')
   })
+
+  it('duplicate-app-id instances render distinct rows linking by instanceKey', async () => {
+    server.use(
+      http.get('/api/subscriptions', () =>
+        HttpResponse.json([
+          { appId: 'daprmq-service', instanceKey: 'daprmq-host-1', pubsubName: 'kafka-pubsub', topic: 'orders' },
+          { appId: 'daprmq-service', instanceKey: 'daprmq-host-2', pubsubName: 'kafka-pubsub', topic: 'orders' },
+        ]),
+      ),
+    )
+    renderAt()
+    const links = await screen.findAllByRole('link', { name: /daprmq-service/ })
+    expect(links.map(l => l.getAttribute('href'))).toEqual(['/apps/daprmq-host-1', '/apps/daprmq-host-2'])
+  })
 })

--- a/web/src/pages/Subscriptions.tsx
+++ b/web/src/pages/Subscriptions.tsx
@@ -76,7 +76,7 @@ export function Subscriptions() {
             </thead>
             <tbody>
               {subscriptions.map((sub) => (
-                <SubscriptionRow key={`${sub.appId}/${sub.pubsubName}/${sub.topic}`} sub={sub} />
+                <SubscriptionRow key={`${sub.instanceKey ?? sub.appId}/${sub.pubsubName}/${sub.topic}`} sub={sub} />
               ))}
             </tbody>
           </table>
@@ -94,11 +94,17 @@ function SubscriptionRow({ sub }: { sub: Subscription }) {
   const firstPath = rules[0]?.path
   const hasMultipleRules = rules.length > 1
   const scopes = sub.scopes ?? []
+  const key = sub.instanceKey ?? sub.appId
 
   return (
     <tr>
       <td className="b">
-        <Link to={`/apps/${sub.appId}`}>{sub.appId}</Link>
+        <Link to={`/apps/${key}`}>
+          {sub.appId}
+          {key !== sub.appId && (
+            <span className="muted" style={{ fontSize: 11, fontWeight: 400, marginLeft: 6 }}>({key})</span>
+          )}
+        </Link>
       </td>
       <td className="mono">{sub.pubsubName}</td>
       <td className="mono">{sub.topic}</td>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -7,6 +7,8 @@ export type HealthStatus = 'healthy' | 'starting' | 'unhealthy' | 'unknown'
  */
 export interface AppSummary {
   appId: string
+  /** routing identity: container name for compose apps, appId otherwise */
+  instanceKey?: string
   health: HealthStatus
   runtime: string
   /** true when the app is .NET Aspire-managed (started by the Aspire host, not a run template) */

--- a/web/src/types/resources.ts
+++ b/web/src/types/resources.ts
@@ -1,5 +1,7 @@
 export interface Actor {
   appId: string
+  /** routing identity: container name for compose apps, appId otherwise */
+  instanceKey?: string
   type: string
   count: number
   placement?: string
@@ -12,6 +14,8 @@ export interface SubRule {
 
 export interface Subscription {
   appId: string
+  /** routing identity: container name for compose apps, appId otherwise */
+  instanceKey?: string
   pubsubName: string
   topic: string
   rules?: SubRule[]


### PR DESCRIPTION
## Problem

When several docker-compose Dapr sidecars share one `-app-id` (scaled instances), the Applications page showed identical rows that all drilled into the same first-matching instance — logs, detail, and the Logs dropdown collapsed the same way. Compose apps also showed runtime "unknown" whenever their locally built image name revealed nothing.

## Solution

### 1. Instance identity: `instanceKey`

A new routing identity alongside the Dapr identity (`appId`):

- **compose**: app container name → daprd container name → app-id (container names are unique per host)
- **`dapr run` / Aspire**: always app-id — zero observable change

**Backend** (`pkg/discovery`, `pkg/server`): `ScanResult.Key()` + serialized `Instance.InstanceKey`; list sorted by `appId, instanceKey`; `service.Get` resolves in two passes (exact instance-key match, then first app-id match so legacy links keep working); `/api/actors` and `/api/subscriptions` rows carry `instanceKey`; component `loadedBy` lists instance keys.

**Frontend** (`web/`): Applications and AppDetail title compose apps by container name with the app-id as a muted sub-line; detail breadcrumb + logs links use the key; Logs dropdown options are valued by key and labeled `appId (container)`; Actors/Subscriptions link per-instance. Workflows intentionally keep linking by app-id (state-store data can't attribute an instance).

### 2. Runtime detection for compose apps

A short-circuiting signal chain computed at scan time (`ScanResult.AppRuntime`), zero extra docker calls:

1. app-container argv (`dotnet X.dll`, `python app.py`, …)
2. base-image env markers (`DOTNET_VERSION`, `NODE_VERSION`, …)
3. image name (pre-existing heuristic)
4. marker files in the service's local compose `build.context` (`go.mod`, `*.sln`/`global.json`, `package.json`, …) — the only step touching the filesystem, reached only when 1–3 fail

All failure paths silently yield "unknown"; standalone/Aspire untouched; no new dependencies (`sigs.k8s.io/yaml` was already direct).

Specs: `docs/superpowers/specs/2026-07-09-compose-container-identity-design.md`, `docs/superpowers/specs/2026-07-09-compose-runtime-detection-design.md`
Plans: `docs/superpowers/plans/2026-07-09-compose-container-identity.md`, `docs/superpowers/plans/2026-07-09-compose-runtime-detection.md`

## Testing

- Full matrix green: `go test -tags unit -race ./...`, 647/647 vitest, `make lint`, `make build`
- Live-verified against a 4-instance compose stack sharing app-id `daprmq-service`: 4 distinct keys in `/api/apps`, exact per-instance resolution, app-id fallback returns 200, and all four apps report runtime `dotnet` (resolved from argv/env signals, no file I/O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
