### PR TITLE
Catalyst-aligned brand styling & button hierarchy

### DIFF
--- a/web/STYLEGUIDE.md
+++ b/web/STYLEGUIDE.md
@@ -111,9 +111,9 @@ All tokens are CSS custom properties. Reference them with `var(--name)`.
 | Token | Use |
 |---|---|
 | `--primary` `#0BDDA3` | Brand mint (theme-independent) |
-| `--accent2` | Theme-aware accent: focus rings, primary buttons, selection tints |
-| `--accent-bright` / `--ok-bright` | Brighter mint for LEDs, "beat" pulse, checkboxes |
+| `--accent-bright` / `--ok-bright` | Brighter mint (theme-independent) — the single interactive accent: `.btn.primary`, focus rings, selection tints, active nav tab, LEDs, "beat" pulse, checkboxes |
 | `--dapr` | Dapr-specific blue (sidecar badges, daprd log source) |
+| `--gold` / `--purple` | Catalyst-brand secondary accents — available for highlights / category chips (not yet used in default UI) |
 
 ### Status palette (paired bg/fg)
 Each status has a background and foreground token, used together:
@@ -135,8 +135,8 @@ Syntax-highlight tokens also exist for YAML (`--yk/--ys/--yc`) and JSON
 | Token | Use |
 |---|---|
 | `--sbw` | Sidebar width (240px; 44px when `.collapsed` or ≤760px) |
-| `--mono` | Monospace stack |
-| `--sans` | Sans stack (default body font) |
+| `--mono` | Monospace stack (system: SF Mono / JetBrains Mono / Menlo…) |
+| `--sans` | Sans stack — **Public Sans** (bundled via `@fontsource-variable/public-sans`, imported in `main.tsx`), system-ui fallback |
 
 ### Implicit scales (radius & padding)
 
@@ -163,7 +163,7 @@ For selection/hover tints, follow the existing pattern with `color-mix` against 
 token rather than inventing a new color:
 
 ```css
-background: color-mix(in srgb, var(--accent2) 10%, var(--surface));
+background: color-mix(in srgb, var(--accent-bright) 10%, var(--surface));
 ```
 
 ---
@@ -288,8 +288,7 @@ component fails the suite until the doc is updated.
   `.compchips`, or a `<pre>`. Use `.ph .ic` for the little square glyph,
   `.ph .tagdot` for a colored dot, `.ph .copybtn` auto-right-aligns.
 - `.stats` / `.stat` — auto-fit grid of summary tiles. `.stat .n` (big number —
-  **mono** + tabular-nums by default; add `.mint` for accent), `.stat .l` (caption
-  label).
+  **mono** + tabular-nums by default), `.stat .l` (caption label).
 - `.metagrid` — dense 4-col key/value header grid (`.m` cell, `.m.span2` to span,
   `.k` label, `.v` value, `.v.mono`). Used on detail headers.
 - `.kv` — 2-col key/value list inside a panel (`.kk` key, `.vv` value, `.vv.mono`).
@@ -321,6 +320,9 @@ component fails the suite until the doc is updated.
 
 **Controls**
 - `.btn` + `.btn.primary` / `.btn.ghost` / `.btn.danger` — buttons.
+  `.primary` = solid green affirmative action; `.danger` = red outline for
+  destructive / disruptive actions (Stop / Remove / Force delete / Disconnect);
+  `.ghost` = neutral outline.
 - `.tbtn` — topbar/secondary button (used for Back / View logs).
 - `.copybtn` (+ `.ok` state) — small copy button; pairs with `copyText` + toast.
 - `.search` (wraps an `<input>`), `.select` — filter inputs.
@@ -386,9 +388,9 @@ flow should be assembled from these — not hand-rolled.
   (`.active` = current, `.done` = completed, mint) separated by `.step-arrow`
   `→` glyphs. Display-only; steps aren't clickable.
 - **`StepNav`** — the Back / Continue / Finish row (`.stepnav`; a `.spacer`
-  keeps the primary action right-aligned when Back is absent). All wizard
-  actions are `.btn.ghost`. Gate progression by passing `canContinue={false}`
-  — disable the button, don't hide it.
+  keeps the primary action right-aligned when Back is absent). The forward
+  action (Continue / Finish) is `.btn.primary`; Back is `.btn.ghost`. Gate
+  progression by passing `canContinue={false}` — disable the button, don't hide it.
 
 The matching CSS is the wizard section of `theme.css` (`.wizard`, `.stepper` /
 `.step`, `.wizard-body` — a min-height so the pane doesn't jump between steps —
@@ -458,7 +460,7 @@ copy/download buttons per builder.
 - **Wide content scrolls, the page doesn't.** Wrap wide tables in `.tablewrap`
   (`overflow-x: auto`). Never let the page body scroll horizontally.
 - **Focus rings are standard:** interactive elements use
-  `:focus-visible { outline: 2px solid var(--accent2); }`. Keep it — don't remove
+  `:focus-visible { outline: 2px solid var(--accent-bright); }`. Keep it — don't remove
   outlines.
 - **Reduced motion:** a global `@media (prefers-reduced-motion: reduce)` disables
   all animation/transition. Any new animation is automatically covered.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,6 +7,7 @@
       "name": "dev-dashboard-web",
       "dependencies": {
         "@datadog/browser-rum": "^7.5.0",
+        "@fontsource-variable/public-sans": "^5.2.7",
         "@tanstack/react-query": "^5.59.0",
         "js-yaml": "^5.2.0",
         "react": "^19",
@@ -631,6 +632,15 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@fontsource-variable/public-sans": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/public-sans/-/public-sans-5.2.7.tgz",
+      "integrity": "sha512-4mvade2J3slKkvwRkS+p8T3szet/0vhWoSnuUJTVU81Uo2pRpSZY/Y8bSLRqpSwzIPxjVmRJ53oq6JKP/l/PSg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@datadog/browser-rum": "^7.5.0",
+    "@fontsource-variable/public-sans": "^5.2.7",
     "@tanstack/react-query": "^5.59.0",
     "js-yaml": "^5.2.0",
     "react": "^19",

--- a/web/src/components/StateStoreConnectionDialog.tsx
+++ b/web/src/components/StateStoreConnectionDialog.tsx
@@ -163,7 +163,7 @@ export function StateStoreConnectionDialog({ open, onClose, onSaved }: Props) {
 
       <div className="modal-actions">
         <button className="btn ghost" onClick={onClose}>Cancel</button>
-        <button className="btn ghost" disabled={!canSave} onClick={handleSave}>Save connection</button>
+        <button className="btn primary" disabled={!canSave} onClick={handleSave}>Save connection</button>
       </div>
     </Modal>
   )

--- a/web/src/components/StateStoreConnectionsPanel.test.tsx
+++ b/web/src/components/StateStoreConnectionsPanel.test.tsx
@@ -30,10 +30,9 @@ describe('StateStoreConnectionsPanel', () => {
     expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /disconnect orders-pg/i })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /edit statestore/i })).not.toBeInTheDocument()
-    // Disconnect is non-destructive: ghost styling, not danger.
+    // Disconnect reuses the danger (outline) styling.
     const btn = screen.getByRole('button', { name: /disconnect orders-pg/i })
-    expect(btn.className).toContain('ghost')
-    expect(btn.className).not.toContain('danger')
+    expect(btn.className).toContain('danger')
     // Add button present.
     expect(screen.getByRole('button', { name: /add connection/i })).toBeInTheDocument()
   })

--- a/web/src/components/StateStoreConnectionsPanel.tsx
+++ b/web/src/components/StateStoreConnectionsPanel.tsx
@@ -44,7 +44,7 @@ export function StateStoreConnectionsPanel() {
     <div className="card" style={{ padding: '14px 16px', marginTop: 16 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
         <b style={{ fontSize: 13 }}>Recent workflow state store connections</b>
-        <button className="btn ghost" onClick={() => setAddOpen(true)}>+ Add connection</button>
+        <button className="btn primary" onClick={() => setAddOpen(true)}>+ Add connection</button>
       </div>
 
       {(stores ?? []).length === 0 && <p className="hint">No state store connections yet.</p>}
@@ -61,7 +61,7 @@ export function StateStoreConnectionsPanel() {
             </span>
             {!s.active && (
               <span style={{ display: 'flex', gap: 6 }}>
-                <button className="btn ghost" aria-label={`disconnect ${s.name}`} onClick={() => openDeleteConfirm(s)}>Disconnect</button>
+                <button className="btn danger" aria-label={`disconnect ${s.name}`} onClick={() => openDeleteConfirm(s)}>Disconnect</button>
               </span>
             )}
           </div>
@@ -100,7 +100,7 @@ export function StateStoreConnectionsPanel() {
         {deleteError && <p className="field-err">{deleteError}</p>}
         <div className="modal-actions">
           <button className="btn ghost" onClick={closeDeleteConfirm}>Cancel</button>
-          <button className="btn primary" onClick={handleConfirmDelete}>Disconnect</button>
+          <button className="btn danger" onClick={handleConfirmDelete}>Disconnect</button>
         </div>
       </Modal>
 

--- a/web/src/components/form/DialogShell.tsx
+++ b/web/src/components/form/DialogShell.tsx
@@ -9,7 +9,7 @@ export function DialogShell({ open, title, onClose, onSave, canSave, children }:
       {children}
       <div className="modal-actions">
         <button type="button" className="btn ghost" onClick={onClose}>Cancel</button>
-        <button type="button" className="btn ghost" disabled={!canSave} onClick={onSave}>Save</button>
+        <button type="button" className="btn primary" disabled={!canSave} onClick={onSave}>Save</button>
       </div>
     </Modal>
   )

--- a/web/src/components/wizard/StepNav.tsx
+++ b/web/src/components/wizard/StepNav.tsx
@@ -17,9 +17,9 @@ export function StepNav({ activeStep, stepCount, canContinue, onBack, onContinue
         <span className="spacer" />
       )}
       {isLast ? (
-        <button type="button" className="btn ghost" disabled={!canContinue} onClick={onFinish}>Finish</button>
+        <button type="button" className="btn primary" disabled={!canContinue} onClick={onFinish}>Finish</button>
       ) : (
-        <button type="button" className="btn ghost" disabled={!canContinue} onClick={onContinue}>Continue</button>
+        <button type="button" className="btn primary" disabled={!canContinue} onClick={onContinue}>Continue</button>
       )}
     </div>
   )

--- a/web/src/components/wizard/wizard.test.tsx
+++ b/web/src/components/wizard/wizard.test.tsx
@@ -32,11 +32,11 @@ describe('StepNav', () => {
     render(<StepNav activeStep={0} stepCount={2} canContinue={false} onBack={() => {}} onContinue={() => {}} onFinish={() => {}} />)
     expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled()
   })
-  it('primary button uses ghost styling, never the green .btn.primary', () => {
+  it('forward action uses the green .btn.primary styling', () => {
     render(<StepNav activeStep={0} stepCount={2} canContinue onBack={() => {}} onContinue={() => {}} onFinish={() => {}} />)
     const cont = screen.getByRole('button', { name: /continue/i })
-    expect(cont).toHaveClass('btn', 'ghost')
-    expect(cont).not.toHaveClass('primary')
+    expect(cont).toHaveClass('btn', 'primary')
+    expect(cont).not.toHaveClass('ghost')
     expect(cont).not.toHaveClass('mono')
   })
   it('fires onContinue / onFinish / onBack', () => {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
+import '@fontsource-variable/public-sans'
 import './styles/theme.css'
 import { applyPrefs } from './lib/prefs'
 import { router } from './router'

--- a/web/src/pages/Actors.tsx
+++ b/web/src/pages/Actors.tsx
@@ -69,7 +69,7 @@ export function Actors() {
       {header}
       <div className="stats">
         <div className="stat">
-          <div className="n mint">{activeActors}</div>
+          <div className="n">{activeActors}</div>
           <div className="l">Active actors</div>
         </div>
         <div className="stat">

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -208,7 +208,7 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
         {/* Application panel */}
         <div className="panel">
           <div className="ph" style={{ display: 'flex', alignItems: 'center' }}>
-            <span className="ic" style={{ background: 'var(--surface-2)', color: 'var(--accent2)' }}>A</span>
+            <span className="ic" style={{ background: 'var(--surface-2)', color: 'var(--accent-bright)' }}>A</span>
             Application
             {panelActions('app', app.appStatus, `application "${app.appId}"`)}
           </div>

--- a/web/src/pages/Applications.tsx
+++ b/web/src/pages/Applications.tsx
@@ -59,7 +59,7 @@ export function Applications() {
       {PAGE_HEADER}
       <div className="stats">
         <div className="stat">
-          <div className="n mint">{running}</div>
+          <div className="n">{running}</div>
           <div className="l">Apps running</div>
         </div>
         <div className="stat">

--- a/web/src/pages/Resiliency.tsx
+++ b/web/src/pages/Resiliency.tsx
@@ -10,7 +10,7 @@ export function Resiliency() {
           <h1>Resiliency</h1>
           <div className="sub">Dapr resiliency policies</div>
         </div>
-        <Link className="btn ghost" to="/resiliency/new">+ New resiliency policy</Link>
+        <Link className="btn primary" to="/resiliency/new">+ New resiliency policy</Link>
       </div>
       <div className="md">
         <div className="card complist" />

--- a/web/src/pages/ResourceList.tsx
+++ b/web/src/pages/ResourceList.tsx
@@ -62,7 +62,7 @@ export function ResourceList({ kind }: ResourceListProps) {
             <div className="sub">{sub}</div>
           </div>
           {kind === 'component' && (
-            <Link className="btn ghost" to="/components/new">+ New component</Link>
+            <Link className="btn primary" to="/components/new">+ New component</Link>
           )}
         </div>
         <p className="muted">Loading…</p>
@@ -81,7 +81,7 @@ export function ResourceList({ kind }: ResourceListProps) {
             <div className="sub">{sub}</div>
           </div>
           {kind === 'component' && (
-            <Link className="btn ghost" to="/components/new">+ New component</Link>
+            <Link className="btn primary" to="/components/new">+ New component</Link>
           )}
         </div>
         <div className="md">
@@ -109,7 +109,7 @@ export function ResourceList({ kind }: ResourceListProps) {
           <div className="sub">{sub}</div>
         </div>
         {kind === 'component' && (
-          <Link className="btn ghost" to="/components/new">+ New component</Link>
+          <Link className="btn primary" to="/components/new">+ New component</Link>
         )}
       </div>
       <div className="md">

--- a/web/src/pages/WorkflowDetail.tsx
+++ b/web/src/pages/WorkflowDetail.tsx
@@ -676,7 +676,7 @@ export function WorkflowDetail() {
         {/* Input */}
         <div className="panel">
           <div className="ph">
-            <span className="tagdot" style={{ background: 'var(--accent2)' }} />
+            <span className="tagdot" style={{ background: 'var(--accent-bright)' }} />
             {' '}Input{' '}
             <button
               className="copybtn"

--- a/web/src/pages/Workflows.tsx
+++ b/web/src/pages/Workflows.tsx
@@ -424,7 +424,7 @@ export function Workflows() {
             borderRadius: 8,
             border: '1px solid var(--line)',
             background: 'var(--surface)',
-            color: removeStatus.failed > 0 ? 'var(--fail-fg)' : 'var(--accent2)',
+            color: removeStatus.failed > 0 ? 'var(--fail-fg)' : 'var(--accent-bright)',
             fontSize: 13,
           }}
         >

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -6,14 +6,14 @@
 /* Font / layout tokens (shared, theme-independent) */
 :root {
   --mono: ui-monospace, "SF Mono", SFMono-Regular, "JetBrains Mono", Menlo, Consolas, monospace;
-  --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --sans: "Public Sans Variable", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --sbw: 240px; /* sidebar width; .collapsed → 44px */
   --primary: #0BDDA3;
 }
 
 html, body, #root { height: 100%; margin: 0; }
 body {
-  background: #F4F6F8; color: #212B36;
+  background: #F8FBFB; color: #212B36;
   font-family: var(--sans);
   -webkit-font-smoothing: antialiased;
 }
@@ -25,7 +25,7 @@ body {
 
 .app {
   --mono: ui-monospace, "SF Mono", SFMono-Regular, "JetBrains Mono", Menlo, Consolas, monospace;
-  --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --sans: "Public Sans Variable", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --primary: #0BDDA3;
   --accent-bright: #2FE3AD;
   --ok-bright: #5fdd86;
@@ -34,10 +34,12 @@ body {
 }
 
 .app[data-theme="dark"] {
-  --bg: #161C24; --surface: #1B232D; --surface-2: #212B36; --raise: #252f3a;
-  --line: #2A333D; --line-soft: #222b34;
-  --text: #F2F5F7; --muted: #94A1AD; --faint: #6B7682;
-  --link: #63B8F6; --dapr: #3EA9F5; --accent2: #2FE3AD;
+  /* Catalyst-aligned green-tinted dark surfaces */
+  --bg: #161918; --surface: #1C1F1E; --surface-2: #232625; --raise: #2B2E2D;
+  --line: #373A39; --line-soft: #262928;
+  --text: #F8F8F8; --muted: #A6A6A6; --faint: #6A6A6A;
+  --link: #63B8F6; --dapr: #3EA9F5;
+  --gold: #F0C75E; --purple: #AC4BFF;
   --run-bg: #0c3450; --run-fg: #7cc6ff; --done-bg: #0c3a1c; --done-fg: #5fdd86;
   --fail-bg: #421321; --fail-fg: #ff8198; --term-bg: #2a323b; --term-fg: #aab4be;
   --susp-bg: #2b1b46; --susp-fg: #c4a0ff; --pend-bg: #332f0a; --pend-fg: #d8d24a;
@@ -47,10 +49,11 @@ body {
 }
 
 .app[data-theme="light"] {
-  --bg: #F4F6F8; --surface: #FFFFFF; --surface-2: #F9FAFB; --raise: #FFFFFF;
+  --bg: color-mix(in srgb, var(--accent-bright) 3%, #FFFFFF); --surface: #FFFFFF; --surface-2: #F9FAFB; --raise: #FFFFFF;
   --line: #DFE3E8; --line-soft: #ECEFF2;
   --text: #212B36; --muted: #637381; --faint: #919EAB;
-  --link: #007AD3; --dapr: #0D2192; --accent2: #0A8A6E;
+  --link: #007AD3; --dapr: #0D2192;
+  --gold: #B8860B; --purple: #7A2FD0;
   --run-bg: #E4F4FE; --run-fg: #0a6ebd; --done-bg: #E3FBEA; --done-fg: #0a8a2c;
   --fail-bg: #FCE4EB; --fail-fg: #b30a45; --term-bg: #EEF1F4; --term-fg: #5c6770;
   --susp-bg: #F0E8FF; --susp-fg: #6b21d6; --pend-bg: #FBF8D6; --pend-fg: #6e6800;
@@ -74,7 +77,7 @@ body {
 .sbhead .lbl { font-family: var(--mono); font-size: 10px; letter-spacing: .14em; text-transform: uppercase; white-space: nowrap; }
 .sbtoggle { margin-left: auto; background: transparent; border: 1px solid var(--line); color: var(--muted); border-radius: 7px; width: 26px; height: 26px; cursor: pointer; flex: none; display: grid; place-items: center; font-size: 13px; }
 .sbtoggle:hover { color: var(--text); border-color: var(--faint); }
-.sbtoggle:focus-visible { outline: 2px solid var(--accent2); outline-offset: 2px; }
+.sbtoggle:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
 .app.collapsed .sbhead { justify-content: center; padding: 12px 0 6px; }
 .app.collapsed .sbhead .lbl { display: none; }
 /* Drop the auto margin when collapsed so the toggle centers (auto margin
@@ -89,7 +92,7 @@ body {
 .sbtitle.newstitle { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .sblink { display: flex; align-items: center; gap: 10px; padding: 7px 10px; border-radius: 7px; color: var(--text); text-decoration: none; font-size: 13px; line-height: 1.3; white-space: nowrap; }
 .sblink:hover { background: var(--surface-2); }
-.sblink:focus-visible { outline: 2px solid var(--accent2); outline-offset: -2px; }
+.sblink:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: -2px; }
 .sblink .ext { margin-left: auto; color: var(--faint); font-size: 11px; opacity: 0; }
 .sblink:hover .ext { opacity: 1; }
 .sblink .col { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
@@ -137,11 +140,11 @@ body {
 .nav { display: flex; gap: 2px; margin-left: 6px; flex-wrap: wrap; }
 .nav a { font-size: 13px; color: var(--muted); text-decoration: none; padding: 6px 10px; border-radius: 7px; font-weight: 500; cursor: pointer; }
 .nav a:hover { color: var(--text); }
-.nav a.active { color: var(--text); background: var(--surface-2); box-shadow: inset 0 0 0 1px var(--line); }
+.nav a.active { color: var(--text); background: color-mix(in srgb, var(--accent-bright) 10%, var(--surface)); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-bright) 35%, transparent); }
 .topright { margin-left: auto; display: flex; align-items: center; gap: 10px; }
 .tbtn { font: inherit; font-size: 12.5px; color: var(--muted); background: transparent; border: 1px solid var(--line); border-radius: 8px; padding: 6px 11px; cursor: pointer; display: flex; align-items: center; gap: 7px; }
 .tbtn:hover { color: var(--text); border-color: var(--faint); }
-.tbtn:focus-visible { outline: 2px solid var(--accent2); outline-offset: 2px; }
+.tbtn:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
 
 /* ---- Page frame ---- */
 .page { max-width: 1240px; margin: 0 auto; padding: clamp(16px, 3vw, 30px); }
@@ -200,19 +203,18 @@ table.t.click tbody tr:hover { background: var(--surface-2); }
 .typechip { font-family: var(--mono); font-size: 11px; padding: 2px 8px; border-radius: 6px; border: 1px solid var(--line); color: var(--muted); white-space: nowrap; }
 .appref { font-family: var(--mono); font-size: 11px; padding: 1px 7px; border-radius: 5px; border: 1px solid var(--line); color: var(--text); }
 .appref.link { cursor: pointer; }
-.appref.link:hover { border-color: var(--accent2); color: var(--link); }
+.appref.link:hover { border-color: var(--accent-bright); color: var(--link); }
 .kebab { color: var(--faint); font-weight: 700; letter-spacing: 1px; padding: 0 4px; }
 .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 12px; margin-bottom: 18px; }
 .stat { background: var(--surface); border: 1px solid var(--line); border-radius: 12px; padding: 13px 15px; box-shadow: var(--shadow); }
 .stat .n { font-family: var(--mono); font-size: 23px; font-weight: 700; font-variant-numeric: tabular-nums; letter-spacing: -.02em; }
 .stat .l { font-family: var(--mono); font-size: 10.5px; letter-spacing: .07em; text-transform: uppercase; color: var(--muted); margin-top: 3px; }
-.stat .n.mint { color: var(--accent2); }
 .stat .n.bad { color: var(--fail-fg); }
 .select { font: inherit; font-size: 12.5px; color: var(--text); background: var(--surface); border: 1px solid var(--line); border-radius: 9px; padding: 7px 30px 7px 11px; cursor: pointer; appearance: none; -webkit-appearance: none; -moz-appearance: none; background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%23888' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"); background-repeat: no-repeat; background-position: right 10px center; background-size: 10px; }
 .refresh-compact { display: inline-flex; align-items: center; gap: 7px; }
 .beatbtn { display: inline-flex; align-items: center; justify-content: center; padding: 5px; background: transparent; border: 1px solid var(--line); border-radius: 8px; cursor: pointer; }
 .beatbtn:hover { border-color: var(--faint); }
-.beatbtn:focus-visible { outline: 2px solid var(--accent2); outline-offset: 2px; }
+.beatbtn:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
 .beatbtn .beat { width: 8px; height: 8px; border-radius: 50%; background: var(--accent-bright); animation: beat 2.4s ease-out infinite; }
 .beatbtn.off .beat { background: var(--muted); animation: none; box-shadow: none; }
 .beatbtn.offline .beat { background: var(--fail-fg); animation: beat-offline 2.4s ease-out infinite; }
@@ -222,16 +224,16 @@ table.t.click tbody tr:hover { background: var(--surface-2); }
 .search { display: flex; align-items: center; gap: 8px; background: var(--surface); border: 1px solid var(--line); border-radius: 9px; padding: 7px 11px; color: var(--faint); font-size: 13px; min-width: 170px; flex: 1; }
 .search input { flex: 1; background: transparent; border: none; outline: none; color: var(--text); font: inherit; font-size: 13px; }
 .childtoggle { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: var(--text); cursor: pointer; }
-.btn { font: inherit; font-size: 12.5px; font-weight: 600; border-radius: 8px; padding: 7px 13px; cursor: pointer; border: 1px solid transparent; }
-.btn.primary { background: var(--accent2); color: #06231a; border-color: transparent; }
+.btn { font: inherit; font-size: 12.5px; font-weight: 600; border-radius: 8px; padding: 7px 13px; cursor: pointer; border: 1px solid transparent; text-decoration: none; }
+.btn.primary { background: var(--accent-bright); color: #06231a; border-color: transparent; }
 .btn.ghost { background: transparent; color: var(--text); border-color: var(--line); }
 .btn.ghost:disabled { color: var(--faint); border-color: var(--line-soft); cursor: default; }
 .btn.danger { background: transparent; color: var(--fail-fg); border-color: color-mix(in srgb, var(--fail-fg) 45%, transparent); }
-.btn:focus-visible { outline: 2px solid var(--accent2); outline-offset: 2px; }
+.btn:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
 .copybtn { font: inherit; font-family: var(--mono); font-size: 10.5px; color: var(--muted); background: var(--surface-2); border: 1px solid var(--line); border-radius: 6px; padding: 3px 8px; cursor: pointer; display: inline-flex; align-items: center; gap: 5px; }
 .copybtn:hover { color: var(--text); border-color: var(--faint); }
 .copybtn.ok { color: var(--done-fg); border-color: color-mix(in srgb, var(--done-fg) 45%, transparent); }
-.copybtn:focus-visible { outline: 2px solid var(--accent2); outline-offset: 2px; }
+.copybtn:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
 .toast { position: fixed; left: 50%; bottom: 26px; transform: translateX(-50%) translateY(8px); background: var(--surface-2); color: var(--text); border: 1px solid var(--line); box-shadow: var(--shadow); border-radius: 9px; padding: 9px 15px; font-size: 12.5px; font-weight: 500; display: flex; align-items: center; gap: 8px; opacity: 0; pointer-events: none; transition: opacity .18s ease, transform .18s ease; z-index: 50; }
 .toast .d { width: 8px; height: 8px; border-radius: 50%; background: var(--done-fg); }
 .toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
@@ -269,7 +271,7 @@ table.t.click tbody tr:hover { background: var(--surface-2); }
 .ci { display: flex; flex-direction: column; gap: 3px; padding: 11px 14px; border-bottom: 1px solid var(--line-soft); cursor: pointer; }
 .ci:last-child { border-bottom: none; }
 .ci:hover { background: var(--surface-2); }
-.ci.sel { background: color-mix(in srgb, var(--accent2) 10%, var(--surface)); box-shadow: inset 3px 0 0 var(--accent2); }
+.ci.sel { background: color-mix(in srgb, var(--accent-bright) 10%, var(--surface)); box-shadow: inset 3px 0 0 var(--accent-bright); }
 .ci .cn { font-weight: 600; font-size: 13.5px; }
 .ci .ct { font-family: var(--mono); font-size: 11px; color: var(--muted); }
 pre.code { margin: 0; padding: 14px; font-family: var(--mono); font-size: 12px; line-height: 1.65; overflow-x: auto; white-space: pre; }
@@ -298,11 +300,11 @@ pre.code { margin: 0; padding: 14px; font-family: var(--mono); font-size: 12px; 
 .lvl.error { color: var(--fail-fg); background: var(--fail-bg); }
 .lsrc { white-space: nowrap; font-size: 11px; }
 .lsrc.lsrc-daprd { color: var(--dapr); }
-.lsrc.lsrc-app { color: var(--accent2); font-weight: 600; }
+.lsrc.lsrc-app { color: var(--accent-bright); font-weight: 600; }
 .lsrc.lsrc-cp { color: var(--run-fg); }
 .lmsg { color: var(--text); white-space: pre-wrap; word-break: break-word; }
 .logrow.error .lmsg { color: var(--fail-fg); }
-.hl { background: color-mix(in srgb, var(--accent2) 30%, transparent); border-radius: 3px; padding: 0 1px; }
+.hl { background: color-mix(in srgb, var(--accent-bright) 30%, transparent); border-radius: 3px; padding: 0 1px; }
 .logfoot { display: flex; align-items: center; gap: 8px; padding: 9px 14px; border-top: 1px solid var(--line); color: var(--muted); font-family: var(--mono); font-size: 11px; }
 
 /* ---- Workflows (mock B) ---- */
@@ -330,8 +332,8 @@ table.wf tbody tr:last-child td { border-bottom: none; }
 .cbx { width: 14px; height: 14px; border: 1.5px solid var(--faint); border-radius: 4px; display: inline-block; vertical-align: middle; }
 .cbx.on { position: relative; }
 .cbx.on::after { content: ""; position: absolute; left: 4px; top: 1px; width: 3px; height: 7px; border: solid var(--text); border-width: 0 2px 2px 0; transform: rotate(45deg); }
-tr.sel { background: color-mix(in srgb, var(--accent2) 9%, var(--surface)); }
-tr.sel:hover { background: color-mix(in srgb, var(--accent2) 13%, var(--surface)); }
+tr.sel { background: color-mix(in srgb, var(--accent-bright) 9%, var(--surface)); }
+tr.sel:hover { background: color-mix(in srgb, var(--accent-bright) 13%, var(--surface)); }
 .selbar { display: flex; align-items: center; gap: 12px; padding: 10px 14px; background: var(--surface-2); border-bottom: 1px solid var(--line); font-size: 13px; }
 .selbar .cnt { font-weight: 600; }
 .selbar .grow { flex: 1; }
@@ -415,8 +417,8 @@ a.pairchip, span.pairchip {
   padding: 1px 6px; display: inline-flex; gap: 5px; align-items: center; white-space: nowrap;
 }
 a.pairchip { cursor: pointer; }
-a.pairchip:hover { color: var(--text); border-color: var(--accent2); }
-a.pairchip:focus-visible { outline: 2px solid var(--accent2); outline-offset: 2px; }
+a.pairchip:hover { color: var(--text); border-color: var(--accent-bright); }
+a.pairchip:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
 span.pairchip.pending { border-style: dashed; color: var(--faint); cursor: default; }
 .ev.pair-hover::after {
   content: "";
@@ -425,24 +427,23 @@ span.pairchip.pending { border-style: dashed; color: var(--faint); cursor: defau
   right: -8px;
   top: 4px;
   bottom: -6px;
-  background: color-mix(in srgb, var(--accent2) 10%, transparent);
+  background: color-mix(in srgb, var(--accent-bright) 10%, transparent);
   border-radius: 10px;
   z-index: -1;
   pointer-events: none;
 }
-/* Selected pair: a clear accent ring + tint drawn directly on the card of BOTH
+/* Selected pair: an accent border + tint drawn directly on the card of BOTH
    related rows (the clicked/active row and its partner). Painted on the visible
    card rather than a behind-the-row overlay so the highlight is unmistakable. */
 .ev.pair-selected .evd {
-  border-color: var(--accent2);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent2) 45%, transparent);
-  background: color-mix(in srgb, var(--accent2) 12%, var(--surface));
+  border-color: var(--accent-bright);
+  background: color-mix(in srgb, var(--accent-bright) 12%, var(--surface));
 }
 .evd.evstatic.selectable { cursor: pointer; }
 .evanchor { grid-column: 5; font-family: var(--mono); font-size: 12px; line-height: 1; color: var(--muted); background: transparent; border: 1px solid transparent; border-radius: 6px; padding: 2px 6px; cursor: pointer; opacity: 0; transition: opacity .12s ease, color .12s ease, border-color .12s ease; }
 .ev:hover .evanchor, .evanchor:focus-visible { opacity: 1; }
 .evanchor:hover { color: var(--text); border-color: var(--line); }
-.evanchor:focus-visible { outline: 2px solid var(--accent2); outline-offset: 2px; }
+.evanchor:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
 .evd.evstatic { cursor: default; border: 1px solid var(--line); border-radius: 10px; background: var(--surface); overflow: hidden; }
 .caret { color: var(--faint); transition: transform .15s ease; }
 details[open] .caret { transform: rotate(90deg); }
@@ -473,7 +474,7 @@ pre.stacktrace { white-space: pre-wrap; overflow-wrap: anywhere; }
 @keyframes fadein { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
 .ev.target-pulse { animation: targetpulse 1.5s ease; }
 @keyframes targetpulse {
-  0% { background: color-mix(in srgb, var(--accent2) 22%, transparent); }
+  0% { background: color-mix(in srgb, var(--accent-bright) 22%, transparent); }
   100% { background: transparent; }
 }
 
@@ -490,7 +491,7 @@ pre.stacktrace { white-space: pre-wrap; overflow-wrap: anywhere; }
 .field > label { font-size: 12px; color: var(--muted); }
 .field .req { color: var(--fail-fg); }
 .inp { font: inherit; font-size: 12.5px; color: var(--text); background: var(--surface); border: 1px solid var(--line); border-radius: 9px; padding: 7px 11px; width: 100%; }
-.inp:focus-visible { outline: 2px solid var(--accent2); outline-offset: 1px; }
+.inp:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: 1px; }
 .field-err { color: var(--fail-fg); font-size: 11px; margin-top: 2px; }
 .field-row { display: flex; align-items: center; gap: 8px; }
 .section-label { font-size: 11px; letter-spacing: .04em; text-transform: uppercase; color: var(--muted); border-top: 1px solid var(--line-soft); padding-top: 10px; margin: 6px 0 8px; }
@@ -501,7 +502,7 @@ pre.stacktrace { white-space: pre-wrap; overflow-wrap: anywhere; }
 .stepper { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; padding-bottom: 14px; border-bottom: 1px solid var(--line-soft); }
 .stepper .step { font-family: var(--mono); font-size: 11px; letter-spacing: .06em; text-transform: uppercase; color: var(--muted); border: 1px solid var(--line); border-radius: 999px; padding: 4px 11px; }
 .stepper .step.active { color: var(--text); border-color: var(--faint); background: var(--surface-2); }
-.stepper .step.done { color: var(--accent2); }
+.stepper .step.done { color: var(--accent-bright); }
 .stepper .step-arrow { font-family: var(--mono); font-size: 12px; line-height: 1; color: var(--faint); user-select: none; }
 .wizard-body { min-height: 120px; }
 .stepnav { display: flex; justify-content: space-between; gap: 10px; }


### PR DESCRIPTION
Aligns the dashboard's typography and accent colors with the **Catalyst** product identity, and establishes a clear primary-action hierarchy across flows. All changes are theme-aware (light + dark).

## Brand
- **Public Sans** as the sans typeface, self-hosted via `@fontsource-variable/public-sans` (bundled woff2 — no CDN, works offline). Mono stack unchanged.
- **Green-tinted dark surfaces** matching Catalyst's warm neutral base (`#161918` / `#1C1F1E` / `#232625`, border `#373A39`).
- Added **`--gold` / `--purple`** Catalyst secondary-accent tokens (available for future use; not yet wired into default UI).

## Accent consolidation
- Collapsed the theme-aware `--accent2` into the theme-independent **`--accent-bright`** (`#2FE3AD`) everywhere — including `color-mix`-derived tints, focus rings, selection highlights, and the active nav tab — and removed the now-unused `--accent2` token. Dark theme is visually unchanged; light theme's accent shifts from the deep `#0A8A6E` to bright mint.

## Buttons
- **`.btn.primary`** now uses `--accent-bright` so it reads on light backgrounds too.
- Promoted affirmative actions to `.btn.primary`: **Save** (shared `DialogShell`, so all builder dialogs inherit it), **Save connection**, wizard **Continue/Finish**, and the **New component / New resiliency policy / Add connection** CTAs.
- **Active nav tab** now uses the same green as the selected component-list row.
- **Disconnect** (trigger + confirm) uses the existing `.btn.danger` outline style.
- Stripped the default underline from button-styled `<Link>` anchors.

## Misc polish
- Light-theme app background is a subtle **3% `--accent-bright` tint** over white.
- Dropped the `.mint` accent on stat numbers (Applications, Actors) — now default text color.
- Removed the box-shadow ring on selected workflow **event-history** rows (accent border + tint retained).

## Docs / tests
- `STYLEGUIDE.md`: token tables, font entry, and button-variant semantics updated.
- Re-pinned the wizard and state-store panel tests to the new styling.

## Verification
- `npm run build` (tsc + vite) clean.
- Full suite: **684/684 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)