### PR TITLE
feat: reliable app & sidecar health visualization

### DIFF
--- a/docs/superpowers/plans/2026-07-10-health-visualization-reliability.md
+++ b/docs/superpowers/plans/2026-07-10-health-visualization-reliability.md
@@ -1,0 +1,755 @@
+# Health Visualization Reliability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make app/sidecar health truthful — verify app-process liveness (PID + port probes), show a combined LED with a reason label, flag orphaned sidecars, and funnel daprd-only actions to whole-instance for `dapr run` apps.
+
+**Architecture:** Liveness probes live inside discovery `enrich` as injectable functions (`pidAlive`, `portOpen`), following the existing `procStart` pattern; a new `SidecarOrphaned` Instance field is computed there too. The lifecycle manager remaps `TargetDaprd → TargetAll` for non-Aspire standalone instances. The frontend derives one display state per instance in a shared `appDisplayState` helper used by both pages.
+
+**Tech Stack:** Go (gopsutil, net, testify, httptest), React + TypeScript (vitest, msw, testing-library).
+
+**Spec:** `docs/superpowers/specs/2026-07-10-health-visualization-reliability-design.md`
+
+## Global Constraints
+
+- Run `make build` (includes `tsc -b`) before claiming any frontend task done — vitest does not typecheck.
+- Go tests are build-tagged: `go test -tags unit ./...` (and `-tags integration` where noted); bare `go test` finds nothing. Check the tag line at the top of the test file you edit and keep it.
+- Status strings: `"running"` / `"stopped"`; empty = unknown. Health values: `healthy|starting|unhealthy|unknown`.
+- Probes: `pidAlive` = gopsutil `PidExists`; `portOpen` = `net.DialTimeout("tcp", "127.0.0.1:<port>", 200ms)`, never called for port 0. Probes run only on the metadata-success path for `SourceStandalone`; metadata-failure and sidecar-unreachable early returns unchanged.
+- Orphan rule (all must hold): `Source == SourceStandalone`, `!IsAspire`, `CLIPID == 0`, `AppStatus == StatusStopped`. JSON field `sidecarOrphaned,omitempty`.
+- Funnel rule: non-Aspire standalone `TargetDaprd` → `TargetAll` in the manager. Aspire and compose dispatch unchanged.
+- Display precedence: stopped (both) → grey `stopped`; `sidecarOrphaned` → amber `orphaned`; healthy sidecar + stopped app → amber `app down`; else existing health.
+- Exact copy strings: orphan tooltip "sidecar has no supervising dapr CLI and no app — safe to stop"; app-down tooltip "app process is not running"; orphan banner "Orphaned sidecar — this daprd has no supervising dapr CLI and its app is gone. Stopping it is safe."
+- Commit after every task, message ending with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+
+---
+
+### Task 1: Discovery — app-liveness probes → truthful `appStatus`
+
+**Files:**
+- Modify: `pkg/discovery/service.go` (service struct, `New`, enrich lines ~220-225)
+- Modify: `pkg/discovery/appproc.go` (probe defaults)
+- Test: `pkg/discovery/service_test.go`
+
+**Interfaces:**
+- Consumes: existing `service.procStart` pattern; `StatusRunning`/`StatusStopped` constants; metadata `Extended["appPID"]`.
+- Produces: `service.pidAlive func(pid int) bool` and `service.portOpen func(port int) bool` (injectable; defaults `gopsutilPidAlive`, `tcpPortOpen`); nil-safe accessors `s.appAlive(pid)` (nil resolver → true, preserving old assume-alive behavior for bare test fixtures) and the port branch guarded by `s.portOpen != nil`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `pkg/discovery/service_test.go` (match its build tag and import style). First a local stub sidecar helper (skip if an equivalent metadata+health stub already exists in the file — reuse it instead):
+
+```go
+// stubSidecar serves /v1.0/healthz (204) and /v1.0/metadata with the given
+// extended appPID ("" omits the field). Returns the listening port.
+func stubSidecar(t *testing.T, appPID string) int {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.0/healthz":
+			w.WriteHeader(http.StatusNoContent)
+		case "/v1.0/metadata":
+			w.Header().Set("Content-Type", "application/json")
+			ext := `{}`
+			if appPID != "" {
+				ext = fmt.Sprintf(`{"appPID":%q,"cliPID":"300"}`, appPID)
+			}
+			fmt.Fprintf(w, `{"id":"orders","extended":%s}`, ext)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(u.Port())
+	require.NoError(t, err)
+	return port
+}
+
+func standaloneScan(httpPort, appPort int) Scanner {
+	return func() ([]ScanResult, error) {
+		return []ScanResult{{AppID: "orders", Source: SourceStandalone, DaprdPID: 200,
+			HTTPPort: httpPort, AppPort: appPort, SidecarReachable: true}}, nil
+	}
+}
+
+func TestEnrichDeadAppPIDMarksAppStopped(t *testing.T) {
+	port := stubSidecar(t, "100")
+	svc := New(standaloneScan(port, 8080), &http.Client{Timeout: time.Second}).(*service)
+	svc.procStart = func(int) (time.Time, bool) { return time.Time{}, false }
+	svc.pidAlive = func(pid int) bool { return false } // 100 is dead
+	items, err := svc.List(context.Background())
+	require.NoError(t, err)
+	in := items[0]
+	require.Equal(t, StatusStopped, in.AppStatus)
+	require.Zero(t, in.AppPID, "dead PID must not be displayed")
+	require.Empty(t, in.AppStartedAt)
+}
+
+func TestEnrichLiveAppPIDMarksAppRunning(t *testing.T) {
+	port := stubSidecar(t, "100")
+	svc := New(standaloneScan(port, 8080), &http.Client{Timeout: time.Second}).(*service)
+	svc.procStart = func(int) (time.Time, bool) { return time.Time{}, false }
+	svc.pidAlive = func(pid int) bool { return pid == 100 }
+	items, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, StatusRunning, items[0].AppStatus)
+	require.Equal(t, 100, items[0].AppPID)
+}
+
+func TestEnrichPortDialDecidesWhenPIDUnknown(t *testing.T) {
+	for _, tc := range []struct {
+		open bool
+		want string
+	}{{true, StatusRunning}, {false, StatusStopped}} {
+		port := stubSidecar(t, "") // metadata without appPID
+		svc := New(standaloneScan(port, 8080), &http.Client{Timeout: time.Second}).(*service)
+		svc.procStart = func(int) (time.Time, bool) { return time.Time{}, false }
+		svc.portOpen = func(p int) bool { require.Equal(t, 8080, p); return tc.open }
+		items, err := svc.List(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, tc.want, items[0].AppStatus)
+	}
+}
+
+func TestEnrichNoLivenessSignalStaysUnknown(t *testing.T) {
+	port := stubSidecar(t, "") // no appPID
+	svc := New(standaloneScan(port, 0), &http.Client{Timeout: time.Second}).(*service) // no app port
+	svc.procStart = func(int) (time.Time, bool) { return time.Time{}, false }
+	items, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "", items[0].AppStatus)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit ./pkg/discovery/ -run 'TestEnrichDead|TestEnrichLive|TestEnrichPort|TestEnrichNoLiveness' -v`
+Expected: FAIL (compile error: unknown fields `pidAlive`/`portOpen`)
+
+- [ ] **Step 3: Implement**
+
+`pkg/discovery/service.go` — extend the struct and constructor:
+
+```go
+type service struct {
+	scan       Scanner
+	client     *http.Client
+	appProc    appProcResolver
+	stdoutFile func(pid int) string
+	procStart  func(pid int) (time.Time, bool)
+	pidAlive   func(pid int) bool
+	portOpen   func(port int) bool
+}
+
+func New(scan Scanner, client *http.Client) Service {
+	return &service{scan: scan, client: client, appProc: gopsutilResolver{}, stdoutFile: lsofStdoutFile,
+		procStart: gopsutilProcStart, pidAlive: gopsutilPidAlive, portOpen: tcpPortOpen}
+}
+
+// appAlive reports whether pid is a live process. A nil resolver (bare test
+// fixtures) preserves the historical assume-alive behavior.
+func (s *service) appAlive(pid int) bool {
+	if s.pidAlive == nil {
+		return true
+	}
+	return s.pidAlive(pid)
+}
+```
+
+Replace the current standalone app-status block in `enrich` (after `in.Placement = md.Placement`):
+
+```go
+	if in.Source == SourceStandalone {
+		switch {
+		case in.AppPID != 0:
+			if s.appAlive(in.AppPID) {
+				in.AppStatus = StatusRunning
+				if t, ok := s.procStartTime(in.AppPID); ok {
+					in.AppStartedAt = t.UTC().Format(time.RFC3339)
+				}
+			} else {
+				// Stale metadata: daprd still reports a PID that has exited.
+				in.AppStatus = StatusStopped
+				in.AppPID = 0
+				in.AppStartedAt = ""
+			}
+		case in.AppPort != 0 && s.portOpen != nil:
+			if s.portOpen(in.AppPort) {
+				in.AppStatus = StatusRunning
+			} else {
+				in.AppStatus = StatusStopped
+			}
+		}
+	}
+```
+
+`pkg/discovery/appproc.go` — probe defaults (add `fmt`, `net`, `time` imports):
+
+```go
+// gopsutilPidAlive reports whether pid exists in the process table.
+func gopsutilPidAlive(pid int) bool {
+	ok, err := gproc.PidExists(int32(pid))
+	return err == nil && ok
+}
+
+// tcpPortOpen probes a loopback TCP port; a refused dial fails immediately,
+// so the timeout only bites for half-open ports (absent on loopback).
+func tcpPortOpen(port int) bool {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+```
+
+- [ ] **Step 4: Run the whole package**
+
+Run: `go test -tags unit ./pkg/discovery/ -v -run TestEnrich` then `go test -tags unit ./pkg/discovery/`
+Expected: PASS. If a pre-existing test constructs the service via `New(...)` with metadata-reported PIDs and now fails (real `PidExists` on a fake PID), inject `svc.pidAlive = func(int) bool { return true }` in that test — behavior-preserving.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/discovery/service.go pkg/discovery/appproc.go pkg/discovery/service_test.go
+git commit -m "feat(discovery): verify app liveness with PID and port probes"
+```
+
+---
+
+### Task 2: Discovery — `SidecarOrphaned` detection
+
+**Files:**
+- Modify: `pkg/discovery/types.go` (Instance field)
+- Modify: `pkg/discovery/service.go` (enrich)
+- Test: `pkg/discovery/service_test.go`
+
+**Interfaces:**
+- Consumes: Task 1's truthful `AppStatus`; `in.IsAspire` (computed by `appRuntime` in enrich), `in.CLIPID` (post-metadata override).
+- Produces: `Instance.SidecarOrphaned bool` (json `sidecarOrphaned,omitempty`), true iff standalone && !IsAspire && CLIPID==0 && AppStatus==stopped.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `pkg/discovery/service_test.go` (reuses Task 1's `stubSidecar`/`standaloneScan`). Note `stubSidecar` with `appPID=""` also omits `cliPID`, so `CLIPID` stays at the scan value:
+
+```go
+// fakeAspireResolver makes appRuntime classify the app-port listener as the
+// Aspire DCP proxy.
+type fakeAspireResolver struct{}
+
+func (fakeAspireResolver) CommandForPort(port int) (string, bool) {
+	return "dotnet Aspire.Hosting.Orchestration.dcp run-controllers", true
+}
+
+func TestSidecarOrphanedDetection(t *testing.T) {
+	newSvc := func(cliPID int) *service {
+		port := stubSidecar(t, "") // no appPID, no cliPID in metadata
+		scan := func() ([]ScanResult, error) {
+			return []ScanResult{{AppID: "orders", Source: SourceStandalone, DaprdPID: 200,
+				CLIPID: cliPID, HTTPPort: port, AppPort: 8080, SidecarReachable: true}}, nil
+		}
+		svc := New(scan, &http.Client{Timeout: time.Second}).(*service)
+		svc.procStart = func(int) (time.Time, bool) { return time.Time{}, false }
+		svc.portOpen = func(int) bool { return false } // app is dead
+		return svc
+	}
+
+	t.Run("no CLI + dead app -> orphaned", func(t *testing.T) {
+		items, err := newSvc(0).List(context.Background())
+		require.NoError(t, err)
+		require.True(t, items[0].SidecarOrphaned)
+	})
+	t.Run("supervising CLI present -> not orphaned", func(t *testing.T) {
+		items, err := newSvc(300).List(context.Background())
+		require.NoError(t, err)
+		require.False(t, items[0].SidecarOrphaned)
+	})
+	t.Run("app alive -> not orphaned", func(t *testing.T) {
+		svc := newSvc(0)
+		svc.portOpen = func(int) bool { return true }
+		items, err := svc.List(context.Background())
+		require.NoError(t, err)
+		require.False(t, items[0].SidecarOrphaned)
+	})
+	t.Run("aspire excluded", func(t *testing.T) {
+		svc := newSvc(0)
+		svc.appProc = fakeAspireResolver{}
+		items, err := svc.List(context.Background())
+		require.NoError(t, err)
+		require.True(t, items[0].IsAspire, "fixture must classify as Aspire")
+		require.False(t, items[0].SidecarOrphaned)
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -tags unit ./pkg/discovery/ -run TestSidecarOrphaned -v`
+Expected: FAIL (unknown field `SidecarOrphaned`)
+
+- [ ] **Step 3: Implement**
+
+`pkg/discovery/types.go` — add to `Instance` after `DaprdStartedAt`:
+
+```go
+	// SidecarOrphaned marks a standalone daprd with no supervising dapr CLI
+	// and no live app (e.g. an external stop missed a detached sidecar).
+	SidecarOrphaned bool `json:"sidecarOrphaned,omitempty"`
+```
+
+`pkg/discovery/service.go` — in `enrich`, immediately after `in.Runtime, in.IsAspire = appRuntime(in.Command, in.AppPort, s.appProc)`:
+
+```go
+	// Orphan: nothing supervises this daprd and its app is gone. Aspire is
+	// excluded — its daprd legitimately lacks CLI metadata.
+	in.SidecarOrphaned = !in.IsAspire && in.CLIPID == 0 && in.AppStatus == StatusStopped
+```
+
+(This line only runs for standalone sources — compose returns earlier — and only on the metadata-success path, per the spec.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test -tags unit ./pkg/discovery/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/discovery/types.go pkg/discovery/service.go pkg/discovery/service_test.go
+git commit -m "feat(discovery): detect orphaned standalone sidecars"
+```
+
+---
+
+### Task 3: Lifecycle — funnel daprd actions to whole-instance for dapr run
+
+**Files:**
+- Modify: `pkg/lifecycle/manager.go` (`doStandalone`)
+- Test: `pkg/lifecycle/manager_test.go`
+
+**Interfaces:**
+- Consumes: existing fakes `fakeApps`, `newFakeProc()`, `standaloneInst()` (AppPID 100, DaprdPID 200, CLIPID 300) in `manager_test.go`; `Registry.Get`.
+- Produces: non-Aspire standalone `TargetDaprd` behaves exactly as `TargetAll` for every action. Aspire and compose dispatch unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `pkg/lifecycle/manager_test.go`:
+
+```go
+func TestStandaloneDaprdTargetFunnelsToAll(t *testing.T) {
+	proc := newFakeProc()
+	proc.snaps[100] = ProcSnapshot{PID: 100, Argv: []string{"go", "run", "."}, Dir: "/src"}
+	proc.snaps[200] = ProcSnapshot{PID: 200, Argv: []string{"daprd", "--app-id", "orders"}, Dir: "/src"}
+	proc.snaps[300] = ProcSnapshot{PID: 300, Argv: []string{"dapr", "run", "--app-id", "orders"}, Dir: "/src"}
+	proc.alive[100], proc.alive[200], proc.alive[300] = true, true, true
+
+	reg := NewRegistry()
+	m := New(fakeApps{items: map[string]discovery.Instance{"orders": standaloneInst()}}, reg, nil, proc, nil).(*manager)
+	m.grace = 10 * time.Millisecond
+
+	require.NoError(t, m.Do(context.Background(), "orders", TargetDaprd, ActionStop))
+	require.Equal(t, []int{300}, proc.terminated, "daprd target must signal the CLI, like TargetAll")
+	e, ok := reg.Get("orders")
+	require.True(t, ok)
+	require.Contains(t, e.Procs, TargetAll, "whole-instance snapshot recorded")
+}
+
+func TestAspireDaprdStopNotFunneled(t *testing.T) {
+	in := standaloneInst()
+	in.IsAspire = true
+	proc := newFakeProc()
+	proc.snaps[200] = ProcSnapshot{PID: 200, Argv: []string{"daprd", "--app-id", "orders"}}
+	proc.alive[200] = true
+	m := New(fakeApps{items: map[string]discovery.Instance{"orders": in}}, NewRegistry(), nil, proc, nil).(*manager)
+	m.grace = 10 * time.Millisecond
+
+	require.NoError(t, m.Do(context.Background(), "orders", TargetDaprd, ActionStop))
+	require.Equal(t, []int{200}, proc.terminated, "Aspire keeps per-PID daprd stop")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit ./pkg/lifecycle/ -run 'TestStandaloneDaprdTarget|TestAspireDaprdStop' -v`
+Expected: `TestStandaloneDaprdTargetFunnelsToAll` FAILS (terminated is `[200]`, not `[300]`); the Aspire test may already pass.
+
+- [ ] **Step 3: Implement**
+
+`pkg/lifecycle/manager.go` — at the top of `doStandalone`, before the Aspire guard:
+
+```go
+	// dapr run supervises app + daprd together: stopping the sidecar alone
+	// cascades to the app, and restarting it alone orphans daprd outside the
+	// CLI. Funnel sidecar actions to the whole instance instead.
+	if !in.IsAspire && target == TargetDaprd {
+		target = TargetAll
+	}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test -tags unit ./pkg/lifecycle/`
+Expected: PASS (no existing test exercises standalone `TargetDaprd`; if one does, its assertion now reflects funneled behavior — update it and note this in the report).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/lifecycle/manager.go pkg/lifecycle/manager_test.go
+git commit -m "feat(lifecycle): funnel daprd actions to whole instance for dapr run apps"
+```
+
+---
+
+### Task 4: Web — types, `appDisplayState` helper, grey LED style
+
+**Files:**
+- Modify: `web/src/types/api.ts` (AppSummary field)
+- Create: `web/src/lib/appDisplayState.ts`
+- Modify: `web/src/styles/theme.css` (`.led.off`)
+- Test: `web/src/lib/appDisplayState.test.ts`
+
+**Interfaces:**
+- Consumes: `ledClass` from `web/src/lib/runtimeSwatch` (`ok|warn|bad`); `AppSummary.health/appStatus/daprdStatus`.
+- Produces: `appDisplayState(app): DisplayState` where `DisplayState = { label: string; led: string; hint?: string }` and `AppSummary.sidecarOrphaned?: boolean`. New CSS class `led off` (grey).
+
+- [ ] **Step 1: Write the failing test**
+
+`web/src/lib/appDisplayState.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { appDisplayState } from './appDisplayState'
+
+describe('appDisplayState', () => {
+  it('both halves stopped -> grey stopped', () => {
+    expect(appDisplayState({ health: 'unknown', appStatus: 'stopped', daprdStatus: 'stopped' }))
+      .toEqual({ label: 'stopped', led: 'off' })
+  })
+  it('orphaned sidecar -> amber orphaned with hint', () => {
+    const s = appDisplayState({ health: 'healthy', appStatus: 'stopped', daprdStatus: 'running', sidecarOrphaned: true })
+    expect(s.label).toBe('orphaned')
+    expect(s.led).toBe('warn')
+    expect(s.hint).toBe('sidecar has no supervising dapr CLI and no app — safe to stop')
+  })
+  it('healthy sidecar but app stopped -> amber app down with hint', () => {
+    const s = appDisplayState({ health: 'healthy', appStatus: 'stopped', daprdStatus: 'running' })
+    expect(s.label).toBe('app down')
+    expect(s.led).toBe('warn')
+    expect(s.hint).toBe('app process is not running')
+  })
+  it('falls back to plain health', () => {
+    expect(appDisplayState({ health: 'healthy', appStatus: 'running', daprdStatus: 'running' }))
+      .toEqual({ label: 'healthy', led: 'ok' })
+    expect(appDisplayState({ health: 'unhealthy' })).toEqual({ label: 'unhealthy', led: 'bad' })
+  })
+  it('precedence: stopped beats orphaned beats app down', () => {
+    expect(appDisplayState({ health: 'unknown', appStatus: 'stopped', daprdStatus: 'stopped', sidecarOrphaned: true }).label)
+      .toBe('stopped')
+    expect(appDisplayState({ health: 'healthy', appStatus: 'stopped', daprdStatus: 'running', sidecarOrphaned: true }).label)
+      .toBe('orphaned')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/lib/appDisplayState.test.ts`
+Expected: FAIL (module not found)
+
+- [ ] **Step 3: Implement**
+
+`web/src/types/api.ts` — in `AppSummary`, after `daprdStartedAt`:
+
+```ts
+  /** true when a standalone daprd has no supervising dapr CLI and no live app */
+  sidecarOrphaned?: boolean
+```
+
+`web/src/lib/appDisplayState.ts`:
+
+```ts
+import type { AppSummary } from '../types/api'
+import { ledClass } from './runtimeSwatch'
+
+export interface DisplayState {
+  label: string
+  /** LED modifier class: 'ok' | 'warn' | 'bad' | 'off' */
+  led: string
+  /** tooltip explaining amber states */
+  hint?: string
+}
+
+type HealthFields = Pick<AppSummary, 'health' | 'appStatus' | 'daprdStatus' | 'sidecarOrphaned'>
+
+/**
+ * Derives the single health state shown for an instance from both halves:
+ * stopped (both) > orphaned > app down > plain sidecar health.
+ */
+export function appDisplayState(app: HealthFields): DisplayState {
+  if (app.appStatus === 'stopped' && app.daprdStatus === 'stopped') {
+    return { label: 'stopped', led: 'off' }
+  }
+  if (app.sidecarOrphaned) {
+    return { label: 'orphaned', led: 'warn', hint: 'sidecar has no supervising dapr CLI and no app — safe to stop' }
+  }
+  if (app.health === 'healthy' && app.appStatus === 'stopped') {
+    return { label: 'app down', led: 'warn', hint: 'app process is not running' }
+  }
+  return { label: app.health, led: ledClass(app.health) }
+}
+```
+
+`web/src/styles/theme.css` — next to the other `.led.*` rules (around line 190):
+
+```css
+.led.off { background: var(--faint); }
+```
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `cd web && npx vitest run src/lib/appDisplayState.test.ts && npx tsc -b`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/types/api.ts web/src/lib/appDisplayState.ts web/src/lib/appDisplayState.test.ts web/src/styles/theme.css
+git commit -m "feat(web): shared appDisplayState helper and grey stopped LED"
+```
+
+---
+
+### Task 5: Web — Applications overview renders the derived state
+
+**Files:**
+- Modify: `web/src/pages/Applications.tsx` (AppRow health cell)
+- Test: `web/src/pages/Applications.test.tsx`
+
+**Interfaces:**
+- Consumes: `appDisplayState` from Task 4.
+- Produces: Health cell shows `state.label` + `state.led`, `title` = `state.hint` (falling back to the compose-unreachable tooltip). `isStopped`/stats logic unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Applications.test.tsx` (reuse its existing render helper and fixture style; base fixtures on the file's existing rows):
+
+```tsx
+it('renders app-down and orphaned states with tooltips', async () => {
+  server.use(
+    http.get('/api/apps', () =>
+      HttpResponse.json([
+        { appId: 'appdown', health: 'healthy', runtime: 'go', httpPort: 3500, grpcPort: 50001, appPort: 8080, daprdPid: 1, appPid: 0, cliPid: 3, age: '5m', created: '10:00:00', runTemplate: '', appStatus: 'stopped', daprdStatus: 'running' },
+        { appId: 'ghost', health: 'healthy', runtime: 'go', httpPort: 3501, grpcPort: 50002, appPort: 8081, daprdPid: 2, appPid: 0, cliPid: 0, age: '5m', created: '10:00:00', runTemplate: '', appStatus: 'stopped', daprdStatus: 'running', sidecarOrphaned: true },
+      ]),
+    ),
+  )
+  renderApplications()
+  await waitFor(() => expect(screen.getByText('appdown')).toBeInTheDocument())
+  expect(screen.getByText('app down')).toBeInTheDocument()
+  expect(screen.getByText('orphaned')).toBeInTheDocument()
+  expect(screen.getByTitle('app process is not running')).toBeInTheDocument()
+  expect(screen.getByTitle('sidecar has no supervising dapr CLI and no app — safe to stop')).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/pages/Applications.test.tsx`
+Expected: FAIL (rows render plain 'healthy')
+
+- [ ] **Step 3: Implement**
+
+In `Applications.tsx`, import the helper:
+
+```tsx
+import { appDisplayState } from '../lib/appDisplayState'
+```
+
+In `AppRow`, replace the `stopped` const and health cell:
+
+```tsx
+  const state = appDisplayState(app)
+  const unreachable = app.source === 'compose' && app.sidecarReachable === false && app.daprdStatus !== 'stopped'
+```
+
+```tsx
+      <td>
+        <span
+          className="health"
+          title={state.hint ?? (unreachable ? 'publish the daprd HTTP port (e.g. 3500:3500) to enable health & metadata' : undefined)}
+        >
+          <span className={`led ${state.led}`} /> {state.label}
+          {unreachable && ' ⓘ'}
+        </span>
+      </td>
+```
+
+(`isStopped` and the `running` stat stay as they are; remove the now-unused `const stopped = isStopped(app)` and `ledClass` import from AppRow if nothing else uses them.)
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `cd web && npx vitest run src/pages/Applications.test.tsx && npx tsc -b`
+Expected: PASS (the existing stopped-row test still passes — the label is unchanged)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/pages/Applications.tsx web/src/pages/Applications.test.tsx
+git commit -m "feat(web): combined health state with reason on the applications list"
+```
+
+---
+
+### Task 6: Web — AppDetail orphan banner, funneled sidecar buttons + final verification
+
+**Files:**
+- Modify: `web/src/pages/AppDetail.tsx`
+- Test: `web/src/pages/AppDetail.test.tsx`
+
+**Interfaces:**
+- Consumes: `appDisplayState`; existing `panelActions(target, status, what)` and `runAction`; `useAppAction` posts to `/api/apps/{key}/{target}/{action}`.
+- Produces: header health badge driven by `appDisplayState`; orphan banner; sidecar panel for non-Aspire `dapr run` apps sends `target: 'all'` with explanatory confirm copy.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `AppDetail.test.tsx` (reuse `renderDetail()` and the `runningApp` fixture):
+
+```tsx
+it('shows the orphan banner and orphaned header state', async () => {
+  server.use(
+    http.get('/api/apps/order', () =>
+      HttpResponse.json({ ...runningApp, appStatus: 'stopped', daprdStatus: 'running', sidecarOrphaned: true, cliPid: 0, appPid: 0 }),
+    ),
+  )
+  renderDetail()
+  await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+  expect(screen.getByText(/Orphaned sidecar — this daprd has no supervising dapr CLI/)).toBeInTheDocument()
+  expect(screen.getByText('orphaned')).toBeInTheDocument()
+})
+
+it('funnels sidecar stop to the whole instance for dapr run apps', async () => {
+  let posted = ''
+  server.use(
+    http.get('/api/apps/order', () => HttpResponse.json(runningApp)), // standalone, not Aspire
+    http.post('/api/apps/order/all/stop', () => {
+      posted = 'all/stop'
+      return HttpResponse.json({ status: 'ok' })
+    }),
+  )
+  const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+  renderDetail()
+  await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+  // Buttons render header-first, then app panel, then daprd panel — the
+  // last Stop button is the daprd panel's.
+  const stops = screen.getAllByRole('button', { name: 'Stop' })
+  stops[stops.length - 1].click()
+  await waitFor(() => expect(posted).toBe('all/stop'))
+  expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('app + sidecar together'))
+  confirmSpy.mockRestore()
+})
+
+it('keeps per-container sidecar target for compose apps', async () => {
+  let posted = ''
+  server.use(
+    http.get('/api/apps/order', () =>
+      HttpResponse.json({ ...runningApp, source: 'compose', daprdContainerName: 'proj-daprd-1' }),
+    ),
+    http.post('/api/apps/order/daprd/stop', () => {
+      posted = 'daprd/stop'
+      return HttpResponse.json({ status: 'ok' })
+    }),
+  )
+  const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+  renderDetail()
+  await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+  const stops = screen.getAllByRole('button', { name: 'Stop' })
+  stops[stops.length - 1].click()
+  await waitFor(() => expect(posted).toBe('daprd/stop'))
+  confirmSpy.mockRestore()
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd web && npx vitest run src/pages/AppDetail.test.tsx`
+Expected: the orphan and funnel tests FAIL (no banner; POST goes to `/daprd/stop`)
+
+- [ ] **Step 3: Implement**
+
+In `AppDetail.tsx`:
+
+1. Import: `import { appDisplayState } from '../lib/appDisplayState'`.
+
+2. Header badge — replace the `<span className="health"><span className={`led ${ledClass(app.health)}`} /> {app.health}</span>` block:
+
+```tsx
+            {(() => {
+              const state = appDisplayState(app)
+              return (
+                <span className="health" title={state.hint}>
+                  <span className={`led ${state.led}`} /> {state.label}
+                </span>
+              )
+            })()}
+```
+
+3. Orphan banner — after the Aspire hint block:
+
+```tsx
+      {app.sidecarOrphaned && (
+        <div className="hint">
+          Orphaned sidecar — this daprd has no supervising dapr CLI and its app is gone. Stopping it is safe.
+        </div>
+      )}
+```
+
+4. Funneled sidecar target — near the other derived consts:
+
+```tsx
+  // dapr run supervises app + daprd together; sidecar actions act on the
+  // whole instance (see lifecycle manager funneling). Compose and Aspire
+  // keep per-target semantics.
+  const daprdTarget: AppTarget = isCompose || app.isAspire ? 'daprd' : 'all'
+  const daprdWhat =
+    isCompose || app.isAspire
+      ? `sidecar of "${app.appId}"`
+      : `"${app.appId}" (dapr run manages app + sidecar together)`
+```
+
+and change the daprd panel call to:
+
+```tsx
+            {panelActions(daprdTarget, app.daprdStatus, daprdWhat)}
+```
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `cd web && npx vitest run src/pages/AppDetail.test.tsx && npx tsc -b`
+Expected: PASS (existing tests unaffected: `ledClass` header usage replaced, but labels for plain health values are identical)
+
+- [ ] **Step 5: Full final verification (whole branch)**
+
+```bash
+make build
+go test -tags unit ./... && go test -tags integration ./...
+cd web && npx vitest run
+```
+Expected: everything green. Paste command tails in the report.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/pages/AppDetail.tsx web/src/pages/AppDetail.test.tsx
+git commit -m "feat(web): orphan banner and funneled sidecar actions on app detail"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** truthful appStatus (T1), sidecarOrphaned (T2), funneling (T3), combined LED + reason via shared helper on both pages (T4/T5/T6 — header badge included), orphan flag + Stop (T2/T6; cleanup uses the existing whole-instance Stop, no new plumbing), exact copy strings carried into Global Constraints. Backfill intentionally absent (spec decision 5).
+- **Type consistency:** `DisplayState { label, led, hint? }` used identically in T4-T6; probe fields `pidAlive`/`portOpen` named consistently; funnel uses existing `TargetDaprd`/`TargetAll`.
+- **Known simplification:** AppDetail's per-panel `statusCell` LEDs keep their existing running/stopped styling (per-target, not instance-level) — the instance-level derivation applies to the header badge and list rows, per the spec's "used by both pages so the rule lives once".

--- a/docs/superpowers/specs/2026-07-10-health-visualization-reliability-design.md
+++ b/docs/superpowers/specs/2026-07-10-health-visualization-reliability-design.md
@@ -1,0 +1,163 @@
+# Health Visualization Reliability — Design
+
+**Date:** 2026-07-10
+**Status:** Approved
+**Follow-up to:** `2026-07-09-app-lifecycle-controls-design.md` (PR #53, merged)
+
+## Problem
+
+The health LED means only "daprd `/v1.0/healthz` answered" (`pkg/discovery/health.go`),
+and all app-process information (`appPID`, command, log paths) comes from
+Extended metadata that only the `dapr` CLI injects at launch
+(`pkg/discovery/metadata.go`). Two consequences observed in practice:
+
+1. An app whose process died still shows a green "healthy" LED as long as its
+   sidecar answers health probes; `appStatus` goes stale or unknown instead
+   of `stopped`.
+2. Stopping/restarting only the daprd sidecar of a `dapr run` app fights the
+   CLI's supervision: the stop cascades to the app, and a dashboard-restarted
+   daprd is detached from the CLI (own process group, no Extended metadata) —
+   an orphaned sidecar that survives external stops and keeps the instance
+   looking healthy forever.
+
+## Decisions (from brainstorming)
+
+1. **App liveness: PID check + port dial.** Verify the metadata-reported
+   `AppPID` with gopsutil `PidExists`; when the PID is unknown but `appPort`
+   is set, a fast local TCP dial decides. daprd's `appConnectionProperties`
+   is NOT consumed — it requires the app to opt into
+   `--enable-app-health-check` and is absent for most local apps.
+2. **Overview: combined LED + reason text.** One LED derived from both
+   halves, with the label naming the state (`healthy`, `app down`,
+   `orphaned`, `unhealthy`, `stopped`).
+3. **Orphaned sidecars: flag + offer Stop.** Detected orphans render amber
+   with an explanation; the existing whole-instance Stop cleans them up.
+4. **Guardrail: funnel daprd-only actions to whole-instance** for `dapr run`
+   apps. The sidecar panel's Stop/Restart act on the whole instance
+   (re-running the original `dapr run` command); the confirm dialog explains
+   why. No dashboard path can create an orphan. Compose keeps per-container
+   control; Aspire stays stop-only, unchanged.
+5. **Registry-snapshot backfill of app info: dropped (YAGNI).** Funneling
+   removes the only dashboard flow that produced metadata-less daprd
+   restarts.
+
+## Architecture
+
+Liveness probing lives inside discovery `enrich` (Approach A): two new
+injectable functions on the `service` struct, following the existing
+`procStart` pattern. Everything downstream renders `Instance` fields — the
+rule lives in one testable place. A background health poller (Approach B) was
+rejected as machinery without payoff: `PidExists` is a syscall and a dial to
+a closed loopback port fails immediately.
+
+## Backend
+
+### Truthful `appStatus` (standalone only; compose is container-state-driven)
+
+`pkg/discovery/service.go`:
+
+- `service` gains `pidAlive func(pid int) bool` (default: gopsutil
+  `PidExists`) and `portOpen func(port int) bool` (default:
+  `net.DialTimeout("tcp", "127.0.0.1:<port>", 200ms)`; never called for
+  port 0).
+- In `enrich`, after metadata, for `SourceStandalone`:
+  - `AppPID != 0`: `pidAlive(AppPID)` decides `AppStatus` =
+    `running`/`stopped`. A dead PID also zeroes `AppPID` and `AppStartedAt`
+    (no stale PID display).
+  - `AppPID == 0 && AppPort != 0`: `portOpen(AppPort)` decides
+    `running`/`stopped`.
+  - Neither signal: `AppStatus` stays `""` (unknown) — honest, never worse
+    than today.
+  - Probes run only on the metadata-success path; the metadata-failure and
+    sidecar-unreachable early returns are unchanged (the orphan case has
+    reachable metadata with empty Extended, so it is covered).
+
+### Orphan detection
+
+New `Instance` field `SidecarOrphaned bool` (`json:"sidecarOrphaned,omitempty"`),
+computed in `enrich`, true when ALL of:
+
+- `Source == SourceStandalone`
+- `!IsAspire` (Aspire daprd legitimately lacks CLI metadata)
+- `CLIPID == 0` (no supervising `dapr` CLI)
+- `AppStatus == StatusStopped`
+
+A normal `dapr run` app always reports a CLI PID, so false positives require
+losing both the CLI and the app while daprd survives — exactly the orphan
+case.
+
+### Funneling (lifecycle manager)
+
+`pkg/lifecycle/manager.go` `doStandalone`: for non-Aspire instances,
+`target == TargetDaprd` is remapped to `TargetAll` before dispatch. Stop and
+restart therefore act on the whole instance via the existing CLI-PID path;
+the existing no-CLI fallback (signal whatever PIDs are alive) covers orphan
+cleanup, where only the daprd PID exists. Aspire (stop-only, per-PID) and
+compose (per-container) behavior unchanged.
+
+### API
+
+No route changes. Two new omitempty JSON fields (`sidecarOrphaned`, plus the
+truthful `appStatus` values) — backward compatible.
+
+## Frontend
+
+### Types
+
+`AppSummary` gains `sidecarOrphaned?: boolean`.
+
+### Derived display state
+
+New pure helper `appDisplayState(app)` in `web/src/lib/` returning
+`{ label, led }`, used by both pages so the rule lives once. Precedence:
+
+1. `appStatus === 'stopped' && daprdStatus === 'stopped'` → grey `stopped`
+   (existing behavior moves into the helper)
+2. `sidecarOrphaned` → amber (`starting` LED style), label `orphaned`
+3. sidecar health healthy but `appStatus === 'stopped'` → amber, `app down`
+4. otherwise → existing `health` value and LED
+
+### Applications overview
+
+The Health cell renders from `appDisplayState`. Amber states carry a
+tooltip: `app down` → "app process is not running"; `orphaned` → "sidecar
+has no supervising dapr CLI and no app — safe to stop". The "Apps running"
+stat keeps its current rule (excludes only fully-stopped instances).
+
+### AppDetail
+
+- Status rows become truthful automatically via the backend change.
+- Orphan banner (hint style, when `sidecarOrphaned`): *"Orphaned sidecar —
+  this daprd has no supervising dapr CLI and its app is gone. Stopping it is
+  safe."* The header Stop button is the cleanup action (funnel + fallback
+  already signal just the daprd PID).
+- Sidecar panel buttons for `dapr run` apps send `target: 'all'`; confirm
+  copy: *"For dapr run apps the sidecar and app are managed together — this
+  will stop/restart the whole instance."* Compose and Aspire button wiring
+  unchanged.
+
+## Edge cases
+
+- **Port-dial false positive** (another process reuses the app port):
+  accepted dev-machine heuristic; the PID check wins whenever a PID is
+  known.
+- **App that never listens on its app port** (`appPort` 0 or a non-server
+  app): no dial attempted; status stays unknown — same as today.
+- **Probe cost:** one syscall or one instant loopback dial per app per poll,
+  inside the existing 8-worker enrich parallelism. The 200 ms timeout only
+  bites for half-open ports, which do not occur on loopback.
+- **Orphan mis-detection:** requires all four conditions; Aspire excluded
+  explicitly.
+
+## Testing
+
+- **Go:** enrich tests with fake `pidAlive`/`portOpen` — dead PID → stopped
+  + zeroed PID/startedAt; port-open → running; port-closed → stopped; no
+  signals → unknown; orphan-flag truth table including the Aspire and
+  CLI-PID exclusions. Manager tests pinning daprd→all funneling for
+  standalone non-Aspire, and unchanged Aspire/compose dispatch.
+- **Frontend:** unit tests for `appDisplayState` (all four branches +
+  precedence); Applications rendering of `app down` and `orphaned` rows with
+  tooltips; AppDetail orphan banner and the new sidecar-panel confirm copy.
+- `make build` (includes `tsc -b`) and full Go (`-tags unit` /
+  `-tags integration`) + vitest suites before commit.

--- a/docs/superpowers/specs/2026-07-10-health-visualization-reliability-design.md
+++ b/docs/superpowers/specs/2026-07-10-health-visualization-reliability-design.md
@@ -132,9 +132,9 @@ stat keeps its current rule (excludes only fully-stopped instances).
   safe."* The header Stop button is the cleanup action (funnel + fallback
   already signal just the daprd PID).
 - Sidecar panel buttons for `dapr run` apps send `target: 'all'`; confirm
-  copy: *"For dapr run apps the sidecar and app are managed together — this
-  will stop/restart the whole instance."* Compose and Aspire button wiring
-  unchanged.
+  copy includes "dapr run manages app + sidecar together" (rendered inside
+  the standard `<Action> <subject>?` template). Compose and Aspire button
+  wiring unchanged.
 
 ## Edge cases
 

--- a/pkg/discovery/appproc.go
+++ b/pkg/discovery/appproc.go
@@ -1,6 +1,8 @@
 package discovery
 
 import (
+	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -87,4 +89,21 @@ func gopsutilProcStart(pid int) (time.Time, bool) {
 		return time.Time{}, false
 	}
 	return time.UnixMilli(ms), true
+}
+
+// gopsutilPidAlive reports whether pid exists in the process table.
+func gopsutilPidAlive(pid int) bool {
+	ok, err := gproc.PidExists(int32(pid))
+	return err == nil && ok
+}
+
+// tcpPortOpen probes a loopback TCP port; a refused dial fails immediately,
+// so the timeout only bites for half-open ports (absent on loopback).
+func tcpPortOpen(port int) bool {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
 }

--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -87,10 +87,13 @@ type service struct {
 	appProc    appProcResolver
 	stdoutFile func(pid int) string
 	procStart  func(pid int) (time.Time, bool)
+	pidAlive   func(pid int) bool
+	portOpen   func(port int) bool
 }
 
 func New(scan Scanner, client *http.Client) Service {
-	return &service{scan: scan, client: client, appProc: gopsutilResolver{}, stdoutFile: lsofStdoutFile, procStart: gopsutilProcStart}
+	return &service{scan: scan, client: client, appProc: gopsutilResolver{}, stdoutFile: lsofStdoutFile,
+		procStart: gopsutilProcStart, pidAlive: gopsutilPidAlive, portOpen: tcpPortOpen}
 }
 
 // procStartTime resolves a process's start time, returning false if the resolver is nil or pid is 0.
@@ -99,6 +102,15 @@ func (s *service) procStartTime(pid int) (time.Time, bool) {
 		return time.Time{}, false
 	}
 	return s.procStart(pid)
+}
+
+// appAlive reports whether pid is a live process. A nil resolver (bare test
+// fixtures) preserves the historical assume-alive behavior.
+func (s *service) appAlive(pid int) bool {
+	if s.pidAlive == nil {
+		return true
+	}
+	return s.pidAlive(pid)
 }
 
 const enrichWorkers = 8
@@ -217,10 +229,26 @@ func (s *service) enrich(ctx context.Context, r ScanResult) Instance {
 	in.Components = md.Components
 	in.EnabledFeatures = md.EnabledFeatures
 	in.Placement = md.Placement
-	if in.Source == SourceStandalone && in.AppPID != 0 {
-		in.AppStatus = StatusRunning
-		if t, ok := s.procStartTime(in.AppPID); ok {
-			in.AppStartedAt = t.UTC().Format(time.RFC3339)
+	if in.Source == SourceStandalone {
+		switch {
+		case in.AppPID != 0:
+			if s.appAlive(in.AppPID) {
+				in.AppStatus = StatusRunning
+				if t, ok := s.procStartTime(in.AppPID); ok {
+					in.AppStartedAt = t.UTC().Format(time.RFC3339)
+				}
+			} else {
+				// Stale metadata: daprd still reports a PID that has exited.
+				in.AppStatus = StatusStopped
+				in.AppPID = 0
+				in.AppStartedAt = ""
+			}
+		case in.AppPort != 0 && s.portOpen != nil:
+			if s.portOpen(in.AppPort) {
+				in.AppStatus = StatusRunning
+			} else {
+				in.AppStatus = StatusStopped
+			}
 		}
 	}
 	if in.Source == SourceCompose {

--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -267,6 +267,9 @@ func (s *service) enrich(ctx context.Context, r ScanResult) Instance {
 		in.Command = md.AppCommand
 	}
 	in.Runtime, in.IsAspire = appRuntime(in.Command, in.AppPort, s.appProc)
+	// Orphan: nothing supervises this daprd and its app is gone. Aspire is
+	// excluded — its daprd legitimately lacks CLI metadata.
+	in.SidecarOrphaned = !in.IsAspire && in.CLIPID == 0 && in.AppStatus == StatusStopped
 	if md.AppLogPath != "" {
 		in.AppLogPath, in.AppLogFormat = md.AppLogPath, logFormatPlain
 	}

--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -263,6 +263,11 @@ func (s *service) enrich(ctx context.Context, r ScanResult) Instance {
 	if md.CLIPID != 0 {
 		in.CLIPID = md.CLIPID
 	}
+	// The CLI PID in metadata is written once at launch and survives the
+	// CLI's death; a dead CLI must not mask an orphan or receive signals.
+	if in.CLIPID != 0 && !s.appAlive(in.CLIPID) {
+		in.CLIPID = 0
+	}
 	if md.AppCommand != "" {
 		in.Command = md.AppCommand
 	}

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -43,7 +44,8 @@ func TestServiceListEnriches(t *testing.T) {
 	scan := func() ([]ScanResult, error) {
 		return []ScanResult{{AppID: "order", HTTPPort: port, GRPCPort: 50001, AppPort: 8080, DaprdPID: 48230, Created: time.Now(), Command: "go run ./cmd/order"}}, nil
 	}
-	svc := New(scan, &http.Client{Timeout: 2 * time.Second})
+	svc := New(scan, &http.Client{Timeout: 2 * time.Second}).(*service)
+	svc.pidAlive = func(int) bool { return true } // fake PID in fixture isn't a real live process
 
 	list, err := svc.List(context.Background())
 	require.NoError(t, err)
@@ -443,4 +445,86 @@ func TestEnrichStandaloneFallsBackToCreatedWhenProcStartFails(t *testing.T) {
 	in := items[0]
 	require.Equal(t, StatusRunning, in.DaprdStatus)
 	require.Equal(t, "2026-07-09T08:59:00Z", in.DaprdStartedAt)
+}
+
+// stubSidecar serves /v1.0/healthz (204) and /v1.0/metadata with the given
+// extended appPID ("" omits the field). Returns the listening port.
+func stubSidecar(t *testing.T, appPID string) int {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.0/healthz":
+			w.WriteHeader(http.StatusNoContent)
+		case "/v1.0/metadata":
+			w.Header().Set("Content-Type", "application/json")
+			ext := `{}`
+			if appPID != "" {
+				ext = fmt.Sprintf(`{"appPID":%q,"cliPID":"300"}`, appPID)
+			}
+			fmt.Fprintf(w, `{"id":"orders","extended":%s}`, ext)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(u.Port())
+	require.NoError(t, err)
+	return port
+}
+
+func standaloneScan(httpPort, appPort int) Scanner {
+	return func() ([]ScanResult, error) {
+		return []ScanResult{{AppID: "orders", Source: SourceStandalone, DaprdPID: 200,
+			HTTPPort: httpPort, AppPort: appPort, SidecarReachable: true}}, nil
+	}
+}
+
+func TestEnrichDeadAppPIDMarksAppStopped(t *testing.T) {
+	port := stubSidecar(t, "100")
+	svc := New(standaloneScan(port, 8080), &http.Client{Timeout: time.Second}).(*service)
+	svc.procStart = func(int) (time.Time, bool) { return time.Time{}, false }
+	svc.pidAlive = func(pid int) bool { return false } // 100 is dead
+	items, err := svc.List(context.Background())
+	require.NoError(t, err)
+	in := items[0]
+	require.Equal(t, StatusStopped, in.AppStatus)
+	require.Zero(t, in.AppPID, "dead PID must not be displayed")
+	require.Empty(t, in.AppStartedAt)
+}
+
+func TestEnrichLiveAppPIDMarksAppRunning(t *testing.T) {
+	port := stubSidecar(t, "100")
+	svc := New(standaloneScan(port, 8080), &http.Client{Timeout: time.Second}).(*service)
+	svc.procStart = func(int) (time.Time, bool) { return time.Time{}, false }
+	svc.pidAlive = func(pid int) bool { return pid == 100 }
+	items, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, StatusRunning, items[0].AppStatus)
+	require.Equal(t, 100, items[0].AppPID)
+}
+
+func TestEnrichPortDialDecidesWhenPIDUnknown(t *testing.T) {
+	for _, tc := range []struct {
+		open bool
+		want string
+	}{{true, StatusRunning}, {false, StatusStopped}} {
+		port := stubSidecar(t, "") // metadata without appPID
+		svc := New(standaloneScan(port, 8080), &http.Client{Timeout: time.Second}).(*service)
+		svc.procStart = func(int) (time.Time, bool) { return time.Time{}, false }
+		svc.portOpen = func(p int) bool { require.Equal(t, 8080, p); return tc.open }
+		items, err := svc.List(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, tc.want, items[0].AppStatus)
+	}
+}
+
+func TestEnrichNoLivenessSignalStaysUnknown(t *testing.T) {
+	port := stubSidecar(t, "")                                                         // no appPID
+	svc := New(standaloneScan(port, 0), &http.Client{Timeout: time.Second}).(*service) // no app port
+	svc.procStart = func(int) (time.Time, bool) { return time.Time{}, false }
+	items, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "", items[0].AppStatus)
 }

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -559,9 +559,19 @@ func TestSidecarOrphanedDetection(t *testing.T) {
 		require.True(t, items[0].SidecarOrphaned)
 	})
 	t.Run("supervising CLI present -> not orphaned", func(t *testing.T) {
-		items, err := newSvc(300).List(context.Background())
+		svc := newSvc(300)
+		svc.pidAlive = func(pid int) bool { return true }
+		items, err := svc.List(context.Background())
 		require.NoError(t, err)
 		require.False(t, items[0].SidecarOrphaned)
+	})
+	t.Run("dead CLI PID -> orphaned", func(t *testing.T) {
+		svc := newSvc(300) // CLIPID from scan, but the process is dead
+		svc.pidAlive = func(pid int) bool { return false }
+		items, err := svc.List(context.Background())
+		require.NoError(t, err)
+		require.True(t, items[0].SidecarOrphaned)
+		require.Zero(t, items[0].CLIPID, "dead CLI PID must not be displayed")
 	})
 	t.Run("app alive -> not orphaned", func(t *testing.T) {
 		svc := newSvc(0)

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -530,3 +530,52 @@ func TestEnrichNoLivenessSignalStaysUnknown(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", items[0].AppStatus)
 }
+
+// fakeAspireResolver makes appRuntime classify the app-port listener as the
+// Aspire DCP proxy.
+type fakeAspireResolver struct{}
+
+func (fakeAspireResolver) CommandForPort(port int) (string, bool) {
+	// Command that passes isAspireProxy check but doesn't match InferRuntime
+	return "/path/to/dcp run-controllers", true
+}
+
+func TestSidecarOrphanedDetection(t *testing.T) {
+	newSvc := func(cliPID int) *service {
+		port := stubSidecar(t, "") // no appPID, no cliPID in metadata
+		scan := func() ([]ScanResult, error) {
+			return []ScanResult{{AppID: "orders", Source: SourceStandalone, DaprdPID: 200,
+				CLIPID: cliPID, HTTPPort: port, AppPort: 8080, SidecarReachable: true}}, nil
+		}
+		svc := New(scan, &http.Client{Timeout: time.Second}).(*service)
+		svc.procStart = func(int) (time.Time, bool) { return time.Time{}, false }
+		svc.portOpen = func(int) bool { return false } // app is dead
+		return svc
+	}
+
+	t.Run("no CLI + dead app -> orphaned", func(t *testing.T) {
+		items, err := newSvc(0).List(context.Background())
+		require.NoError(t, err)
+		require.True(t, items[0].SidecarOrphaned)
+	})
+	t.Run("supervising CLI present -> not orphaned", func(t *testing.T) {
+		items, err := newSvc(300).List(context.Background())
+		require.NoError(t, err)
+		require.False(t, items[0].SidecarOrphaned)
+	})
+	t.Run("app alive -> not orphaned", func(t *testing.T) {
+		svc := newSvc(0)
+		svc.portOpen = func(int) bool { return true }
+		items, err := svc.List(context.Background())
+		require.NoError(t, err)
+		require.False(t, items[0].SidecarOrphaned)
+	})
+	t.Run("aspire excluded", func(t *testing.T) {
+		svc := newSvc(0)
+		svc.appProc = fakeAspireResolver{}
+		items, err := svc.List(context.Background())
+		require.NoError(t, err)
+		require.True(t, items[0].IsAspire, "fixture must classify as Aspire")
+		require.False(t, items[0].SidecarOrphaned)
+	})
+}

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -513,10 +513,12 @@ func TestEnrichPortDialDecidesWhenPIDUnknown(t *testing.T) {
 		port := stubSidecar(t, "") // metadata without appPID
 		svc := New(standaloneScan(port, 8080), &http.Client{Timeout: time.Second}).(*service)
 		svc.procStart = func(int) (time.Time, bool) { return time.Time{}, false }
-		svc.portOpen = func(p int) bool { require.Equal(t, 8080, p); return tc.open }
+		var gotPort int
+		svc.portOpen = func(p int) bool { gotPort = p; return tc.open }
 		items, err := svc.List(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, tc.want, items[0].AppStatus)
+		require.Equal(t, 8080, gotPort)
 	}
 }
 

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -22,43 +22,46 @@ type Instance struct {
 	// InstanceKey is the routing identity: container name for compose apps
 	// (falling back to app id), app id otherwise. Unique per instance even
 	// when several compose sidecars share one -app-id.
-	InstanceKey        string         `json:"instanceKey"`
-	Health             Health         `json:"health"`
-	Runtime            string         `json:"runtime"`            // e.g. "go", "python", "node", "dotnet", "java", "rust", "unknown"
-	IsAspire           bool           `json:"isAspire,omitempty"` // true when the app is .NET Aspire-managed
-	Source             string         `json:"source"`             // "standalone" | "compose"
-	ComposeProject     string         `json:"composeProject,omitempty"`
-	ComposeService     string         `json:"composeService,omitempty"`
-	DaprdContainerID   string         `json:"daprdContainerId,omitempty"`
-	DaprdContainerName string         `json:"daprdContainerName,omitempty"`
-	AppContainerID     string         `json:"appContainerId,omitempty"`
-	AppContainerName   string         `json:"appContainerName,omitempty"`
-	SidecarReachable   bool           `json:"sidecarReachable"`
-	HTTPPort           int            `json:"httpPort"`
-	GRPCPort           int            `json:"grpcPort"`
-	AppPort            int            `json:"appPort"`
-	DaprdPID           int            `json:"daprdPid"`
-	AppPID             int            `json:"appPid"` // 0 = unknown
-	CLIPID             int            `json:"cliPid"`
-	AppStatus          string         `json:"appStatus,omitempty"`      // "running" | "stopped"; "" unknown
-	DaprdStatus        string         `json:"daprdStatus,omitempty"`    // "running" | "stopped"; "" unknown
-	AppStartedAt       string         `json:"appStartedAt,omitempty"`   // RFC3339 UTC; "" when stopped/unknown
-	DaprdStartedAt     string         `json:"daprdStartedAt,omitempty"` // RFC3339 UTC; "" when stopped/unknown
-	Age                string         `json:"age"`                      // human, e.g. "14m"
-	Created            string         `json:"created"`                  // local time string
-	RunTemplate        string         `json:"runTemplate"`
-	ResourcePaths      []string       `json:"resourcePaths"`
-	ConfigPath         string         `json:"configPath"`
-	AppLogPath         string         `json:"appLogPath"`
-	DaprdLogPath       string         `json:"daprdLogPath"`
-	AppLogFormat       string         `json:"appLogFormat,omitempty"`   // "" / "plain" / "dcp"
-	DaprdLogFormat     string         `json:"daprdLogFormat,omitempty"` // "" / "plain" / "dcp"
-	Command            string         `json:"command"`
-	RuntimeVersion     string         `json:"runtimeVersion"` // from metadata; "" if unavailable
-	MetadataOK         bool           `json:"metadataOk"`     // false if /v1.0/metadata failed
-	Actors             []ActorType    `json:"actors,omitempty"`
-	Subscriptions      []Subscription `json:"subscriptions,omitempty"`
-	Components         []Component    `json:"components,omitempty"`
-	EnabledFeatures    []string       `json:"enabledFeatures,omitempty"`
-	Placement          string         `json:"placement,omitempty"`
+	InstanceKey        string `json:"instanceKey"`
+	Health             Health `json:"health"`
+	Runtime            string `json:"runtime"`            // e.g. "go", "python", "node", "dotnet", "java", "rust", "unknown"
+	IsAspire           bool   `json:"isAspire,omitempty"` // true when the app is .NET Aspire-managed
+	Source             string `json:"source"`             // "standalone" | "compose"
+	ComposeProject     string `json:"composeProject,omitempty"`
+	ComposeService     string `json:"composeService,omitempty"`
+	DaprdContainerID   string `json:"daprdContainerId,omitempty"`
+	DaprdContainerName string `json:"daprdContainerName,omitempty"`
+	AppContainerID     string `json:"appContainerId,omitempty"`
+	AppContainerName   string `json:"appContainerName,omitempty"`
+	SidecarReachable   bool   `json:"sidecarReachable"`
+	HTTPPort           int    `json:"httpPort"`
+	GRPCPort           int    `json:"grpcPort"`
+	AppPort            int    `json:"appPort"`
+	DaprdPID           int    `json:"daprdPid"`
+	AppPID             int    `json:"appPid"` // 0 = unknown
+	CLIPID             int    `json:"cliPid"`
+	AppStatus          string `json:"appStatus,omitempty"`      // "running" | "stopped"; "" unknown
+	DaprdStatus        string `json:"daprdStatus,omitempty"`    // "running" | "stopped"; "" unknown
+	AppStartedAt       string `json:"appStartedAt,omitempty"`   // RFC3339 UTC; "" when stopped/unknown
+	DaprdStartedAt     string `json:"daprdStartedAt,omitempty"` // RFC3339 UTC; "" when stopped/unknown
+	// SidecarOrphaned marks a standalone daprd with no supervising dapr CLI
+	// and no live app (e.g. an external stop missed a detached sidecar).
+	SidecarOrphaned bool           `json:"sidecarOrphaned,omitempty"`
+	Age             string         `json:"age"`     // human, e.g. "14m"
+	Created         string         `json:"created"` // local time string
+	RunTemplate     string         `json:"runTemplate"`
+	ResourcePaths   []string       `json:"resourcePaths"`
+	ConfigPath      string         `json:"configPath"`
+	AppLogPath      string         `json:"appLogPath"`
+	DaprdLogPath    string         `json:"daprdLogPath"`
+	AppLogFormat    string         `json:"appLogFormat,omitempty"`   // "" / "plain" / "dcp"
+	DaprdLogFormat  string         `json:"daprdLogFormat,omitempty"` // "" / "plain" / "dcp"
+	Command         string         `json:"command"`
+	RuntimeVersion  string         `json:"runtimeVersion"` // from metadata; "" if unavailable
+	MetadataOK      bool           `json:"metadataOk"`     // false if /v1.0/metadata failed
+	Actors          []ActorType    `json:"actors,omitempty"`
+	Subscriptions   []Subscription `json:"subscriptions,omitempty"`
+	Components      []Component    `json:"components,omitempty"`
+	EnabledFeatures []string       `json:"enabledFeatures,omitempty"`
+	Placement       string         `json:"placement,omitempty"`
 }

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -113,6 +113,12 @@ func composeTargets(in discovery.Instance, target Target, action Action) ([]stri
 // doStandalone dispatches start/stop/restart for a process-table instance.
 // Aspire-managed apps only allow stop; Aspire itself owns start/restart.
 func (m *manager) doStandalone(ctx context.Context, in discovery.Instance, target Target, action Action) error {
+	// dapr run supervises app + daprd together: stopping the sidecar alone
+	// cascades to the app, and restarting it alone orphans daprd outside the
+	// CLI. Funnel sidecar actions to the whole instance instead.
+	if !in.IsAspire && target == TargetDaprd {
+		target = TargetAll
+	}
 	if in.IsAspire && action != ActionStop {
 		return fmt.Errorf("%w: Aspire manages this app's lifecycle — restart it from the Aspire dashboard", ErrUnsupported)
 	}

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -279,3 +279,34 @@ func TestStandaloneRestartStopsThenStarts(t *testing.T) {
 	require.Equal(t, []int{100}, proc.terminated)
 	require.Equal(t, [][]string{{"go", "run", "."}}, st.started)
 }
+
+func TestStandaloneDaprdTargetFunnelsToAll(t *testing.T) {
+	proc := newFakeProc()
+	proc.snaps[100] = ProcSnapshot{PID: 100, Argv: []string{"go", "run", "."}, Dir: "/src"}
+	proc.snaps[200] = ProcSnapshot{PID: 200, Argv: []string{"daprd", "--app-id", "orders"}, Dir: "/src"}
+	proc.snaps[300] = ProcSnapshot{PID: 300, Argv: []string{"dapr", "run", "--app-id", "orders"}, Dir: "/src"}
+	proc.alive[100], proc.alive[200], proc.alive[300] = true, true, true
+
+	reg := NewRegistry()
+	m := New(fakeApps{items: map[string]discovery.Instance{"orders": standaloneInst()}}, reg, nil, proc, nil).(*manager)
+	m.grace = 10 * time.Millisecond
+
+	require.NoError(t, m.Do(context.Background(), "orders", TargetDaprd, ActionStop))
+	require.Equal(t, []int{300}, proc.terminated, "daprd target must signal the CLI, like TargetAll")
+	e, ok := reg.Get("orders")
+	require.True(t, ok)
+	require.Contains(t, e.Procs, TargetAll, "whole-instance snapshot recorded")
+}
+
+func TestAspireDaprdStopNotFunneled(t *testing.T) {
+	in := standaloneInst()
+	in.IsAspire = true
+	proc := newFakeProc()
+	proc.snaps[200] = ProcSnapshot{PID: 200, Argv: []string{"daprd", "--app-id", "orders"}}
+	proc.alive[200] = true
+	m := New(fakeApps{items: map[string]discovery.Instance{"orders": in}}, NewRegistry(), nil, proc, nil).(*manager)
+	m.grace = 10 * time.Millisecond
+
+	require.NoError(t, m.Do(context.Background(), "orders", TargetDaprd, ActionStop))
+	require.Equal(t, []int{200}, proc.terminated, "Aspire keeps per-PID daprd stop")
+}

--- a/web/src/lib/appDisplayState.test.ts
+++ b/web/src/lib/appDisplayState.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { appDisplayState } from './appDisplayState'
+
+describe('appDisplayState', () => {
+  it('both halves stopped -> grey stopped', () => {
+    expect(appDisplayState({ health: 'unknown', appStatus: 'stopped', daprdStatus: 'stopped' }))
+      .toEqual({ label: 'stopped', led: 'off' })
+  })
+  it('orphaned sidecar -> amber orphaned with hint', () => {
+    const s = appDisplayState({ health: 'healthy', appStatus: 'stopped', daprdStatus: 'running', sidecarOrphaned: true })
+    expect(s.label).toBe('orphaned')
+    expect(s.led).toBe('warn')
+    expect(s.hint).toBe('sidecar has no supervising dapr CLI and no app — safe to stop')
+  })
+  it('healthy sidecar but app stopped -> amber app down with hint', () => {
+    const s = appDisplayState({ health: 'healthy', appStatus: 'stopped', daprdStatus: 'running' })
+    expect(s.label).toBe('app down')
+    expect(s.led).toBe('warn')
+    expect(s.hint).toBe('app process is not running')
+  })
+  it('falls back to plain health', () => {
+    expect(appDisplayState({ health: 'healthy', appStatus: 'running', daprdStatus: 'running' }))
+      .toEqual({ label: 'healthy', led: 'ok' })
+    expect(appDisplayState({ health: 'unhealthy' })).toEqual({ label: 'unhealthy', led: 'bad' })
+  })
+  it('precedence: stopped beats orphaned beats app down', () => {
+    expect(appDisplayState({ health: 'unknown', appStatus: 'stopped', daprdStatus: 'stopped', sidecarOrphaned: true }).label)
+      .toBe('stopped')
+    expect(appDisplayState({ health: 'healthy', appStatus: 'stopped', daprdStatus: 'running', sidecarOrphaned: true }).label)
+      .toBe('orphaned')
+  })
+})

--- a/web/src/lib/appDisplayState.ts
+++ b/web/src/lib/appDisplayState.ts
@@ -1,0 +1,29 @@
+import type { AppSummary } from '../types/api'
+import { ledClass } from './runtimeSwatch'
+
+export interface DisplayState {
+  label: string
+  /** LED modifier class: 'ok' | 'warn' | 'bad' | 'off' */
+  led: string
+  /** tooltip explaining amber states */
+  hint?: string
+}
+
+type HealthFields = Pick<AppSummary, 'health' | 'appStatus' | 'daprdStatus' | 'sidecarOrphaned'>
+
+/**
+ * Derives the single health state shown for an instance from both halves:
+ * stopped (both) > orphaned > app down > plain sidecar health.
+ */
+export function appDisplayState(app: HealthFields): DisplayState {
+  if (app.appStatus === 'stopped' && app.daprdStatus === 'stopped') {
+    return { label: 'stopped', led: 'off' }
+  }
+  if (app.sidecarOrphaned) {
+    return { label: 'orphaned', led: 'warn', hint: 'sidecar has no supervising dapr CLI and no app — safe to stop' }
+  }
+  if (app.health === 'healthy' && app.appStatus === 'stopped') {
+    return { label: 'app down', led: 'warn', hint: 'app process is not running' }
+  }
+  return { label: app.health, led: ledClass(app.health) }
+}

--- a/web/src/pages/AppDetail.test.tsx
+++ b/web/src/pages/AppDetail.test.tsx
@@ -344,4 +344,57 @@ describe('AppDetail', () => {
     expect(screen.getByText(/^5m 0[0-2]s$/)).toBeInTheDocument() // app uptime ticks from startedAt
     vi.useRealTimers()
   })
+
+  it('shows the orphan banner and orphaned header state', async () => {
+    server.use(
+      http.get('/api/apps/order', () =>
+        HttpResponse.json({ ...runningApp, appStatus: 'stopped', daprdStatus: 'running', sidecarOrphaned: true, cliPid: 0, appPid: 0 }),
+      ),
+    )
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    expect(screen.getByText(/Orphaned sidecar — this daprd has no supervising dapr CLI/)).toBeInTheDocument()
+    expect(screen.getByText('orphaned')).toBeInTheDocument()
+  })
+
+  it('funnels sidecar stop to the whole instance for dapr run apps', async () => {
+    let posted = ''
+    server.use(
+      http.get('/api/apps/order', () => HttpResponse.json(runningApp)), // standalone, not Aspire
+      http.post('/api/apps/order/all/stop', () => {
+        posted = 'all/stop'
+        return HttpResponse.json({ status: 'ok' })
+      }),
+    )
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    // Buttons render header-first, then app panel, then daprd panel — the
+    // last Stop button is the daprd panel's.
+    const stops = screen.getAllByRole('button', { name: 'Stop' })
+    stops[stops.length - 1].click()
+    await waitFor(() => expect(posted).toBe('all/stop'))
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('app + sidecar together'))
+    confirmSpy.mockRestore()
+  })
+
+  it('keeps per-container sidecar target for compose apps', async () => {
+    let posted = ''
+    server.use(
+      http.get('/api/apps/order', () =>
+        HttpResponse.json({ ...runningApp, source: 'compose', daprdContainerName: 'proj-daprd-1' }),
+      ),
+      http.post('/api/apps/order/daprd/stop', () => {
+        posted = 'daprd/stop'
+        return HttpResponse.json({ status: 'ok' })
+      }),
+    )
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    const stops = screen.getAllByRole('button', { name: 'Stop' })
+    stops[stops.length - 1].click()
+    await waitFor(() => expect(posted).toBe('daprd/stop'))
+    confirmSpy.mockRestore()
+  })
 })

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -3,6 +3,7 @@ import { useApp } from '../hooks/useApps'
 import { useAppAction, type AppTarget, type AppLifecycleAction } from '../hooks/useAppAction'
 import type { AppDetail as AppDetailType } from '../types/api'
 import { copyText } from '../lib/clipboard'
+import { appDisplayState } from '../lib/appDisplayState'
 import { ledClass, runtimeSwatch } from '../lib/runtimeSwatch'
 import { useToast } from '../lib/toast'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
@@ -46,6 +47,15 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
   const anyRunning = appRunning || daprdRunning
   const allStopped = (appStopped || daprdStopped) && !appRunning && !daprdRunning
   const busy = action.isPending
+
+  // dapr run supervises app + daprd together; sidecar actions act on the
+  // whole instance (see lifecycle manager funneling). Compose and Aspire
+  // keep per-target semantics.
+  const daprdTarget: AppTarget = isCompose || app.isAspire ? 'daprd' : 'all'
+  const daprdWhat =
+    isCompose || app.isAspire
+      ? `sidecar of "${app.appId}"`
+      : `"${app.appId}" (dapr run manages app + sidecar together)`
 
   const statusCell = (status?: string) =>
     status ? (
@@ -97,9 +107,14 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
         <div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
             <h1>{app.appId}</h1>
-            <span className="health">
-              <span className={`led ${ledClass(app.health)}`} /> {app.health}
-            </span>
+            {(() => {
+              const state = appDisplayState(app)
+              return (
+                <span className="health" title={state.hint}>
+                  <span className={`led ${state.led}`} /> {state.label}
+                </span>
+              )
+            })()}
             <span className="lang">
               <span className="sw" style={{ background: runtimeSwatch(app.runtime) }} />
               {app.runtime}
@@ -153,6 +168,11 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
       )}
       {app.isAspire && (appStopped || daprdStopped) && (
         <div className="hint">Managed by Aspire — restart it from the Aspire dashboard.</div>
+      )}
+      {app.sidecarOrphaned && (
+        <div className="hint">
+          Orphaned sidecar — this daprd has no supervising dapr CLI and its app is gone. Stopping it is safe.
+        </div>
       )}
 
       {/* Two-column: Application + Dapr sidecar */}
@@ -211,7 +231,7 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
           <div className="ph" style={{ display: 'flex', alignItems: 'center' }}>
             <span className="ic" style={{ background: 'var(--dapr)', color: '#fff' }}>d</span>
             Dapr sidecar (daprd)
-            {panelActions('daprd', app.daprdStatus, `sidecar of "${app.appId}"`)}
+            {panelActions(daprdTarget, app.daprdStatus, daprdWhat)}
           </div>
           <div className="kv">
             <div className="kk">Status</div>

--- a/web/src/pages/Applications.test.tsx
+++ b/web/src/pages/Applications.test.tsx
@@ -219,4 +219,24 @@ describe('Applications', () => {
     await waitFor(() => expect(screen.getByText('primes-go')).toBeInTheDocument())
     expect(screen.queryByTitle(/publish the daprd HTTP port/i)).not.toBeInTheDocument()
   })
+
+  it('renders app-down and orphaned states with tooltips', async () => {
+    mockApps([
+      { ...baseApp, appId: 'appdown', appStatus: 'stopped', daprdStatus: 'running' },
+      {
+        ...baseApp,
+        appId: 'ghost',
+        appPid: 0,
+        appStatus: 'stopped',
+        daprdStatus: 'running',
+        sidecarOrphaned: true,
+      },
+    ])
+    renderAt()
+    await waitFor(() => expect(screen.getByText('appdown')).toBeInTheDocument())
+    expect(screen.getByText('app down')).toBeInTheDocument()
+    expect(screen.getByText('orphaned')).toBeInTheDocument()
+    expect(screen.getByTitle('app process is not running')).toBeInTheDocument()
+    expect(screen.getByTitle('sidecar has no supervising dapr CLI and no app — safe to stop')).toBeInTheDocument()
+  })
 })

--- a/web/src/pages/Applications.tsx
+++ b/web/src/pages/Applications.tsx
@@ -1,8 +1,9 @@
 import { Link, useNavigate } from 'react-router-dom'
 import { useApps } from '../hooks/useApps'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
-import { ledClass, runtimeSwatch } from '../lib/runtimeSwatch'
+import { runtimeSwatch } from '../lib/runtimeSwatch'
 import { appKey } from '../lib/appKey'
+import { appDisplayState } from '../lib/appDisplayState'
 import type { AppSummary } from '../types/api'
 
 // Fully stopped: both the app process/container and its daprd sidecar report 'stopped'.
@@ -109,7 +110,7 @@ function AppRow({ app, onOpen }: { app: AppSummary; onOpen: () => void }) {
   const num = (v: number) =>
     v ? <td className="mono tabnum">{v}</td> : <td className="mono tabnum faint">—</td>
   const sourceLabel = app.runTemplate || (app.isAspire ? 'Aspire' : app.source === 'compose' ? 'Compose' : '—')
-  const stopped = isStopped(app)
+  const state = appDisplayState(app)
   const unreachable = app.source === 'compose' && app.sidecarReachable === false && app.daprdStatus !== 'stopped'
   const key = appKey(app)
   const hasContainerName = key !== app.appId
@@ -118,9 +119,9 @@ function AppRow({ app, onOpen }: { app: AppSummary; onOpen: () => void }) {
       <td>
         <span
           className="health"
-          title={unreachable ? 'publish the daprd HTTP port (e.g. 3500:3500) to enable health & metadata' : undefined}
+          title={state.hint ?? (unreachable ? 'publish the daprd HTTP port (e.g. 3500:3500) to enable health & metadata' : undefined)}
         >
-          <span className={`led ${ledClass(stopped ? 'unknown' : app.health)}`} /> {stopped ? 'stopped' : app.health}
+          <span className={`led ${state.led}`} /> {state.label}
           {unreachable && ' ⓘ'}
         </span>
       </td>

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -190,6 +190,7 @@ table.t.click tbody tr:hover { background: var(--surface-2); }
 .led.ok { background: var(--ok-bright); }
 .led.warn { background: var(--pend-fg); }
 .led.bad { background: var(--fail-fg); }
+.led.off { background: var(--faint); }
 .lang { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono); font-size: 12px; }
 .lang .sw { width: 9px; height: 9px; border-radius: 2px; }
 .chip { font-family: var(--mono); font-size: 11px; color: var(--muted); background: var(--surface-2); border: 1px solid var(--line); border-radius: 7px; padding: 3px 8px; display: inline-flex; gap: 6px; align-items: center; }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -36,6 +36,8 @@ export interface AppSummary {
   appStartedAt?: string
   /** RFC3339 start time of the daprd process/container ("" while stopped) */
   daprdStartedAt?: string
+  /** true when a standalone daprd has no supervising dapr CLI and no live app */
+  sidecarOrphaned?: boolean
   age: string
   created: string
   runTemplate: string


### PR DESCRIPTION
## Summary

Follow-up to #53. Fixes the "dashboard says healthy while the app is dead" problem observed with fanoutfanin: the health LED only reflected daprd's `/v1.0/healthz`, app-process info silently went stale, and a daprd-only stop/restart could orphan the sidecar outside the dapr CLI's supervision.

### Backend
- **Truthful `appStatus`** — discovery `enrich` now verifies the metadata-reported app PID (gopsutil `PidExists`; dead PID → `stopped` and zeroed) and falls back to a fast loopback TCP dial on the app port when the PID is unknown. No signals → honestly `unknown`.
- **Dead CLI PIDs cleared** — `cliPID` from daprd metadata survives the CLI's death; enrich now verifies it, so externally killed `dapr run` instances are detected correctly and never receive signals at stale/reused PIDs.
- **`sidecarOrphaned` field** — flags a standalone daprd with no supervising CLI and no live app (Aspire excluded).
- **Lifecycle funneling** — sidecar Stop/Restart for `dapr run` apps act on the whole instance (`TargetDaprd → TargetAll`), so the dashboard can no longer create orphans by restarting daprd outside CLI supervision. Compose and Aspire unchanged.

### Frontend
- Shared `appDisplayState` helper drives the Applications health cell and the AppDetail header badge: green `healthy`, amber `app down` / `orphaned` (with explanatory tooltips), red `unhealthy`, grey `stopped` (new `.led.off` style).
- AppDetail shows an orphan banner ("…Stopping it is safe.") and the sidecar panel's confirm dialog explains that dapr run manages app + sidecar together.

Design spec: `docs/superpowers/specs/2026-07-10-health-visualization-reliability-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-10-health-visualization-reliability.md`

## Test plan

- [x] `make build` (Go build + `tsc -b` + web build)
- [x] `go test -tags unit ./...` and `go test -tags integration ./...` — all green
- [x] `cd web && npx vitest run` — 670/670 across 82 files
- [x] New coverage: PID/port liveness matrix, orphan truth table (incl. Aspire exclusion and dead-CLI-PID case), funnel routing (standalone vs Aspire), display-state precedence, list/detail rendering with exact tooltip/banner copy, POST-target funneling in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)