### PR TITLE
fix: close remaining UX dead-ends after lifecycle actions

### DIFF
--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -15,6 +15,10 @@ func logger() *slog.Logger { return slog.Default().With("component", "lifecycle"
 // Manager starts, stops and restarts discovered app instances.
 type Manager interface {
 	Do(ctx context.Context, key string, target Target, action Action) error
+	// Forget drops a remembered stopped instance so it no longer appears on
+	// the dashboard. Only registry-backed (fully stopped standalone)
+	// instances have an entry; anything else is discovery.ErrNotFound.
+	Forget(ctx context.Context, key string) error
 }
 
 type manager struct {
@@ -108,6 +112,18 @@ func composeTargets(in discovery.Instance, target Target, action Action) ([]stri
 		return startOrder, nil
 	}
 	return stopOrder, nil
+}
+
+// Forget implements Manager: it resolves key like the registry (InstanceKey
+// first, AppID fallback) and drops the entry under its own key.
+func (m *manager) Forget(ctx context.Context, key string) error {
+	e, ok := m.reg.Get(key)
+	if !ok {
+		return fmt.Errorf("%w: %s", discovery.ErrNotFound, key)
+	}
+	logger().Info("forgetting stopped instance", "key", e.Instance.InstanceKey)
+	m.reg.Drop(e.Instance.InstanceKey)
+	return nil
 }
 
 // doStandalone dispatches start/stop/restart for a process-table instance.

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -164,7 +164,12 @@ func (m *manager) standaloneStop(ctx context.Context, in discovery.Instance, tar
 		if in.AppPID == 0 {
 			return fmt.Errorf("%w: app process unknown", ErrUnsupported)
 		}
+		// Killing the app usually makes the dapr CLI tear down daprd and exit
+		// (supervision cascade), so capture all three commands even though
+		// only the app is signalled — the whole instance stays recoverable.
 		snapshot(TargetApp, in.AppPID, in.AppLogPath)
+		snapshot(TargetDaprd, in.DaprdPID, in.DaprdLogPath)
+		snapshot(TargetAll, in.CLIPID, "")
 		pids = []int{in.AppPID}
 	case TargetDaprd:
 		if in.DaprdPID == 0 {

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -232,8 +232,12 @@ func (m *manager) terminateWithEscalation(ctx context.Context, pid int) error {
 }
 
 // standaloneStart re-runs the snapshot captured at stop time. TargetAll
-// prefers the dapr CLI command (it starts both halves); the entry is dropped
-// so the next scan's live data wins.
+// prefers the dapr CLI command (it starts both halves). The registry entry
+// deliberately survives the start: dropping it here opened a window where
+// the instance was neither remembered nor yet discovered (the page 404'd,
+// and a command that exited immediately erased the instance for good). The
+// overlay's live reconciliation removes the entry once the process scan
+// sees the instance again.
 func (m *manager) standaloneStart(ctx context.Context, in discovery.Instance, target Target) error {
 	entry, ok := m.reg.Get(in.InstanceKey)
 	if !ok {
@@ -241,11 +245,7 @@ func (m *manager) standaloneStart(ctx context.Context, in discovery.Instance, ta
 	}
 	if target == TargetAll {
 		if snap, ok := entry.Procs[TargetAll]; ok {
-			if err := m.start.Start(snap.Argv, snap.Dir, snap.LogPath); err != nil {
-				return err
-			}
-			m.reg.Drop(in.InstanceKey)
-			return nil
+			return m.start.Start(snap.Argv, snap.Dir, snap.LogPath)
 		}
 		// No CLI snapshot: bring the halves up individually, sidecar first.
 		started := false
@@ -257,7 +257,6 @@ func (m *manager) standaloneStart(ctx context.Context, in discovery.Instance, ta
 			if err := m.start.Start(snap.Argv, snap.Dir, snap.LogPath); err != nil {
 				return err
 			}
-			m.reg.DropTarget(in.InstanceKey, t)
 			started = true
 		}
 		if !started {
@@ -269,9 +268,5 @@ func (m *manager) standaloneStart(ctx context.Context, in discovery.Instance, ta
 	if !ok {
 		return fmt.Errorf("%w: no captured command for %s", ErrUnsupported, target)
 	}
-	if err := m.start.Start(snap.Argv, snap.Dir, snap.LogPath); err != nil {
-		return err
-	}
-	m.reg.DropTarget(in.InstanceKey, target)
-	return nil
+	return m.start.Start(snap.Argv, snap.Dir, snap.LogPath)
 }

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -241,7 +241,7 @@ func TestStandaloneStartAllRerunsCLICommand(t *testing.T) {
 	require.Equal(t, [][]string{{"dapr", "run", "--app-id", "orders"}}, st.started)
 	require.Equal(t, []string{"/src"}, st.dirs)
 	_, ok := reg.Get("orders")
-	require.False(t, ok, "whole entry dropped after start")
+	require.True(t, ok, "entry survives start; the overlay drops it once discovery sees the instance live")
 }
 
 func TestStandaloneStartSingleTarget(t *testing.T) {
@@ -256,8 +256,8 @@ func TestStandaloneStartSingleTarget(t *testing.T) {
 	require.NoError(t, m.Do(context.Background(), "orders", TargetApp, ActionStart))
 	require.Equal(t, [][]string{{"go", "run", "."}}, st.started)
 	e, ok := reg.Get("orders")
-	require.True(t, ok, "daprd snapshot remains")
-	require.Len(t, e.Procs, 1)
+	require.True(t, ok, "entry survives start; live reconciliation cleans it up")
+	require.Len(t, e.Procs, 2)
 }
 
 func TestStandaloneStartWithoutSnapshotRejected(t *testing.T) {
@@ -325,8 +325,9 @@ func TestStandaloneStartAllWithoutCLISnapshotStartsHalvesInOrder(t *testing.T) {
 
 	require.NoError(t, m.Do(context.Background(), "orders", TargetAll, ActionStart))
 	require.Equal(t, [][]string{{"daprd", "--app-id", "orders"}, {"go", "run", "."}}, st.started, "sidecar starts before the app")
-	_, ok := reg.Get("orders")
-	require.False(t, ok, "both targets dropped -> entry gone")
+	e, ok := reg.Get("orders")
+	require.True(t, ok, "entry survives start; live reconciliation cleans it up")
+	require.Len(t, e.Procs, 2)
 }
 
 // An orphaned sidecar (no supervising CLI, app gone) supports only stop:

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -375,3 +375,27 @@ func TestStandaloneAppStopSnapshotsEverything(t *testing.T) {
 	require.Contains(t, e.Procs, TargetDaprd, "cascade insurance: daprd command captured")
 	require.Contains(t, e.Procs, TargetAll, "cascade insurance: CLI command captured")
 }
+
+func TestForgetDropsRememberedInstance(t *testing.T) {
+	reg := NewRegistry()
+	reg.RecordStop(standaloneInst(), map[Target]ProcSnapshot{TargetAll: {PID: 300}})
+	m := New(fakeApps{items: map[string]discovery.Instance{}}, reg, nil, newFakeProc(), nil)
+
+	require.NoError(t, m.Forget(context.Background(), "orders"))
+	_, ok := reg.Get("orders")
+	require.False(t, ok, "entry dropped")
+
+	require.ErrorIs(t, m.Forget(context.Background(), "orders"), discovery.ErrNotFound)
+}
+
+func TestForgetResolvesAppIDFallback(t *testing.T) {
+	reg := NewRegistry()
+	in := standaloneInst()
+	in.InstanceKey = "orders-1"
+	reg.RecordStop(in, map[Target]ProcSnapshot{TargetAll: {PID: 300}})
+	m := New(fakeApps{items: map[string]discovery.Instance{}}, reg, nil, newFakeProc(), nil)
+
+	require.NoError(t, m.Forget(context.Background(), "orders"), "AppID fallback resolves")
+	_, ok := reg.Get("orders-1")
+	require.False(t, ok, "the entry's own key is dropped, not the fallback alias")
+}

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -352,3 +352,25 @@ func TestOrphanedSidecarOnlyStopAllowed(t *testing.T) {
 	_, ok := reg.Get("orders")
 	require.False(t, ok, "orphan stop must not create a registry entry")
 }
+
+// Stopping only the app usually makes the dapr CLI tear down daprd and exit
+// (supervision cascade). Capture all three commands so the whole instance
+// stays recoverable even when only the app was signalled.
+func TestStandaloneAppStopSnapshotsEverything(t *testing.T) {
+	proc := newFakeProc()
+	proc.snaps[100] = ProcSnapshot{PID: 100, Argv: []string{"go", "run", "."}, Dir: "/src"}
+	proc.snaps[200] = ProcSnapshot{PID: 200, Argv: []string{"daprd", "--app-id", "orders"}, Dir: "/src"}
+	proc.snaps[300] = ProcSnapshot{PID: 300, Argv: []string{"dapr", "run", "--app-id", "orders"}, Dir: "/src"}
+	proc.alive[100] = true
+	reg := NewRegistry()
+	m := New(fakeApps{items: map[string]discovery.Instance{"orders": standaloneInst()}}, reg, nil, proc, nil).(*manager)
+	m.grace = 10 * time.Millisecond
+
+	require.NoError(t, m.Do(context.Background(), "orders", TargetApp, ActionStop))
+	require.Equal(t, []int{100}, proc.terminated, "only the app is signalled")
+	e, ok := reg.Get("orders")
+	require.True(t, ok)
+	require.Contains(t, e.Procs, TargetApp)
+	require.Contains(t, e.Procs, TargetDaprd, "cascade insurance: daprd command captured")
+	require.Contains(t, e.Procs, TargetAll, "cascade insurance: CLI command captured")
+}

--- a/pkg/lifecycle/overlay.go
+++ b/pkg/lifecycle/overlay.go
@@ -62,17 +62,24 @@ func (o *overlay) Get(ctx context.Context, key string) (discovery.Instance, erro
 	return discovery.Instance{}, err
 }
 
-// applyEntry reconciles a live instance against its registry entry. The
-// scanner keys off daprd, so a live key proves daprd is back: daprd/all
-// snapshots are stale. An app snapshot survives only while the app process
-// has not reappeared under a new PID.
+// applyEntry reconciles a live instance against its registry entry. Every
+// snapshot survives while it still describes the live process (same PID):
+// an app-only stop deliberately captures daprd and the CLI as cascade
+// insurance while both are still running, and dropping those eagerly (the
+// scanner seeing the key proves daprd is alive, but not that it was ever
+// restarted) would erase the insurance on the very next poll. A snapshot is
+// stale only once its process reappears under a NEW pid.
 func (o *overlay) applyEntry(in *discovery.Instance) {
 	e, ok := o.reg.Get(in.InstanceKey)
 	if !ok || in.Source == discovery.SourceCompose {
 		return
 	}
-	o.reg.DropTarget(in.InstanceKey, TargetDaprd)
-	o.reg.DropTarget(in.InstanceKey, TargetAll)
+	if snap, ok := e.Procs[TargetDaprd]; ok && in.DaprdPID != 0 && in.DaprdPID != snap.PID {
+		o.reg.DropTarget(in.InstanceKey, TargetDaprd) // daprd restarted since capture
+	}
+	if snap, ok := e.Procs[TargetAll]; ok && in.CLIPID != 0 && in.CLIPID != snap.PID {
+		o.reg.DropTarget(in.InstanceKey, TargetAll) // new dapr run supervisor
+	}
 	snap, ok := e.Procs[TargetApp]
 	if !ok {
 		return

--- a/pkg/lifecycle/overlay_test.go
+++ b/pkg/lifecycle/overlay_test.go
@@ -91,15 +91,38 @@ func TestOverlayDropsEntryWhenAppExternallyRestarted(t *testing.T) {
 	require.False(t, ok, "stale entry dropped")
 }
 
-func TestOverlayDropsDaprdEntryWhenKeyLiveAgain(t *testing.T) {
+func TestOverlayDropsDaprdEntryWhenDaprdRestarted(t *testing.T) {
+	// The snapshot captured daprd under PID 999; the live instance runs it
+	// under 200 — the snapshot is stale and must go.
 	reg := NewRegistry()
-	reg.RecordStop(standaloneInst(), map[Target]ProcSnapshot{TargetDaprd: {PID: 200}})
+	reg.RecordStop(standaloneInst(), map[Target]ProcSnapshot{TargetDaprd: {PID: 999}, TargetAll: {PID: 888}})
 
-	live := standaloneInst()
+	live := standaloneInst() // DaprdPID 200, CLIPID 300
 	live.DaprdStatus = discovery.StatusRunning
 	svc := Overlay(fakeApps{items: map[string]discovery.Instance{"orders": live}}, reg, newFakeProc())
 	_, err := svc.List(context.Background())
 	require.NoError(t, err)
 	_, ok := reg.Get("orders")
 	require.False(t, ok)
+}
+
+func TestOverlayKeepsCascadeInsuranceSnapshotsWhilePIDsMatch(t *testing.T) {
+	// An app-only stop captures daprd + CLI while both still run (cascade
+	// insurance). The overlay must not erase them on the next poll: they
+	// still describe the live processes (same PIDs).
+	reg := NewRegistry()
+	reg.RecordStop(standaloneInst(), map[Target]ProcSnapshot{
+		TargetApp:   {PID: 100},
+		TargetDaprd: {PID: 200},
+		TargetAll:   {PID: 300},
+	})
+
+	live := standaloneInst() // AppPID 100, DaprdPID 200, CLIPID 300
+	live.DaprdStatus = discovery.StatusRunning
+	svc := Overlay(fakeApps{items: map[string]discovery.Instance{"orders": live}}, reg, newFakeProc())
+	_, err := svc.List(context.Background())
+	require.NoError(t, err)
+	e, ok := reg.Get("orders")
+	require.True(t, ok, "insurance snapshots survive while PIDs match")
+	require.Len(t, e.Procs, 3)
 }

--- a/pkg/server/apps.go
+++ b/pkg/server/apps.go
@@ -62,5 +62,21 @@ func appsRouter(svc discovery.Service, containerLogs func(context.Context, strin
 		}
 	})
 
+	r.Delete("/{appId}", func(w http.ResponseWriter, req *http.Request) {
+		if life == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "lifecycle actions unavailable"})
+			return
+		}
+		err := life.Forget(req.Context(), chi.URLParam(req, "appId"))
+		switch {
+		case err == nil:
+			w.WriteHeader(http.StatusNoContent)
+		case errors.Is(err, discovery.ErrNotFound):
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "no remembered stopped instance for this app"})
+		default:
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		}
+	})
+
 	return r
 }

--- a/pkg/server/apps_test.go
+++ b/pkg/server/apps_test.go
@@ -81,15 +81,21 @@ func TestAppsLogsReturns404WhenNoLogPath(t *testing.T) {
 
 // fakeLifecycle is a test double for lifecycle.Manager.
 type fakeLifecycle struct {
-	err    error
-	gotKey string
-	gotTgt lifecycle.Target
-	gotAct lifecycle.Action
+	err       error
+	forgetErr error
+	gotKey    string
+	gotTgt    lifecycle.Target
+	gotAct    lifecycle.Action
 }
 
 func (f *fakeLifecycle) Do(ctx context.Context, key string, target lifecycle.Target, action lifecycle.Action) error {
 	f.gotKey, f.gotTgt, f.gotAct = key, target, action
 	return f.err
+}
+
+func (f *fakeLifecycle) Forget(ctx context.Context, key string) error {
+	f.gotKey = key
+	return f.forgetErr
 }
 
 func TestAppsLifecycleRoute(t *testing.T) {
@@ -126,6 +132,38 @@ func TestAppsLifecycleRoute(t *testing.T) {
 func TestAppsLifecycleRouteNilManager(t *testing.T) {
 	h := appsRouter(newFakeApps(), nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/orders/app/stop", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestAppsForgetRoute(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    error
+		status int
+	}{
+		{"ok", nil, http.StatusNoContent},
+		{"not found", discovery.ErrNotFound, http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			life := &fakeLifecycle{forgetErr: tc.err}
+			h := appsRouter(newFakeApps(), nil, life)
+			req := httptest.NewRequest(http.MethodDelete, "/orders", nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			require.Equal(t, tc.status, rec.Code)
+			if tc.err == nil {
+				require.Equal(t, "orders", life.gotKey)
+			}
+		})
+	}
+}
+
+func TestAppsForgetRouteNilManager(t *testing.T) {
+	h := appsRouter(newFakeApps(), nil, nil)
+	req := httptest.NewRequest(http.MethodDelete, "/orders", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusServiceUnavailable, rec.Code)

--- a/web/src/hooks/useAppAction.test.tsx
+++ b/web/src/hooks/useAppAction.test.tsx
@@ -3,7 +3,7 @@ import { http, HttpResponse } from 'msw'
 import { describe, it, expect } from 'vitest'
 import { server } from '../test/setup'
 import { makeQueryClient, QueryProvider } from '../lib/query'
-import { useAppAction } from './useAppAction'
+import { useAppAction, useAppForget } from './useAppAction'
 
 function wrapper({ children }: { children: React.ReactNode }) {
   return <QueryProvider client={makeQueryClient()}>{children}</QueryProvider>
@@ -34,5 +34,33 @@ describe('useAppAction', () => {
     result.current.mutate({ target: 'app', action: 'start' })
     await waitFor(() => expect(result.current.isError).toBe(true))
     expect(result.current.error?.message).toBe('no captured command')
+  })
+})
+
+describe('useAppForget', () => {
+  it('DELETEs the app entry and resolves', async () => {
+    let hit = false
+    server.use(
+      http.delete('/api/apps/orders', () => {
+        hit = true
+        return new HttpResponse(null, { status: 204 })
+      }),
+    )
+    const { result } = renderHook(() => useAppForget('orders'), { wrapper })
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(hit).toBe(true)
+  })
+
+  it('surfaces the API error body as the Error message', async () => {
+    server.use(
+      http.delete('/api/apps/orders', () =>
+        HttpResponse.json({ error: 'no remembered stopped instance for this app' }, { status: 404 }),
+      ),
+    )
+    const { result } = renderHook(() => useAppForget('orders'), { wrapper })
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe('no remembered stopped instance for this app')
   })
 })

--- a/web/src/hooks/useAppAction.ts
+++ b/web/src/hooks/useAppAction.ts
@@ -4,21 +4,30 @@ import { apiUrl } from '../lib/api'
 export type AppTarget = 'app' | 'daprd' | 'all'
 export type AppLifecycleAction = 'start' | 'stop' | 'restart'
 
+// Throws the API's {error} body (or a status-only message) for non-2xx responses.
+async function throwIfNotOK(res: Response): Promise<void> {
+  if (res.ok) return
+  let msg = `request failed: ${res.status}`
+  try {
+    const data = (await res.json()) as { error?: unknown }
+    if (data && typeof data.error === 'string') msg = data.error
+  } catch {
+    // keep status-only message
+  }
+  throw new Error(msg)
+}
+
 async function sendAppAction(key: string, target: AppTarget, action: AppLifecycleAction): Promise<void> {
   const res = await fetch(
     apiUrl(`/apps/${encodeURIComponent(key)}/${encodeURIComponent(target)}/${encodeURIComponent(action)}`),
     { method: 'POST' },
   )
-  if (!res.ok) {
-    let msg = `request failed: ${res.status}`
-    try {
-      const data = (await res.json()) as { error?: unknown }
-      if (data && typeof data.error === 'string') msg = data.error
-    } catch {
-      // keep status-only message
-    }
-    throw new Error(msg)
-  }
+  await throwIfNotOK(res)
+}
+
+async function sendAppForget(key: string): Promise<void> {
+  const res = await fetch(apiUrl(`/apps/${encodeURIComponent(key)}`), { method: 'DELETE' })
+  await throwIfNotOK(res)
 }
 
 /**
@@ -30,6 +39,18 @@ export function useAppAction(key: string) {
   return useMutation({
     mutationFn: ({ target, action }: { target: AppTarget; action: AppLifecycleAction }) =>
       sendAppAction(key, target, action),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['apps'] }),
+  })
+}
+
+/**
+ * Drops a remembered stopped instance from the dashboard via
+ * DELETE /api/apps/:key. Invalidates all app queries on success.
+ */
+export function useAppForget(key: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => sendAppForget(key),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['apps'] }),
   })
 }

--- a/web/src/pages/AppDetail.test.tsx
+++ b/web/src/pages/AppDetail.test.tsx
@@ -464,6 +464,59 @@ describe('AppDetail', () => {
     expect(screen.getAllByRole('button', { name: 'Start' })).toHaveLength(1)
   })
 
+  it('removes a fully stopped instance from the list and returns to the overview', async () => {
+    let deleted = false
+    server.use(
+      http.get('/api/apps/order', () =>
+        HttpResponse.json({
+          ...runningApp,
+          health: 'unknown',
+          appStatus: 'stopped',
+          daprdStatus: 'stopped',
+          appPid: 0,
+          daprdPid: 0,
+        }),
+      ),
+      http.delete('/api/apps/order', () => {
+        deleted = true
+        return new HttpResponse(null, { status: 204 })
+      }),
+    )
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    screen.getByRole('button', { name: 'Remove from list' }).click()
+    await waitFor(() => expect(screen.getByText('Applications index')).toBeInTheDocument())
+    expect(deleted).toBe(true)
+    confirmSpy.mockRestore()
+  })
+
+  it('offers Remove from list for a fully stopped Aspire ghost, not for running or compose apps', async () => {
+    server.use(
+      http.get('/api/apps/order', () =>
+        HttpResponse.json({
+          ...runningApp,
+          isAspire: true,
+          health: 'unknown',
+          appStatus: 'stopped',
+          daprdStatus: 'stopped',
+          appPid: 0,
+          daprdPid: 0,
+        }),
+      ),
+    )
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: 'Remove from list' })).toBeInTheDocument()
+  })
+
+  it('hides Remove from list for running instances', async () => {
+    server.use(http.get('/api/apps/order', () => HttpResponse.json(runningApp)))
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: 'Remove from list' })).not.toBeInTheDocument()
+  })
+
   it('surfaces action errors via toast', async () => {
     server.use(
       http.get('/api/apps/order', () => HttpResponse.json(runningApp)),

--- a/web/src/pages/AppDetail.test.tsx
+++ b/web/src/pages/AppDetail.test.tsx
@@ -517,6 +517,18 @@ describe('AppDetail', () => {
     expect(screen.queryByRole('button', { name: 'Remove from list' })).not.toBeInTheDocument()
   })
 
+  it('offers a back link when the app cannot be loaded', async () => {
+    server.use(
+      http.get('/api/apps/order', () =>
+        HttpResponse.json({ error: 'app not found' }, { status: 404 }),
+      ),
+    )
+    renderDetail()
+    // The query client retries once (~1s backoff) before surfacing the error.
+    expect(await screen.findByText('App not found or failed to load.', undefined, { timeout: 4000 })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Back to applications/ })).toHaveAttribute('href', '/')
+  })
+
   it('surfaces action errors via toast', async () => {
     server.use(
       http.get('/api/apps/order', () => HttpResponse.json(runningApp)),

--- a/web/src/pages/AppDetail.test.tsx
+++ b/web/src/pages/AppDetail.test.tsx
@@ -443,6 +443,27 @@ describe('AppDetail', () => {
     confirmSpy.mockRestore()
   })
 
+
+  it('offers a single whole-instance Start when a dapr run app is fully stopped', async () => {
+    server.use(
+      http.get('/api/apps/order', () =>
+        HttpResponse.json({
+          ...runningApp,
+          health: 'unknown',
+          appStatus: 'stopped',
+          daprdStatus: 'stopped',
+          appPid: 0,
+          daprdPid: 0,
+        }),
+      ),
+    )
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    // Per-panel Starts are hidden: a bare app or bare daprd restart is not
+    // discoverable/useful — the header whole-instance Start is the affordance.
+    expect(screen.getAllByRole('button', { name: 'Start' })).toHaveLength(1)
+  })
+
   it('surfaces action errors via toast', async () => {
     server.use(
       http.get('/api/apps/order', () => HttpResponse.json(runningApp)),

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -441,6 +441,7 @@ export function AppDetail() {
     return (
       <div className="page">
         <p className="err">App not found or failed to load.</p>
+        <Link className="tbtn" to="/">← Back to applications</Link>
       </div>
     )
   }

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useApp } from '../hooks/useApps'
-import { useAppAction, type AppTarget, type AppLifecycleAction } from '../hooks/useAppAction'
+import { useAppAction, useAppForget, type AppTarget, type AppLifecycleAction } from '../hooks/useAppAction'
 import type { AppDetail as AppDetailType } from '../types/api'
 import { copyText } from '../lib/clipboard'
 import { appDisplayState } from '../lib/appDisplayState'
@@ -56,6 +56,17 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
   const busy = action.isPending
   // An orphaned sidecar has nothing re-runnable: Stop is the only action.
   const orphaned = !!app.sidecarOrphaned
+  // Fully stopped standalone instances (incl. Aspire ghosts) exist only as
+  // registry memories; offer dropping them from the list.
+  const removable = !isCompose && appStopped && daprdStopped
+  const forget = useAppForget(key)
+  const removeFromList = () => {
+    if (!window.confirm(`Remove "${app.appId}" from the list? The stopped instance will no longer be shown.`)) return
+    forget.mutate(undefined, {
+      onError: (e) => toast.show(e instanceof Error ? e.message : 'Remove failed'),
+      onSuccess: () => navigate('/'),
+    })
+  }
 
   // dapr run supervises app + daprd together; sidecar actions act on the
   // whole instance (see lifecycle manager funneling). Compose and Aspire
@@ -154,6 +165,11 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
                 Stop
               </button>
             </>
+          )}
+          {removable && (
+            <button className="btn ghost" disabled={busy || forget.isPending} onClick={removeFromList}>
+              Remove from list
+            </button>
           )}
           {allStopped && !app.isAspire && !orphaned && (
             <button

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -94,7 +94,10 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
           </button>
         </>
       )}
-      {status === 'stopped' && !app.isAspire && !orphaned && (
+      {/* Per-panel Start is hidden for fully-stopped dapr run apps: a bare
+          half-restart is not discoverable — the header's whole-instance Start
+          is the affordance. Compose keeps per-container starts. */}
+      {status === 'stopped' && !app.isAspire && !orphaned && (isCompose || !allStopped) && (
         <button className="btn ghost" disabled={busy} onClick={() => runAction(target, 'start', what)}>
           Start
         </button>


### PR DESCRIPTION
## Summary

Closes the remaining dead-ends found while auditing lifecycle-action flows (follow-up to #55/#56):

1. **App-only stop is now fully recoverable.** Stopping just the app usually cascades through the dapr CLI to daprd; the stop now snapshots all three commands (still signalling only the app), so the header's whole-instance Start re-runs the original `dapr run`. Per-panel Start is hidden for fully-stopped dapr run apps — a bare half-restart is undiscoverable; the whole-instance Start is the affordance. Compose keeps per-container starts.
2. **No more "App not found" flash after Start.** The registry entry now survives the start; the overlay's live reconciliation removes it once discovery sees the instance again. Bonus: a re-run command that exits immediately no longer erases the instance — the stopped row stays with Start available. (Known trade-off: for the ~1–2 s until discovery catches up, an impatient second Start is possible; a duplicate `dapr run` would fail on port conflict.)
3. **"Remove from list"** for leftover ghosts: new `DELETE /api/apps/{key}` → `Manager.Forget` drops the registry entry (404 when none). The detail page of a fully stopped standalone instance — including stopped Aspire ghosts, which can never be restarted from the dashboard — offers Remove from list, then returns to the overview. Previously these lingered until a dashboard restart.
4. **Back link on the detail 404** ("← Back to applications"), softening every dead-app path: bookmarks, dashboard restarts, races.

**Review finding fixed pre-PR:** the overlay's eager drop of daprd/CLI snapshots on any live poll would have erased fix 1's cascade insurance within one refetch (the post-mutation poll races the CLI teardown). Snapshots are now dropped only when their process reappears under a **new** PID — same cleanup after real restarts, no erasure while a snapshot still describes the live process.

## Test plan

- [x] `make build` (tsc -b + vite + go build)
- [x] `go test -tags unit ./...` / `go test -tags integration ./...` — clean
- [x] `cd web && npx vitest run` — 684/684 across 82 files
- [x] New coverage: app-stop snapshot set, start-keeps-entry (3 flipped assertions), Forget happy/404/AppID-fallback, DELETE route mapping incl. nil manager, insurance-snapshots-survive vs dropped-on-new-PID overlay tests, Remove-from-list flow + visibility, single-Start-when-fully-stopped, 404 back link

🤖 Generated with [Claude Code](https://claude.com/claude-code)