### PR TITLE
chore: deferred-minors cleanup bundle (PRs #53/#55 follow-ups)

### DIFF
--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -172,13 +172,18 @@ func (s *service) enrich(ctx context.Context, r ScanResult) Instance {
 		AppID: r.AppID, InstanceKey: r.Key(), HTTPPort: r.HTTPPort, GRPCPort: r.GRPCPort, AppPort: r.AppPort,
 		DaprdPID: r.DaprdPID, CLIPID: r.CLIPID, RunTemplate: r.RunTemplate,
 		ResourcePaths: r.ResourcePaths, ConfigPath: r.ConfigPath, Command: r.Command,
-		Created: r.Created.Local().Format("15:04:05"), Age: humanAge(r.Created),
+		Age:     humanAge(r.Created),
 		Runtime: InferRuntime(r.Command), Health: HealthUnknown,
 		Source: r.Source, ComposeProject: r.ComposeProject, ComposeService: r.ComposeService,
 		DaprdContainerID: r.DaprdContainerID, DaprdContainerName: r.DaprdContainerName,
 		AppContainerID: r.AppContainerID, AppContainerName: r.AppContainerName,
 		SidecarReachable: r.SidecarReachable,
 		AppStatus:        r.AppStatus, DaprdStatus: r.DaprdStatus,
+	}
+	// A zero Created (e.g. a compose container created but never started)
+	// would otherwise render as "00:00:00".
+	if !r.Created.IsZero() {
+		in.Created = r.Created.Local().Format("15:04:05")
 	}
 	if !r.AppStartedAt.IsZero() && r.AppStatus != StatusStopped {
 		in.AppStartedAt = r.AppStartedAt.UTC().Format(time.RFC3339)

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -589,3 +589,17 @@ func TestSidecarOrphanedDetection(t *testing.T) {
 		require.False(t, items[0].SidecarOrphaned)
 	})
 }
+
+// A compose container that was created but never started has a zero StartedAt;
+// it must render no Created timestamp ("00:00:00") and no Age.
+func TestEnrichZeroCreatedShowsNoTimestamp(t *testing.T) {
+	scan := func() ([]ScanResult, error) {
+		return []ScanResult{{AppID: "checkout", Source: SourceCompose,
+			DaprdStatus: StatusStopped, AppStatus: StatusStopped}}, nil
+	}
+	svc := New(scan, &http.Client{Timeout: time.Second})
+	items, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "", items[0].Created)
+	require.Equal(t, "", items[0].Age)
+}

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -122,6 +122,12 @@ func (m *manager) doStandalone(ctx context.Context, in discovery.Instance, targe
 	if in.IsAspire && action != ActionStop {
 		return fmt.Errorf("%w: Aspire manages this app's lifecycle — restart it from the Aspire dashboard", ErrUnsupported)
 	}
+	// An orphaned sidecar has no supervising CLI and no app: nothing is
+	// re-runnable, so starting or restarting would only resurrect another
+	// orphan. Stop is the sole supported action.
+	if in.SidecarOrphaned && action != ActionStop {
+		return fmt.Errorf("%w: orphaned sidecar — only stop is supported", ErrUnsupported)
+	}
 	switch action {
 	case ActionStop:
 		return m.standaloneStop(ctx, in, target)
@@ -183,7 +189,12 @@ func (m *manager) standaloneStop(ctx context.Context, in discovery.Instance, tar
 			return fmt.Errorf("%w: no processes to stop", ErrUnsupported)
 		}
 	}
-	m.reg.RecordStop(in, snaps)
+	// Orphans record nothing: their daprd command must not be offered for
+	// re-run (it would only resurrect another orphan), so the instance simply
+	// disappears once its process is gone.
+	if !in.SidecarOrphaned {
+		m.reg.RecordStop(in, snaps)
+	}
 	for _, pid := range pids {
 		if err := m.terminateWithEscalation(ctx, pid); err != nil {
 			return fmt.Errorf("stop pid %d: %w", pid, err)

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -310,3 +310,21 @@ func TestAspireDaprdStopNotFunneled(t *testing.T) {
 	require.NoError(t, m.Do(context.Background(), "orders", TargetDaprd, ActionStop))
 	require.Equal(t, []int{200}, proc.terminated, "Aspire keeps per-PID daprd stop")
 }
+
+// Pins the TargetAll start fallback: with no CLI snapshot (e.g. the CLI was
+// never captured), the halves start individually, sidecar first, and each
+// started target leaves the registry.
+func TestStandaloneStartAllWithoutCLISnapshotStartsHalvesInOrder(t *testing.T) {
+	reg := NewRegistry()
+	reg.RecordStop(standaloneInst(), map[Target]ProcSnapshot{
+		TargetDaprd: {PID: 200, Argv: []string{"daprd", "--app-id", "orders"}, Dir: "/src"},
+		TargetApp:   {PID: 100, Argv: []string{"go", "run", "."}, Dir: "/src"},
+	})
+	st := &fakeStarter{}
+	m := New(fakeApps{items: map[string]discovery.Instance{"orders": standaloneInst()}}, reg, nil, newFakeProc(), st)
+
+	require.NoError(t, m.Do(context.Background(), "orders", TargetAll, ActionStart))
+	require.Equal(t, [][]string{{"daprd", "--app-id", "orders"}, {"go", "run", "."}}, st.started, "sidecar starts before the app")
+	_, ok := reg.Get("orders")
+	require.False(t, ok, "both targets dropped -> entry gone")
+}

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -328,3 +328,27 @@ func TestStandaloneStartAllWithoutCLISnapshotStartsHalvesInOrder(t *testing.T) {
 	_, ok := reg.Get("orders")
 	require.False(t, ok, "both targets dropped -> entry gone")
 }
+
+// An orphaned sidecar (no supervising CLI, app gone) supports only stop:
+// there is no re-runnable command, so start/restart are rejected and a stop
+// records nothing in the registry.
+func TestOrphanedSidecarOnlyStopAllowed(t *testing.T) {
+	in := standaloneInst()
+	in.SidecarOrphaned = true
+	in.CLIPID = 0
+	in.AppPID = 0
+	proc := newFakeProc()
+	proc.snaps[200] = ProcSnapshot{PID: 200, Argv: []string{"daprd", "--app-id", "orders"}}
+	proc.alive[200] = true
+	reg := NewRegistry()
+	m := New(fakeApps{items: map[string]discovery.Instance{"orders": in}}, reg, nil, proc, nil).(*manager)
+	m.grace = 10 * time.Millisecond
+
+	require.ErrorIs(t, m.Do(context.Background(), "orders", TargetAll, ActionStart), ErrUnsupported)
+	require.ErrorIs(t, m.Do(context.Background(), "orders", TargetDaprd, ActionRestart), ErrUnsupported)
+
+	require.NoError(t, m.Do(context.Background(), "orders", TargetAll, ActionStop))
+	require.Equal(t, []int{200}, proc.terminated, "orphan stop signals the surviving daprd")
+	_, ok := reg.Get("orders")
+	require.False(t, ok, "orphan stop must not create a registry entry")
+}

--- a/web/src/pages/AppDetail.test.tsx
+++ b/web/src/pages/AppDetail.test.tsx
@@ -398,6 +398,26 @@ describe('AppDetail', () => {
     confirmSpy.mockRestore()
   })
 
+  it('offers only Stop for an orphaned sidecar', async () => {
+    server.use(
+      http.get('/api/apps/order', () =>
+        HttpResponse.json({
+          ...runningApp,
+          appStatus: 'stopped',
+          daprdStatus: 'running',
+          sidecarOrphaned: true,
+          cliPid: 0,
+          appPid: 0,
+        }),
+      ),
+    )
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    expect(screen.getAllByRole('button', { name: 'Stop' }).length).toBeGreaterThan(0)
+    expect(screen.queryByRole('button', { name: 'Restart' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Start' })).not.toBeInTheDocument()
+  })
+
   it('surfaces action errors via toast', async () => {
     server.use(
       http.get('/api/apps/order', () => HttpResponse.json(runningApp)),

--- a/web/src/pages/AppDetail.test.tsx
+++ b/web/src/pages/AppDetail.test.tsx
@@ -397,4 +397,42 @@ describe('AppDetail', () => {
     await waitFor(() => expect(posted).toBe('daprd/stop'))
     confirmSpy.mockRestore()
   })
+
+  it('surfaces action errors via toast', async () => {
+    server.use(
+      http.get('/api/apps/order', () => HttpResponse.json(runningApp)),
+      http.post('/api/apps/order/all/stop', () =>
+        HttpResponse.json({ error: 'boom from backend' }, { status: 502 }),
+      ),
+    )
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    screen.getAllByRole('button', { name: 'Stop' })[0].click()
+    await waitFor(() => expect(screen.getByText('boom from backend')).toBeInTheDocument())
+    confirmSpy.mockRestore()
+  })
+
+  it('disables lifecycle buttons while an action is in flight', async () => {
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    server.use(
+      http.get('/api/apps/order', () => HttpResponse.json(runningApp)),
+      http.post('/api/apps/order/all/stop', async () => {
+        await gate
+        return HttpResponse.json({ status: 'ok' })
+      }),
+    )
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    const stop = screen.getAllByRole('button', { name: 'Stop' })[0]
+    stop.click()
+    await waitFor(() => expect(stop).toBeDisabled())
+    release()
+    await waitFor(() => expect(stop).toBeEnabled())
+    confirmSpy.mockRestore()
+  })
 })

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -47,6 +47,8 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
   const anyRunning = appRunning || daprdRunning
   const allStopped = (appStopped || daprdStopped) && !appRunning && !daprdRunning
   const busy = action.isPending
+  // An orphaned sidecar has nothing re-runnable: Stop is the only action.
+  const orphaned = !!app.sidecarOrphaned
 
   // dapr run supervises app + daprd together; sidecar actions act on the
   // whole instance (see lifecycle manager funneling). Compose and Aspire
@@ -75,7 +77,7 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
     <span style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}>
       {status === 'running' && (
         <>
-          {!app.isAspire && (
+          {!app.isAspire && !orphaned && (
             <button className="btn ghost" disabled={busy} onClick={() => runAction(target, 'restart', what)}>
               Restart
             </button>
@@ -85,7 +87,7 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
           </button>
         </>
       )}
-      {status === 'stopped' && !app.isAspire && (
+      {status === 'stopped' && !app.isAspire && !orphaned && (
         <button className="btn ghost" disabled={busy} onClick={() => runAction(target, 'start', what)}>
           Start
         </button>
@@ -125,7 +127,7 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
         <div style={{ display: 'flex', gap: 8 }}>
           {anyRunning && (
             <>
-              {!app.isAspire && (
+              {!app.isAspire && !orphaned && (
                 <button
                   className="btn ghost"
                   disabled={busy}
@@ -143,7 +145,7 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
               </button>
             </>
           )}
-          {allStopped && !app.isAspire && (
+          {allStopped && !app.isAspire && !orphaned && (
             <button
               className="btn ghost"
               disabled={busy}

--- a/web/src/pages/Applications.test.tsx
+++ b/web/src/pages/Applications.test.tsx
@@ -239,4 +239,44 @@ describe('Applications', () => {
     expect(screen.getByTitle('app process is not running')).toBeInTheDocument()
     expect(screen.getByTitle('sidecar has no supervising dapr CLI and no app — safe to stop')).toBeInTheDocument()
   })
+
+  it('counts amber states (app down, orphaned) as Unhealthy in the stat cards', async () => {
+    mockApps([
+      { ...baseApp, appId: 'ok1', appStatus: 'running', daprdStatus: 'running' },
+      { ...baseApp, appId: 'appdown', appStatus: 'stopped', daprdStatus: 'running' },
+      { ...baseApp, appId: 'ghost', appPid: 0, appStatus: 'stopped', daprdStatus: 'running', sidecarOrphaned: true },
+    ])
+    renderAt()
+    await waitFor(() => expect(screen.getByText('ok1')).toBeInTheDocument())
+    expect(screen.getByText('Healthy').previousElementSibling).toHaveTextContent('1')
+    expect(screen.getByText('Unhealthy').previousElementSibling).toHaveTextContent('2')
+  })
+
+  it('renders the stopped row with the grey off LED', async () => {
+    mockApps([
+      { ...baseApp, appId: 'halted', health: 'unknown', appStatus: 'stopped', daprdStatus: 'stopped' },
+    ])
+    renderAt()
+    await waitFor(() => expect(screen.getByText('halted')).toBeInTheDocument())
+    const badge = screen.getByText('stopped').closest('.health')
+    expect(badge?.querySelector('.led')).toHaveClass('off')
+  })
+
+  it('keeps the unreachable hint for an unreachable but running compose sidecar', async () => {
+    mockApps([
+      {
+        ...baseApp,
+        appId: 'primes-go',
+        source: 'compose',
+        composeProject: 'saga',
+        sidecarReachable: false,
+        health: 'unknown',
+        appStatus: 'running',
+        daprdStatus: 'running',
+      },
+    ])
+    renderAt()
+    await waitFor(() => expect(screen.getByText('primes-go')).toBeInTheDocument())
+    expect(screen.getByTitle(/publish the daprd HTTP port/i)).toBeInTheDocument()
+  })
 })

--- a/web/src/pages/Applications.tsx
+++ b/web/src/pages/Applications.tsx
@@ -43,9 +43,13 @@ export function Applications() {
   }
 
   const running = apps.filter((a) => !isStopped(a)).length
-  const healthy = apps.filter((a) => a.health === 'healthy').length
-  const starting = apps.filter((a) => a.health === 'starting').length
-  const unhealthy = apps.filter((a) => a.health === 'unhealthy').length
+  // Stat cards follow the combined display state so a row and its card never
+  // disagree; the amber states (app down, orphaned) need attention and count
+  // as Unhealthy.
+  const labels = apps.map((a) => appDisplayState(a).label)
+  const healthy = labels.filter((l) => l === 'healthy').length
+  const starting = labels.filter((l) => l === 'starting').length
+  const unhealthy = labels.filter((l) => l === 'unhealthy' || l === 'app down' || l === 'orphaned').length
   // Total components loaded across every running app; '—' when none report any.
   const componentsTotal = apps.reduce((n, a) => n + (a.components?.length ?? 0), 0)
   const componentsLoaded = componentsTotal > 0 ? componentsTotal : '—'


### PR DESCRIPTION
## Summary

Bundles the quick-win deferred minors from the PR #53 and #55 review ledgers, plus the orphan-actions decision. Stacked on `feat/health-viz-reliability` (#55) — GitHub will retarget to `main` when #55 merges.

**Behavior changes (3):**
- **Orphaned sidecars only allow Stop**: start/restart are rejected in the lifecycle manager (`ErrUnsupported` → 400), stopping an orphan records no registry entry (so no ghost "stopped" row offering a Start that would resurrect a bare daprd), and the detail page hides Start/Restart for orphans.
- **Stat cards follow the combined display state**: the Healthy/Starting/Unhealthy cards now count `appDisplayState` labels instead of raw sidecar health, so an amber "app down" or "orphaned" row no longer inflates Healthy — amber states count as Unhealthy. Fully-stopped rows continue to count in no card.
- **Zero `Created` guard**: a compose container that was created but never started no longer renders `Created "00:00:00"` — timestamp and age show `—`.

**Test-only (5):**
- Pin the `TargetAll` start fallback (no CLI snapshot → daprd then app, registry targets dropped)
- Pin the grey `.led.off` class on stopped rows
- Pin the unreachable-ⓘ hint still firing for an unreachable-but-*running* compose sidecar
- Pin toast-on-error for lifecycle actions
- Pin buttons disabled while a lifecycle action is in flight

## Test plan

- [x] `make build` (tsc -b + vite + go build)
- [x] `go test -tags unit ./...` / `go test -tags integration ./...` — clean
- [x] `cd web && npx vitest run` — 676/676 across 82 files
- [x] Inline high-effort code review on the bundle: no blocking findings (2 minor polish notes recorded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)