### PR TITLE
Replace Run template stat card with Unhealthy count

### DIFF
--- a/docs/superpowers/plans/2026-07-09-unhealthy-stat-card.md
+++ b/docs/superpowers/plans/2026-07-09-unhealthy-stat-card.md
@@ -1,0 +1,148 @@
+# Unhealthy Stat Card Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the "Run template" stat card on the Applications overview with an "Unhealthy" count card.
+
+**Architecture:** Pure frontend change to the Applications page stats row. The card counts apps with `health === 'unhealthy'` (not `'unknown'`) and renders the number in the fail color only when the count is greater than 0. The per-row "Run template" table column and its `sourceLabel` logic are unchanged. No backend/API changes.
+
+**Tech Stack:** React + TypeScript, vitest + @testing-library/react + msw, plain CSS (`web/src/styles/theme.css`).
+
+**Spec:** `docs/superpowers/specs/2026-07-09-unhealthy-stat-card-design.md`
+
+## Global Constraints
+
+- Vitest does NOT typecheck: after any `.ts`/`.tsx` change, run `cd web && npx tsc -b` before claiming done.
+- Card order in the stats row must be: Apps running · Healthy · Starting · Unhealthy · Components loaded.
+- Apps with `health === 'unknown'` are NOT counted as unhealthy.
+- The number uses class `bad` (color `var(--fail-fg)`) only when the count > 0; at 0 it is the default neutral color.
+
+---
+
+### Task 1: Replace the Run template stat card with an Unhealthy count card
+
+**Files:**
+- Modify: `web/src/pages/Applications.tsx:44-77` (stats derivation + stats row)
+- Modify: `web/src/styles/theme.css:208` (add `.stat .n.bad` rule next to `.stat .n.mint`)
+- Test: `web/src/pages/Applications.test.tsx`
+
+**Interfaces:**
+- Consumes: `AppSummary.health` (`'healthy' | 'starting' | 'unhealthy' | 'unknown'`) from `web/src/types/api.ts` — already present, no type changes.
+- Produces: nothing consumed by other tasks (single-task plan).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `web/src/pages/Applications.test.tsx`:
+
+1. Update the existing stats-row test (currently asserts `/run template/i` appears). Note the table header still contains a "Run template" column, so instead assert the stat *label* moved: the string `Unhealthy` (capital U, exact match — the table's health cells render lowercase `unhealthy` so they don't collide) exists, and `Run template` now appears exactly once (the column header only). Replace the test body:
+
+```tsx
+  it('renders a stats row with running/healthy/starting/unhealthy counts', async () => {
+    server.use(http.get('/api/apps', () => HttpResponse.json(sampleApps)))
+    renderAt()
+    // Wait for data
+    await screen.findByRole('link', { name: 'order' })
+    // Stat labels (uppercased via CSS; assert on the source text)
+    expect(screen.getByText(/apps running/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/^healthy$/i).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText(/^starting$/i).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('Unhealthy')).toBeInTheDocument()
+    // The run-template stat card is gone; only the table column header remains.
+    expect(screen.getAllByText(/run template/i)).toHaveLength(1)
+  })
+```
+
+2. Add two new tests after it (the stat number is the element immediately before the label inside the same `.stat` card):
+
+```tsx
+  it('unhealthy stat shows 0 without the bad class when all apps are fine', async () => {
+    server.use(http.get('/api/apps', () => HttpResponse.json(sampleApps)))
+    renderAt()
+    await screen.findByRole('link', { name: 'order' })
+    const num = screen.getByText('Unhealthy').previousElementSibling as HTMLElement
+    expect(num).toHaveTextContent('0')
+    expect(num).not.toHaveClass('bad')
+  })
+
+  it('unhealthy stat counts unhealthy apps (not unknown) and turns bad', async () => {
+    mockApps([
+      { ...baseApp },
+      { ...baseApp, appId: 'billing', health: 'unhealthy' },
+      { ...baseApp, appId: 'primes-go', source: 'compose', sidecarReachable: false, health: 'unknown' },
+    ])
+    renderAt()
+    await screen.findByRole('link', { name: 'billing' })
+    const num = screen.getByText('Unhealthy').previousElementSibling as HTMLElement
+    expect(num).toHaveTextContent('1')
+    expect(num).toHaveClass('bad')
+  })
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web && npx vitest run src/pages/Applications.test.tsx`
+Expected: the updated stats-row test FAILS (`Unable to find an element with the text: Unhealthy`) and both new tests FAIL for the same reason. The other tests in the file still PASS.
+
+- [ ] **Step 3: Implement the card in `web/src/pages/Applications.tsx`**
+
+Replace the `runTemplate` derivation (lines 47–50):
+
+```tsx
+  // Prefer a real run-template name; else label Aspire-managed apps; else label compose; else '—'.
+  const runTemplate =
+    apps.find((a) => a.runTemplate)?.runTemplate ||
+    (apps.some((a) => a.isAspire) ? 'Aspire' : apps.some((a) => a.source === 'compose') ? 'Compose' : '—')
+```
+
+with:
+
+```tsx
+  const unhealthy = apps.filter((a) => a.health === 'unhealthy').length
+```
+
+Replace the Run template stat card (lines 72–77):
+
+```tsx
+        <div className="stat">
+          <div className="n mono" style={{ fontSize: 18 }}>
+            {runTemplate}
+          </div>
+          <div className="l">Run template</div>
+        </div>
+```
+
+with an Unhealthy card, and move it BEFORE the Components loaded card so the row reads Apps running · Healthy · Starting · Unhealthy · Components loaded:
+
+```tsx
+        <div className="stat">
+          <div className={unhealthy > 0 ? 'n bad' : 'n'}>{unhealthy}</div>
+          <div className="l">Unhealthy</div>
+        </div>
+```
+
+Do NOT touch `AppRow`'s `sourceLabel` or the "Run template" table column.
+
+- [ ] **Step 4: Add the CSS rule in `web/src/styles/theme.css`**
+
+Directly after the existing rule on line 208 (`.stat .n.mint { color: var(--accent2); }`) add:
+
+```css
+.stat .n.bad { color: var(--fail-fg); }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd web && npx vitest run src/pages/Applications.test.tsx`
+Expected: all tests PASS.
+
+- [ ] **Step 6: Typecheck and full test suite**
+
+Run: `cd web && npx tsc -b && npx vitest run`
+Expected: no type errors; all tests PASS (vitest does not typecheck, so `tsc -b` is mandatory).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/pages/Applications.tsx web/src/pages/Applications.test.tsx web/src/styles/theme.css
+git commit -m "feat(web): replace Run template stat card with Unhealthy count"
+```

--- a/docs/superpowers/specs/2026-07-09-unhealthy-stat-card-design.md
+++ b/docs/superpowers/specs/2026-07-09-unhealthy-stat-card-design.md
@@ -1,0 +1,62 @@
+# Replace "Run template" stat card with "Unhealthy" — Design
+
+**Date:** 2026-07-09
+**Status:** Approved
+
+## Problem
+
+The Applications overview page has a stats row with five cards: Apps running,
+Healthy, Starting, Components loaded, and Run template. The Run template card
+picks a single template name via a fallback chain (first app with a
+`runTemplate`, else "Aspire" if any Aspire app, else "Compose", else "—").
+Since the dashboard now discovers apps from multiple run processes (dapr run
+templates, .NET Aspire, docker compose) at the same time, a single-value
+"Run template" card is misleading and redundant — the per-row Run template
+column already shows the source per app.
+
+## Decision
+
+Replace the Run template stat card with an **Unhealthy** count card.
+
+- Counts exactly `health === 'unhealthy'`. Apps with `unknown` health (e.g.
+  compose apps whose sidecar HTTP port is not published) are **not** counted;
+  they remain visible in the table with their amber LED.
+- Card order becomes: Apps running · Healthy · Starting · Unhealthy ·
+  Components loaded.
+- The number renders in the fail color (`--fail-fg`) only when the count is
+  greater than 0; at 0 it stays the default neutral color.
+
+Alternatives considered and rejected:
+- **Run sources summary** (e.g. "CLI · Compose"): keeps provenance info but is
+  less actionable; the per-row column already covers it.
+- **Distinct runtimes count**: nice-to-know, not actionable.
+- **Counting unknown into the card** (or into Starting): makes labels lie;
+  an unpublished port is benign and would inflate an alarm-colored number.
+
+## Changes
+
+### `web/src/pages/Applications.tsx`
+- Remove the `runTemplate` derivation (the `apps.find(...)` fallback chain)
+  and the Run template stat card.
+- Add `const unhealthy = apps.filter((a) => a.health === 'unhealthy').length`.
+- Add the Unhealthy stat card after Starting:
+  `<div className="n bad">` when `unhealthy > 0`, plain `"n"` otherwise;
+  label `Unhealthy`.
+- The per-row **Run template column and `sourceLabel` logic are unchanged.**
+
+### `web/src/styles/theme.css`
+- Add `.stat .n.bad { color: var(--fail-fg); }` next to the existing
+  `.stat .n.mint` rule, reusing the same token as `.led.bad`.
+
+### `web/src/pages/Applications.test.tsx`
+- Update the stats-row test that asserts `/run template/i` appears in the
+  stats row (the table header still contains "Run template", so the assertion
+  must scope to the stats row or assert the label count drops to 1).
+- Add: with one unhealthy app, the Unhealthy card shows `1` and the number
+  element has the `bad` class.
+- Add: with zero unhealthy apps, the card shows `0` without the `bad` class.
+
+## Testing
+
+Component tests via vitest as above; run `tsc -b` (vitest does not typecheck).
+No backend/API changes.

--- a/web/src/pages/Applications.test.tsx
+++ b/web/src/pages/Applications.test.tsx
@@ -72,7 +72,7 @@ describe('Applications', () => {
     expect(link).toHaveAttribute('href', '/apps/order')
   })
 
-  it('renders a stats row with running/healthy/starting counts', async () => {
+  it('renders a stats row with running/healthy/starting/unhealthy counts', async () => {
     server.use(http.get('/api/apps', () => HttpResponse.json(sampleApps)))
     renderAt()
     // Wait for data
@@ -81,7 +81,31 @@ describe('Applications', () => {
     expect(screen.getByText(/apps running/i)).toBeInTheDocument()
     expect(screen.getAllByText(/^healthy$/i).length).toBeGreaterThanOrEqual(1)
     expect(screen.getAllByText(/^starting$/i).length).toBeGreaterThanOrEqual(1)
-    expect(screen.getAllByText(/run template/i).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('Unhealthy')).toBeInTheDocument()
+    // The run-template stat card is gone; only the table column header remains.
+    expect(screen.getAllByText(/run template/i)).toHaveLength(1)
+  })
+
+  it('unhealthy stat shows 0 without the bad class when all apps are fine', async () => {
+    server.use(http.get('/api/apps', () => HttpResponse.json(sampleApps)))
+    renderAt()
+    await screen.findByRole('link', { name: 'order' })
+    const num = screen.getByText('Unhealthy').previousElementSibling as HTMLElement
+    expect(num).toHaveTextContent('0')
+    expect(num).not.toHaveClass('bad')
+  })
+
+  it('unhealthy stat counts unhealthy apps (not unknown) and turns bad', async () => {
+    mockApps([
+      { ...baseApp },
+      { ...baseApp, appId: 'billing', health: 'unhealthy' },
+      { ...baseApp, appId: 'primes-go', source: 'compose', sidecarReachable: false, health: 'unknown' },
+    ])
+    renderAt()
+    await screen.findByRole('link', { name: 'billing' })
+    const num = screen.getByText('Unhealthy').previousElementSibling as HTMLElement
+    expect(num).toHaveTextContent('1')
+    expect(num).toHaveClass('bad')
   })
 
   it('shows an empty state when no apps', async () => {

--- a/web/src/pages/Applications.tsx
+++ b/web/src/pages/Applications.tsx
@@ -41,13 +41,10 @@ export function Applications() {
   const running = apps.length
   const healthy = apps.filter((a) => a.health === 'healthy').length
   const starting = apps.filter((a) => a.health === 'starting').length
+  const unhealthy = apps.filter((a) => a.health === 'unhealthy').length
   // Total components loaded across every running app; '—' when none report any.
   const componentsTotal = apps.reduce((n, a) => n + (a.components?.length ?? 0), 0)
   const componentsLoaded = componentsTotal > 0 ? componentsTotal : '—'
-  // Prefer a real run-template name; else label Aspire-managed apps; else label compose; else '—'.
-  const runTemplate =
-    apps.find((a) => a.runTemplate)?.runTemplate ||
-    (apps.some((a) => a.isAspire) ? 'Aspire' : apps.some((a) => a.source === 'compose') ? 'Compose' : '—')
 
   return (
     <div className="page">
@@ -66,14 +63,12 @@ export function Applications() {
           <div className="l">Starting</div>
         </div>
         <div className="stat">
-          <div className="n">{componentsLoaded}</div>
-          <div className="l">Components loaded</div>
+          <div className={unhealthy > 0 ? 'n bad' : 'n'}>{unhealthy}</div>
+          <div className="l">Unhealthy</div>
         </div>
         <div className="stat">
-          <div className="n mono" style={{ fontSize: 18 }}>
-            {runTemplate}
-          </div>
-          <div className="l">Run template</div>
+          <div className="n">{componentsLoaded}</div>
+          <div className="l">Components loaded</div>
         </div>
       </div>
       <div className="card">

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -206,6 +206,7 @@ table.t.click tbody tr:hover { background: var(--surface-2); }
 .stat .n { font-family: var(--mono); font-size: 23px; font-weight: 700; font-variant-numeric: tabular-nums; letter-spacing: -.02em; }
 .stat .l { font-family: var(--mono); font-size: 10.5px; letter-spacing: .07em; text-transform: uppercase; color: var(--muted); margin-top: 3px; }
 .stat .n.mint { color: var(--accent2); }
+.stat .n.bad { color: var(--fail-fg); }
 .select { font: inherit; font-size: 12.5px; color: var(--text); background: var(--surface); border: 1px solid var(--line); border-radius: 9px; padding: 7px 30px 7px 11px; cursor: pointer; appearance: none; -webkit-appearance: none; -moz-appearance: none; background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%23888' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"); background-repeat: no-repeat; background-position: right 10px center; background-size: 10px; }
 .refresh-compact { display: inline-flex; align-items: center; gap: 7px; }
 .beatbtn { display: inline-flex; align-items: center; justify-content: center; padding: 5px; background: transparent; border: 1px solid var(--line); border-radius: 8px; cursor: pointer; }


### PR DESCRIPTION
## Summary
- The Applications overview's "Run template" stat card assumed a single run process; now that apps are discovered from run templates, .NET Aspire, and docker compose simultaneously, it showed a misleading single value. The per-row Run template column already covers per-app provenance.
- Replaces the card with an **Unhealthy** count (stats row now reads Apps running · Healthy · Starting · Unhealthy · Components loaded), completing the health triad with the most actionable at-a-glance signal.
- Counts only `health === 'unhealthy'` (apps with `unknown` health — e.g. compose sidecars without a published HTTP port — are excluded and keep their amber LED in the table). The number renders in the fail color (`--fail-fg`) only when > 0.

Spec: `docs/superpowers/specs/2026-07-09-unhealthy-stat-card-design.md`
Plan: `docs/superpowers/plans/2026-07-09-unhealthy-stat-card.md`

## Test plan
- [x] New tests: unhealthy count shows 0 without the `bad` class; counts unhealthy apps (not unknown) and turns red
- [x] Updated stats-row test asserts the card swap (Run template text remains only as the table column header)
- [x] `tsc -b` clean, full suite 649/649 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)