### PR TITLE
feat: Aspire container mode — env-contract discovery + GHCR image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.claude
+.superpowers
+bin
+docs
+node_modules
+web/node_modules
+web/dist
+test
+*.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,3 +21,9 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: '24' }
       - run: cd web && npm install && npm run lint && npm run build && npm test
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build container image (no push)
+        run: docker build -t dev-dashboard:ci .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
     tags: ['v*']
 permissions:
   contents: write
+  packages: write
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -17,6 +18,16 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -59,6 +59,9 @@ docker_manifests:
       - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-amd64"
       - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-arm64"
   - name_template: "ghcr.io/diagridio/dev-dashboard:latest"
+    # Prerelease tags (v1.5.0-rc.1) must not move :latest — consumers
+    # (README example, Aspire hosting integration) resolve it by default.
+    skip_push: auto
     image_templates:
       - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-amd64"
       - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-arm64"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,6 +31,38 @@ archives:
         formats: [zip]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
+dockers:
+  - id: linux-amd64
+    ids: [dev-dashboard]
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    image_templates:
+      - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - id: linux-arm64
+    ids: [dev-dashboard]
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    image_templates:
+      - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-arm64"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "ghcr.io/diagridio/dev-dashboard:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-amd64"
+      - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/diagridio/dev-dashboard:latest"
+    image_templates:
+      - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-amd64"
+      - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-arm64"
+
 checksum:
   name_template: "checksums.txt"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:22-alpine AS web
+FROM node:24-alpine AS web
 WORKDIR /src/web
 COPY web/package.json web/package-lock.json ./
 RUN npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+
+FROM node:22-alpine AS web
+WORKDIR /src/web
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+COPY web/ ./
+RUN npm run build
+
+FROM golang:1.26-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+COPY --from=web /src/web/dist ./web/dist
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG DATE=unknown
+RUN CGO_ENABLED=0 go build \
+    -ldflags "-s -w \
+    -X github.com/diagridio/dev-dashboard/pkg/version.Version=${VERSION} \
+    -X github.com/diagridio/dev-dashboard/pkg/version.Commit=${COMMIT} \
+    -X github.com/diagridio/dev-dashboard/pkg/version.Date=${DATE}" \
+    -o /out/dev-dashboard .
+
+FROM gcr.io/distroless/static:nonroot
+COPY --from=build /out/dev-dashboard /dev-dashboard
+ENV DEVDASHBOARD_MODE=aspire
+EXPOSE 8080
+ENTRYPOINT ["/dev-dashboard"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,5 @@
+FROM gcr.io/distroless/static:nonroot
+COPY dev-dashboard /dev-dashboard
+ENV DEVDASHBOARD_MODE=aspire
+EXPOSE 8080
+ENTRYPOINT ["/dev-dashboard"]

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ docker run --rm -p 8080:8080 \
 | `DEVDASHBOARD_APP_<i>_ID` | yes | Dapr app-id |
 | `DEVDASHBOARD_APP_<i>_DAPR_HTTP` | yes | daprd HTTP base URL, reachable **from the dashboard container** (e.g. `http://myapp-dapr:3500`) |
 | `DEVDASHBOARD_APP_<i>_NAMESPACE` | no | per-app Dapr namespace; defaults to `DEVDASHBOARD_NAMESPACE`. Used for **app-scoped** workflow operations — fetching one instance's history, an app-filtered workflow list/stats, and force delete — so those honor the app's own namespace. The store-wide workflow list, stats, and app-id dropdown (all-apps scans) still use the global `DEVDASHBOARD_NAMESPACE` |
-| `DEVDASHBOARD_APP_<i>_LABEL` | no | display name; defaults to the app-id. Accepted and exposed in the API; currently informational — UI display of labels is planned |
+| `DEVDASHBOARD_APP_<i>_LABEL` | no | display name; defaults to the app-id. Shown in the applications list and app detail header whenever it differs from the app-id |
 
 Validation is fail-fast at startup: a missing or non-numeric `DEVDASHBOARD_APP_COUNT`, any
 missing required per-app var, or an unparsable `DAPR_HTTP` URL exits with an error naming the

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ dev-dashboard --version
 The dashboard also ships as a container image, purpose-built for embedding inside a
 [.NET Aspire](https://learn.microsoft.com/dotnet/aspire/) AppHost via the
 [`diagrid-labs/dashboard-aspire`](https://github.com/diagrid-labs/dashboard-aspire) hosting
-integration (currently being rewritten against the contract below). It also runs standalone
+integration (which will be rewritten against the contract below). It also runs standalone
 with a hand-written `docker run`.
 
-**Image:** `ghcr.io/diagridio/dev-dashboard`, tagged `:vX.Y.Z` (in lockstep with binary
+**Image:** `ghcr.io/diagridio/dev-dashboard`, tagged `:X.Y.Z` (in lockstep with binary
 releases) and `:latest`. The image bakes in `DEVDASHBOARD_MODE=aspire` and serves on port
 `8080` bound to `0.0.0.0`.
 

--- a/README.md
+++ b/README.md
@@ -102,12 +102,16 @@ docker run --rm -p 8080:8080 \
 | `DEVDASHBOARD_APP_COUNT` | yes | number of apps (`0` is valid: empty dashboard) |
 | `DEVDASHBOARD_APP_<i>_ID` | yes | Dapr app-id |
 | `DEVDASHBOARD_APP_<i>_DAPR_HTTP` | yes | daprd HTTP base URL, reachable **from the dashboard container** (e.g. `http://myapp-dapr:3500`) |
-| `DEVDASHBOARD_APP_<i>_NAMESPACE` | no | per-app Dapr namespace; defaults to `DEVDASHBOARD_NAMESPACE` |
-| `DEVDASHBOARD_APP_<i>_LABEL` | no | display name; defaults to the app-id |
+| `DEVDASHBOARD_APP_<i>_NAMESPACE` | no | per-app Dapr namespace; defaults to `DEVDASHBOARD_NAMESPACE`. Accepted and exposed in the API; currently informational — workflow queries use the global `DEVDASHBOARD_NAMESPACE`, not the per-app value |
+| `DEVDASHBOARD_APP_<i>_LABEL` | no | display name; defaults to the app-id. Accepted and exposed in the API; currently informational — UI display of labels is planned |
 
 Validation is fail-fast at startup: a missing or non-numeric `DEVDASHBOARD_APP_COUNT`, any
 missing required per-app var, or an unparsable `DAPR_HTTP` URL exits with an error naming the
 exact variable.
+
+**Security note:** in aspire mode the dashboard accepts any `Host` header (same-origin CSRF
+protection on mutating requests still applies). This is intended for local development behind
+Aspire's proxy — do not publish the container's port beyond the developer's own machine/network.
 
 **Serving and features:**
 
@@ -424,7 +428,8 @@ single commit with `git commit --no-verify`.
 > [`release` GitHub Actions workflow](.github/workflows/release.yaml): pushing a `vX.Y.Z` tag
 > runs [GoReleaser](https://goreleaser.com), which compiles the cross-platform archives plus
 > `checksums.txt` and publishes them to a GitHub Release. The version (`dev-dashboard --version`)
-> is injected from the tag via build-time ldflags.
+> is injected from the tag via build-time ldflags. The same tag-driven run also builds and
+> pushes the multi-arch container image to `ghcr.io/diagridio/dev-dashboard` via goreleaser.
 
 Because `go install` cannot run `npm`, the release tag commit must embed the prebuilt
 `web/dist`. `scripts/release.sh` handles this: it builds the SPA, creates a **detached** commit

--- a/README.md
+++ b/README.md
@@ -62,6 +62,66 @@ Download the archive for your platform from the [GitHub Releases](https://github
 dev-dashboard --version
 ```
 
+## Run as a container (.NET Aspire)
+
+The dashboard also ships as a container image, purpose-built for embedding inside a
+[.NET Aspire](https://learn.microsoft.com/dotnet/aspire/) AppHost via the
+[`diagrid-labs/dashboard-aspire`](https://github.com/diagrid-labs/dashboard-aspire) hosting
+integration (currently being rewritten against the contract below). It also runs standalone
+with a hand-written `docker run`.
+
+**Image:** `ghcr.io/diagridio/dev-dashboard`, tagged `:vX.Y.Z` (in lockstep with binary
+releases) and `:latest`. The image bakes in `DEVDASHBOARD_MODE=aspire` and serves on port
+`8080` bound to `0.0.0.0`.
+
+In aspire mode, discovery is restricted to the env contract below (no host process scan, no
+Docker Compose scan), and the following are disabled: app lifecycle controls
+(start/stop/restart), the control-plane page, log tailing, self-update/update-check, and
+automatic browser opening.
+
+**Try it:**
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e DEVDASHBOARD_APP_COUNT=1 \
+  -e DEVDASHBOARD_APP_0_ID=myapp \
+  -e DEVDASHBOARD_APP_0_DAPR_HTTP=http://host.docker.internal:3500 \
+  ghcr.io/diagridio/dev-dashboard:latest
+```
+
+**Mode switch:**
+
+| Source | Values | Default |
+|---|---|---|
+| `--mode` flag / `DEVDASHBOARD_MODE` env | `aspire` (reserved for future work: `dapr`, `compose`) | unset |
+
+**App discovery** — one set of `_<i>_*` vars per app, for `i = 0..DEVDASHBOARD_APP_COUNT-1`:
+
+| Env var | Required | Meaning |
+|---|---|---|
+| `DEVDASHBOARD_APP_COUNT` | yes | number of apps (`0` is valid: empty dashboard) |
+| `DEVDASHBOARD_APP_<i>_ID` | yes | Dapr app-id |
+| `DEVDASHBOARD_APP_<i>_DAPR_HTTP` | yes | daprd HTTP base URL, reachable **from the dashboard container** (e.g. `http://myapp-dapr:3500`) |
+| `DEVDASHBOARD_APP_<i>_NAMESPACE` | no | per-app Dapr namespace; defaults to `DEVDASHBOARD_NAMESPACE` |
+| `DEVDASHBOARD_APP_<i>_LABEL` | no | display name; defaults to the app-id |
+
+Validation is fail-fast at startup: a missing or non-numeric `DEVDASHBOARD_APP_COUNT`, any
+missing required per-app var, or an unparsable `DAPR_HTTP` URL exits with an error naming the
+exact variable.
+
+**Serving and features:**
+
+| Env var / flag | Default (aspire) | Meaning |
+|---|---|---|
+| `DEVDASHBOARD_PORT` / `--port` | `8080` | listen port |
+| `DEVDASHBOARD_BIND` / `--bind` | `0.0.0.0` | bind address |
+| `DEVDASHBOARD_STATESTORE_FILE` / `--statestore` | unset | path to a mounted Dapr state-store component YAML; enables the Workflows page |
+| `DEVDASHBOARD_NAMESPACE` / `--namespace` | `default` | default Dapr namespace for workflow actor keys |
+| `DEVDASHBOARD_RESOURCES_PATH` | dir of `DEVDASHBOARD_STATESTORE_FILE` | extra component directories for the Resources page, `os.PathListSeparator`-separated |
+| `DEVDASHBOARD_MODE` | `aspire` (baked into the image) | see mode switch above |
+
+Precedence everywhere is **flag > env > mode default**.
+
 ## Run the dashboard
 
 ```sh
@@ -82,6 +142,13 @@ dev-dashboard --verbose
 No additional setup is needed: the dashboard discovers running Dapr apps the same way
 `dapr list` does, so anything started with `dapr run` / `dapr run -f`, Aspire and Docker compose shows up within one
 refresh cycle.
+
+With `--mode`/`DEVDASHBOARD_MODE` unset (the default for host use), the dashboard performs the
+complete scan across all discovery sources described above. `--mode=aspire` restricts
+discovery to the container env contract and switches to container serving posture — see
+[Run as a container](#run-as-a-container-net-aspire) above. `dapr` and `compose` are reserved
+mode values for future single-source filtering and are not implemented yet. `--bind` (default
+`127.0.0.1`, `0.0.0.0` in aspire mode) controls the listen address alongside `--port`.
 
 ## Updating the dashboard
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ integration (which will be rewritten against the contract below). It also runs s
 with a hand-written `docker run`.
 
 **Image:** `ghcr.io/diagridio/dev-dashboard`, tagged `:X.Y.Z` (in lockstep with binary
-releases) and `:latest`. The image bakes in `DEVDASHBOARD_MODE=aspire` and serves on port
+releases) and `:latest`. Prerelease tags (e.g. `v1.5.0-rc.1`) publish their own version tag
+but do not move `:latest`. The image bakes in `DEVDASHBOARD_MODE=aspire` and serves on port
 `8080` bound to `0.0.0.0`.
 
 In aspire mode, discovery is restricted to the env contract below (no host process scan, no
@@ -435,6 +436,8 @@ single commit with `git commit --no-verify`.
 > `checksums.txt` and publishes them to a GitHub Release. The version (`dev-dashboard --version`)
 > is injected from the tag via build-time ldflags. The same tag-driven run also builds and
 > pushes the multi-arch container image to `ghcr.io/diagridio/dev-dashboard` via goreleaser.
+> Prerelease tags (any `-suffix`, e.g. `v1.5.0-rc.1`) push their version-tagged image but
+> skip the `:latest` manifest, so release candidates never reach `:latest` consumers.
 
 Because `go install` cannot run `npm`, the release tag commit must embed the prebuilt
 `web/dist`. `scripts/release.sh` handles this: it builds the SPA, creates a **detached** commit

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ docker run --rm -p 8080:8080 \
 | `DEVDASHBOARD_APP_COUNT` | yes | number of apps (`0` is valid: empty dashboard) |
 | `DEVDASHBOARD_APP_<i>_ID` | yes | Dapr app-id |
 | `DEVDASHBOARD_APP_<i>_DAPR_HTTP` | yes | daprd HTTP base URL, reachable **from the dashboard container** (e.g. `http://myapp-dapr:3500`) |
-| `DEVDASHBOARD_APP_<i>_NAMESPACE` | no | per-app Dapr namespace; defaults to `DEVDASHBOARD_NAMESPACE`. Accepted and exposed in the API; currently informational — workflow queries use the global `DEVDASHBOARD_NAMESPACE`, not the per-app value |
+| `DEVDASHBOARD_APP_<i>_NAMESPACE` | no | per-app Dapr namespace; defaults to `DEVDASHBOARD_NAMESPACE`. Used for **app-scoped** workflow operations — fetching one instance's history, an app-filtered workflow list/stats, and force delete — so those honor the app's own namespace. The store-wide workflow list, stats, and app-id dropdown (all-apps scans) still use the global `DEVDASHBOARD_NAMESPACE` |
 | `DEVDASHBOARD_APP_<i>_LABEL` | no | display name; defaults to the app-id. Accepted and exposed in the API; currently informational — UI display of labels is planned |
 
 Validation is fail-fast at startup: a missing or non-numeric `DEVDASHBOARD_APP_COUNT`, any

--- a/README.md
+++ b/README.md
@@ -109,9 +109,13 @@ Validation is fail-fast at startup: a missing or non-numeric `DEVDASHBOARD_APP_C
 missing required per-app var, or an unparsable `DAPR_HTTP` URL exits with an error naming the
 exact variable.
 
-**Security note:** in aspire mode the dashboard accepts any `Host` header (same-origin CSRF
-protection on mutating requests still applies). This is intended for local development behind
-Aspire's proxy — do not publish the container's port beyond the developer's own machine/network.
+**Security note:** in aspire mode the dashboard drops the loopback `Host` check (the container
+is addressed by its Docker-network name or a published port). Without `DEVDASHBOARD_ALLOWED_HOSTS`
+it accepts any `Host`, which means a malicious web page using DNS rebinding can reach the API even
+when the port is published only to `localhost`. Setting `DEVDASHBOARD_ALLOWED_HOSTS` to the
+hostnames the dashboard is served under closes that hole (loopback names are always allowed).
+Mutating requests are still protected by a normalized same-origin check. The dashboard is a local
+development tool — never expose it publicly.
 
 **Serving and features:**
 
@@ -122,6 +126,7 @@ Aspire's proxy — do not publish the container's port beyond the developer's ow
 | `DEVDASHBOARD_STATESTORE_FILE` / `--statestore` | unset | path to a mounted Dapr state-store component YAML; enables the Workflows page |
 | `DEVDASHBOARD_NAMESPACE` / `--namespace` | `default` | default Dapr namespace for workflow actor keys |
 | `DEVDASHBOARD_RESOURCES_PATH` | dir of `DEVDASHBOARD_STATESTORE_FILE` | extra component directories for the Resources page, `os.PathListSeparator`-separated |
+| `DEVDASHBOARD_ALLOWED_HOSTS` | unset (any host) | optional, aspire mode only; comma-separated hostnames the `Host` header is restricted to (loopback always allowed). Empty means any host. Set it to close the DNS-rebinding hole described above |
 | `DEVDASHBOARD_MODE` | `aspire` (baked into the image) | see mode switch above |
 
 Precedence everywhere is **flag > env > mode default**.

--- a/cmd/compose_discovery_integration_test.go
+++ b/cmd/compose_discovery_integration_test.go
@@ -130,7 +130,7 @@ spec:
 
 	pool := newConnPool("default", nil, apps, nil)
 	registry := LoadRegistry(t.TempDir())
-	rc := newReconciler(context.Background(), apps, "default", "", "", nil, registry, pool, src.Env)
+	rc := newReconciler(context.Background(), apps, "default", "", "", nil, registry, pool, src.Env, nil)
 	defer rc.Close()
 
 	got, err := apps.List(context.Background())

--- a/cmd/compose_discovery_integration_test.go
+++ b/cmd/compose_discovery_integration_test.go
@@ -128,7 +128,7 @@ spec:
 	})
 	apps := discovery.New(src.Scanner(), httpClientNoDial()) // enrichment fails fast; scan data suffices
 
-	pool := newConnPool("default", nil, apps, nil)
+	pool := newConnPool("default", nil, apps, nil, nil)
 	registry := LoadRegistry(t.TempDir())
 	rc := newReconciler(context.Background(), apps, "default", "", "", nil, registry, pool, src.Env, nil)
 	defer rc.Close()

--- a/cmd/connpool.go
+++ b/cmd/connpool.go
@@ -28,6 +28,10 @@ type connPool struct {
 	client    *http.Client
 	apps      discovery.Service
 	open      storeOpener
+	// appNS is the static appID→namespace map from the aspire env contract
+	// (nil in host mode); passed through to each built store entry so workflow
+	// reads resolve per-app namespaces without discovery probes.
+	appNS map[string]string
 
 	mu     sync.Mutex
 	slots  map[string]*poolSlot
@@ -35,7 +39,7 @@ type connPool struct {
 }
 
 // newConnPool builds a connPool. open == nil defaults to statestore.New.
-func newConnPool(namespace string, client *http.Client, apps discovery.Service, open storeOpener) *connPool {
+func newConnPool(namespace string, client *http.Client, apps discovery.Service, open storeOpener, appNS map[string]string) *connPool {
 	if open == nil {
 		open = statestore.New
 	}
@@ -44,6 +48,7 @@ func newConnPool(namespace string, client *http.Client, apps discovery.Service, 
 		client:    client,
 		apps:      apps,
 		open:      open,
+		appNS:     appNS,
 		slots:     make(map[string]*poolSlot),
 	}
 }
@@ -101,7 +106,7 @@ func (p *connPool) openOrGet(ctx context.Context, c statestore.Component) (store
 	}
 
 	slot.store = st
-	slot.entry = buildStoreEntry(st, p.namespace, p.client, p.apps)
+	slot.entry = buildStoreEntry(st, p.namespace, p.client, p.apps, p.appNS)
 	close(slot.done)
 	return slot.entry, nil
 }

--- a/cmd/connpool_test.go
+++ b/cmd/connpool_test.go
@@ -58,7 +58,7 @@ func compB() statestore.Component {
 
 func TestConnPool_OpensOnceAndCaches(t *testing.T) {
 	o := &poolOpener{}
-	p := newConnPool("default", &http.Client{}, nil, o.open)
+	p := newConnPool("default", &http.Client{}, nil, o.open, nil)
 
 	e1, err := p.openOrGet(context.Background(), compA())
 	require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestConnPool_OpensOnceAndCaches(t *testing.T) {
 
 func TestConnPool_OpenError_NotCached(t *testing.T) {
 	o := &poolOpener{err: errors.New("connect failed")}
-	p := newConnPool("default", &http.Client{}, nil, o.open)
+	p := newConnPool("default", &http.Client{}, nil, o.open, nil)
 
 	_, err := p.openOrGet(context.Background(), compA())
 	require.Error(t, err)
@@ -84,7 +84,7 @@ func TestConnPool_OpenError_NotCached(t *testing.T) {
 
 func TestConnPool_SingleFlight(t *testing.T) {
 	o := &poolOpener{block: make(chan struct{})}
-	p := newConnPool("default", &http.Client{}, nil, o.open)
+	p := newConnPool("default", &http.Client{}, nil, o.open, nil)
 
 	const n = 8
 	var wg sync.WaitGroup
@@ -106,7 +106,7 @@ func TestConnPool_SingleFlight(t *testing.T) {
 
 func TestConnPool_CloseClosesAll(t *testing.T) {
 	o := &poolOpener{}
-	p := newConnPool("default", &http.Client{}, nil, o.open)
+	p := newConnPool("default", &http.Client{}, nil, o.open, nil)
 
 	_, err := p.openOrGet(context.Background(), compA())
 	require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestConnPool_CloseClosesAll(t *testing.T) {
 
 func TestConnPool_TwoIdentitiesBothRetained(t *testing.T) {
 	o := &poolOpener{}
-	p := newConnPool("default", &http.Client{}, nil, o.open)
+	p := newConnPool("default", &http.Client{}, nil, o.open, nil)
 
 	_, err := p.openOrGet(context.Background(), compA())
 	require.NoError(t, err)
@@ -137,7 +137,7 @@ func TestConnPool_TwoIdentitiesBothRetained(t *testing.T) {
 func TestConnPool_EvictDuringOpenClosesStore(t *testing.T) {
 	block := make(chan struct{})
 	o := &poolOpener{block: block}
-	p := newConnPool("default", &http.Client{}, nil, o.open)
+	p := newConnPool("default", &http.Client{}, nil, o.open, nil)
 
 	comp := compA()
 	var openErr error
@@ -188,7 +188,7 @@ func TestConnPool_EvictDuringOpenClosesStore(t *testing.T) {
 	// The pool must have no cached entry for compA.
 	// A subsequent openOrGet should open a brand-new connection (opens count goes to 2).
 	o2 := &poolOpener{}
-	p2 := newConnPool("default", &http.Client{}, nil, o2.open)
+	p2 := newConnPool("default", &http.Client{}, nil, o2.open, nil)
 	_, err := p2.openOrGet(context.Background(), comp)
 	require.NoError(t, err) // sanity: a fresh pool works normally
 }
@@ -216,7 +216,7 @@ func TestConnPool_EvictDuringStoreAssignment_NoLeakNoRace(t *testing.T) {
 			close(returning) // signal "opener about to return"; the store write happens after this
 			return st, err
 		}
-		p := newConnPool("default", &http.Client{}, nil, open)
+		p := newConnPool("default", &http.Client{}, nil, open, nil)
 
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -259,7 +259,7 @@ func TestConnPool_CloseJoinsAllErrors(t *testing.T) {
 		}
 		return failingCloseStore{poolStore: poolStore{closes: &closes}, closeErr: e}, nil
 	}
-	p := newConnPool("default", &http.Client{}, nil, open)
+	p := newConnPool("default", &http.Client{}, nil, open, nil)
 
 	_, err := p.openOrGet(context.Background(), compA())
 	require.NoError(t, err)
@@ -276,7 +276,7 @@ func TestConnPool_CloseJoinsAllErrors(t *testing.T) {
 // connection is opened and openOrGet returns an error.
 func TestConnPool_OpenOrGetAfterCloseErrors(t *testing.T) {
 	o := &poolOpener{}
-	p := newConnPool("default", &http.Client{}, nil, o.open)
+	p := newConnPool("default", &http.Client{}, nil, o.open, nil)
 
 	require.NoError(t, p.Close())
 

--- a/cmd/derive.go
+++ b/cmd/derive.go
@@ -18,7 +18,11 @@ import (
 //
 // stateStorePath, when non-empty, is an explicit component YAML that overrides
 // state-store auto-detection (scanPaths becomes exactly that path).
-func derivePaths(apps []discovery.Instance, homeDir, stateStorePath string) (resPaths, scanPaths []string, loaded map[string]bool, appPaths []string) {
+// extraResPaths are appended to resPaths only (scanPaths untouched) — the
+// aspire-mode resources path(s) live alongside apps' own resource paths but
+// must not participate in state-store auto-detection, which the explicit
+// statestore path owns.
+func derivePaths(apps []discovery.Instance, homeDir, stateStorePath string, extraResPaths []string) (resPaths, scanPaths []string, loaded map[string]bool, appPaths []string) {
 	loaded = make(map[string]bool)
 	for _, a := range apps {
 		for _, c := range a.Components {
@@ -49,6 +53,7 @@ func derivePaths(apps []discovery.Instance, homeDir, stateStorePath string) (res
 			resPaths = append(resPaths, filepath.Dir(a.ConfigPath))
 		}
 	}
+	resPaths = append(resPaths, extraResPaths...)
 	return resPaths, scanPaths, loaded, appPaths
 }
 

--- a/cmd/derive_test.go
+++ b/cmd/derive_test.go
@@ -14,7 +14,7 @@ func TestDerivePaths_AutoDetect(t *testing.T) {
 		{AppID: "order", ResourcePaths: []string{"/app/resources"}, ConfigPath: "/app/config/cfg.yaml",
 			Components: []discovery.Component{{Name: "statestore", Type: "state.redis"}}},
 	}
-	resPaths, scanPaths, loaded, _ := derivePaths(apps, "/home/me", "")
+	resPaths, scanPaths, loaded, _ := derivePaths(apps, "/home/me", "", nil)
 
 	require.Contains(t, resPaths, "/home/me/.dapr/components")
 	require.Contains(t, resPaths, "/home/me/.dapr")
@@ -30,7 +30,7 @@ func TestDerivePaths_AutoDetect(t *testing.T) {
 
 func TestDerivePaths_ExplicitStateStoreOverride(t *testing.T) {
 	apps := []discovery.Instance{{AppID: "order", ResourcePaths: []string{"/app/resources"}}}
-	_, scanPaths, _, _ := derivePaths(apps, "/home/me", "/explicit/store.yaml")
+	_, scanPaths, _, _ := derivePaths(apps, "/home/me", "/explicit/store.yaml", nil)
 	require.Equal(t, []string{"/explicit/store.yaml"}, scanPaths)
 }
 
@@ -39,7 +39,7 @@ func TestDerivePaths_AppPaths(t *testing.T) {
 		{AppID: "a", ResourcePaths: []string{"/app/a/resources"}},
 		{AppID: "b", ResourcePaths: []string{"/app/b/resources"}},
 	}
-	_, _, _, appPaths := derivePaths(apps, "/home/me", "")
+	_, _, _, appPaths := derivePaths(apps, "/home/me", "", nil)
 	require.ElementsMatch(t, []string{"/app/a/resources", "/app/b/resources"}, appPaths)
 	require.NotContains(t, appPaths, "/home/me/.dapr/components")
 }
@@ -94,4 +94,20 @@ func TestAppsFingerprint_GroupSeparatorNotConfusableWithItems(t *testing.T) {
 	}
 	require.NotEqual(t, appsFingerprint(idItem), appsFingerprint(pathNamedItem),
 		"an id item must never hash like a group boundary + path item")
+}
+
+func TestDerivePathsExtraResPaths(t *testing.T) {
+	resPaths, scanPaths, _, _ := derivePaths(nil, "", "/app/components/state.yaml", []string{"/app/components"})
+	found := false
+	for _, p := range resPaths {
+		if p == "/app/components" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("resPaths missing extra path: %v", resPaths)
+	}
+	if len(scanPaths) != 1 || scanPaths[0] != "/app/components/state.yaml" {
+		t.Fatalf("explicit statestore must own scanPaths: %v", scanPaths)
+	}
 }

--- a/cmd/mode.go
+++ b/cmd/mode.go
@@ -1,6 +1,12 @@
 package cmd
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
 
 // Mode selects the dashboard's discovery and serving posture. ModeDefault
 // (the zero value, mode unset) is the complete scan across all discovery
@@ -26,4 +32,59 @@ func resolveMode(flagValue string, getenv func(string) string) (Mode, error) {
 		return Mode(v), nil
 	}
 	return ModeDefault, fmt.Errorf("unknown mode %q: supported values are \"aspire\", or unset for the complete scan", v)
+}
+
+// serveSettings is the fully resolved serve configuration: flag > env > mode
+// default, per the spec's precedence rule.
+type serveSettings struct {
+	Port           int
+	Bind           string
+	StateStore     string
+	Namespace      string
+	ResourcesPaths []string
+}
+
+// resolveServeSettings applies the flag > env > mode-default precedence.
+// flagChanged reports whether the named cobra flag was set explicitly; port,
+// bind, stateStore, namespace carry the flag values (which hold cobra
+// defaults when unchanged).
+func resolveServeSettings(mode Mode, flagChanged func(string) bool, port int, bind, stateStore, namespace string, getenv func(string) string) (serveSettings, error) {
+	s := serveSettings{Port: port, Bind: bind, StateStore: stateStore, Namespace: namespace}
+
+	if !flagChanged("port") {
+		if v := getenv("DEVDASHBOARD_PORT"); v != "" {
+			p, err := strconv.Atoi(v)
+			if err != nil || p < 1 || p > 65535 {
+				return s, fmt.Errorf("DEVDASHBOARD_PORT: expected a port number, got %q", v)
+			}
+			s.Port = p
+		} else if mode == ModeAspire {
+			s.Port = 8080
+		}
+	}
+	if !flagChanged("bind") {
+		if v := getenv("DEVDASHBOARD_BIND"); v != "" {
+			s.Bind = v
+		} else if mode == ModeAspire {
+			s.Bind = "0.0.0.0"
+		}
+	}
+	if s.StateStore == "" {
+		s.StateStore = getenv("DEVDASHBOARD_STATESTORE_FILE")
+	}
+	if !flagChanged("namespace") {
+		if v := getenv("DEVDASHBOARD_NAMESPACE"); v != "" {
+			s.Namespace = v
+		}
+	}
+	if v := getenv("DEVDASHBOARD_RESOURCES_PATH"); v != "" {
+		for _, p := range strings.Split(v, string(os.PathListSeparator)) {
+			if p = strings.TrimSpace(p); p != "" {
+				s.ResourcesPaths = append(s.ResourcesPaths, p)
+			}
+		}
+	} else if mode == ModeAspire && s.StateStore != "" {
+		s.ResourcesPaths = []string{filepath.Dir(s.StateStore)}
+	}
+	return s, nil
 }

--- a/cmd/mode.go
+++ b/cmd/mode.go
@@ -42,6 +42,9 @@ type serveSettings struct {
 	StateStore     string
 	Namespace      string
 	ResourcesPaths []string
+	// AllowedHosts restricts the Host header in container posture
+	// (DEVDASHBOARD_ALLOWED_HOSTS, comma-separated; env-only, no flag).
+	AllowedHosts []string
 }
 
 // resolveServeSettings applies the flag > env > mode-default precedence.
@@ -85,6 +88,13 @@ func resolveServeSettings(mode Mode, flagChanged func(string) bool, port int, bi
 		}
 	} else if mode == ModeAspire && s.StateStore != "" {
 		s.ResourcesPaths = []string{filepath.Dir(s.StateStore)}
+	}
+	if v := getenv("DEVDASHBOARD_ALLOWED_HOSTS"); v != "" {
+		for _, h := range strings.Split(v, ",") {
+			if h = strings.TrimSpace(h); h != "" {
+				s.AllowedHosts = append(s.AllowedHosts, h)
+			}
+		}
 	}
 	return s, nil
 }

--- a/cmd/mode.go
+++ b/cmd/mode.go
@@ -31,7 +31,7 @@ func resolveMode(flagValue string, getenv func(string) string) (Mode, error) {
 	case ModeDefault, ModeAspire:
 		return Mode(v), nil
 	}
-	return ModeDefault, fmt.Errorf("unknown mode %q: supported values are \"aspire\", or unset for the complete scan", v)
+	return ModeDefault, fmt.Errorf("unknown mode %q: supported values are \"aspire\" (or unset for the complete scan)", v)
 }
 
 // serveSettings is the fully resolved serve configuration: flag > env > mode

--- a/cmd/mode.go
+++ b/cmd/mode.go
@@ -1,0 +1,29 @@
+package cmd
+
+import "fmt"
+
+// Mode selects the dashboard's discovery and serving posture. ModeDefault
+// (the zero value, mode unset) is the complete scan across all discovery
+// sources with today's host behavior; ModeAspire restricts discovery to the
+// DEVDASHBOARD_APP_* env contract and switches to container posture.
+// "dapr" and "compose" are reserved for future single-source filter modes.
+type Mode string
+
+const (
+	ModeDefault Mode = ""
+	ModeAspire  Mode = "aspire"
+)
+
+// resolveMode picks the mode from the --mode flag value and the
+// DEVDASHBOARD_MODE env var (flag wins; both empty means ModeDefault).
+func resolveMode(flagValue string, getenv func(string) string) (Mode, error) {
+	v := flagValue
+	if v == "" {
+		v = getenv("DEVDASHBOARD_MODE")
+	}
+	switch Mode(v) {
+	case ModeDefault, ModeAspire:
+		return Mode(v), nil
+	}
+	return ModeDefault, fmt.Errorf("unknown mode %q: supported values are \"aspire\", or unset for the complete scan", v)
+}

--- a/cmd/mode_test.go
+++ b/cmd/mode_test.go
@@ -66,13 +66,15 @@ func TestListenAddr(t *testing.T) {
 func TestResolveServeSettings(t *testing.T) {
 	noneChanged := func(string) bool { return false }
 	tests := []struct {
-		name    string
-		mode    Mode
-		changed func(string) bool
-		port    int
-		bind    string
-		env     map[string]string
-		want    serveSettings
+		name       string
+		mode       Mode
+		changed    func(string) bool
+		port       int
+		bind       string
+		stateStore string
+		namespace  string
+		env        map[string]string
+		want       serveSettings
 	}{
 		{
 			name: "default mode keeps host defaults",
@@ -120,11 +122,36 @@ func TestResolveServeSettings(t *testing.T) {
 			want: serveSettings{Port: 8080, Bind: "0.0.0.0", Namespace: "default",
 				AllowedHosts: []string{"a.example", "b.example"}},
 		},
+		{
+			name: "changed bind flag beats env",
+			mode: ModeDefault, changed: func(f string) bool { return f == "bind" },
+			port: 9090, bind: "10.0.0.5",
+			env:  map[string]string{"DEVDASHBOARD_BIND": "192.168.1.1"},
+			want: serveSettings{Port: 9090, Bind: "10.0.0.5", Namespace: "default"},
+		},
+		{
+			name: "changed namespace flag beats env",
+			mode: ModeDefault, changed: func(f string) bool { return f == "namespace" },
+			port: 9090, bind: "127.0.0.1", namespace: "team-x",
+			env:  map[string]string{"DEVDASHBOARD_NAMESPACE": "env-ns"},
+			want: serveSettings{Port: 9090, Bind: "127.0.0.1", Namespace: "team-x"},
+		},
+		{
+			name: "non-empty statestore flag beats env",
+			mode: ModeDefault, changed: noneChanged,
+			port: 9090, bind: "127.0.0.1", stateStore: "/flag/state.yaml",
+			env:  map[string]string{"DEVDASHBOARD_STATESTORE_FILE": "/env/state.yaml"},
+			want: serveSettings{Port: 9090, Bind: "127.0.0.1", StateStore: "/flag/state.yaml", Namespace: "default"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			getenv := func(k string) string { return tc.env[k] }
-			got, err := resolveServeSettings(tc.mode, tc.changed, tc.port, tc.bind, "", "default", getenv)
+			ns := tc.namespace
+			if ns == "" {
+				ns = "default"
+			}
+			got, err := resolveServeSettings(tc.mode, tc.changed, tc.port, tc.bind, tc.stateStore, ns, getenv)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/cmd/mode_test.go
+++ b/cmd/mode_test.go
@@ -46,6 +46,23 @@ func TestResolveMode(t *testing.T) {
 	}
 }
 
+func TestListenAddr(t *testing.T) {
+	tests := []struct {
+		bind string
+		port int
+		want string
+	}{
+		{"127.0.0.1", 9090, "127.0.0.1:9090"},
+		{"::", 8080, "[::]:8080"},
+		{"0.0.0.0", 8080, "0.0.0.0:8080"},
+	}
+	for _, tc := range tests {
+		if got := listenAddr(tc.bind, tc.port); got != tc.want {
+			t.Fatalf("listenAddr(%q,%d)=%q want %q", tc.bind, tc.port, got, tc.want)
+		}
+	}
+}
+
 func TestResolveServeSettings(t *testing.T) {
 	noneChanged := func(string) bool { return false }
 	tests := []struct {

--- a/cmd/mode_test.go
+++ b/cmd/mode_test.go
@@ -2,7 +2,12 @@
 
 package cmd
 
-import "testing"
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
 
 func TestResolveMode(t *testing.T) {
 	env := func(vals map[string]string) func(string) string {
@@ -39,4 +44,79 @@ func TestResolveMode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveServeSettings(t *testing.T) {
+	noneChanged := func(string) bool { return false }
+	tests := []struct {
+		name    string
+		mode    Mode
+		changed func(string) bool
+		port    int
+		bind    string
+		env     map[string]string
+		want    serveSettings
+	}{
+		{
+			name: "default mode keeps host defaults",
+			mode: ModeDefault, changed: noneChanged, port: 9090, bind: "127.0.0.1",
+			want: serveSettings{Port: 9090, Bind: "127.0.0.1", Namespace: "default"},
+		},
+		{
+			name: "aspire mode defaults to 8080 on 0.0.0.0",
+			mode: ModeAspire, changed: noneChanged, port: 9090, bind: "127.0.0.1",
+			want: serveSettings{Port: 8080, Bind: "0.0.0.0", Namespace: "default"},
+		},
+		{
+			name: "env overrides aspire defaults",
+			mode: ModeAspire, changed: noneChanged, port: 9090, bind: "127.0.0.1",
+			env: map[string]string{
+				"DEVDASHBOARD_PORT":            "9999",
+				"DEVDASHBOARD_BIND":            "127.0.0.1",
+				"DEVDASHBOARD_STATESTORE_FILE": "/app/components/state.yaml",
+				"DEVDASHBOARD_NAMESPACE":       "team-a",
+			},
+			want: serveSettings{Port: 9999, Bind: "127.0.0.1", StateStore: "/app/components/state.yaml",
+				Namespace: "team-a", ResourcesPaths: []string{"/app/components"}},
+		},
+		{
+			name: "changed flag beats env",
+			mode: ModeAspire, changed: func(f string) bool { return f == "port" }, port: 7000, bind: "127.0.0.1",
+			env:  map[string]string{"DEVDASHBOARD_PORT": "9999"},
+			want: serveSettings{Port: 7000, Bind: "0.0.0.0", Namespace: "default"},
+		},
+		{
+			name: "explicit resources path splits on list separator",
+			mode: ModeAspire, changed: noneChanged, port: 9090, bind: "127.0.0.1",
+			env: map[string]string{
+				"DEVDASHBOARD_RESOURCES_PATH": "/mnt/a" + string(os.PathListSeparator) + "/mnt/b",
+			},
+			want: serveSettings{Port: 8080, Bind: "0.0.0.0", Namespace: "default",
+				ResourcesPaths: []string{"/mnt/a", "/mnt/b"}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			getenv := func(k string) string { return tc.env[k] }
+			got, err := resolveServeSettings(tc.mode, tc.changed, tc.port, tc.bind, "", "default", getenv)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %+v want %+v", got, tc.want)
+			}
+		})
+	}
+	t.Run("bad DEVDASHBOARD_PORT errors", func(t *testing.T) {
+		_, err := resolveServeSettings(ModeAspire, noneChanged, 9090, "127.0.0.1", "", "default",
+			func(k string) string {
+				if k == "DEVDASHBOARD_PORT" {
+					return "not-a-port"
+				}
+				return ""
+			})
+		if err == nil || !strings.Contains(err.Error(), "DEVDASHBOARD_PORT") {
+			t.Fatalf("want error naming DEVDASHBOARD_PORT, got %v", err)
+		}
+	})
 }

--- a/cmd/mode_test.go
+++ b/cmd/mode_test.go
@@ -1,0 +1,42 @@
+//go:build unit
+
+package cmd
+
+import "testing"
+
+func TestResolveMode(t *testing.T) {
+	env := func(vals map[string]string) func(string) string {
+		return func(k string) string { return vals[k] }
+	}
+	tests := []struct {
+		name    string
+		flag    string
+		env     map[string]string
+		want    Mode
+		wantErr bool
+	}{
+		{name: "unset everywhere is default", flag: "", env: nil, want: ModeDefault},
+		{name: "flag aspire", flag: "aspire", env: nil, want: ModeAspire},
+		{name: "env aspire", flag: "", env: map[string]string{"DEVDASHBOARD_MODE": "aspire"}, want: ModeAspire},
+		{name: "flag wins over env", flag: "aspire", env: map[string]string{"DEVDASHBOARD_MODE": "bogus"}, want: ModeAspire},
+		{name: "unknown flag value errors", flag: "compose", wantErr: true},
+		{name: "unknown env value errors", env: map[string]string{"DEVDASHBOARD_MODE": "dapr"}, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveMode(tc.flag, env(tc.env))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/mode_test.go
+++ b/cmd/mode_test.go
@@ -94,6 +94,15 @@ func TestResolveServeSettings(t *testing.T) {
 			want: serveSettings{Port: 8080, Bind: "0.0.0.0", Namespace: "default",
 				ResourcesPaths: []string{"/mnt/a", "/mnt/b"}},
 		},
+		{
+			name: "allowed hosts split on comma, trimmed",
+			mode: ModeAspire, changed: noneChanged, port: 9090, bind: "127.0.0.1",
+			env: map[string]string{
+				"DEVDASHBOARD_ALLOWED_HOSTS": "a.example, b.example",
+			},
+			want: serveSettings{Port: 8080, Bind: "0.0.0.0", Namespace: "default",
+				AllowedHosts: []string{"a.example", "b.example"}},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/reconciler.go
+++ b/cmd/reconciler.go
@@ -47,6 +47,9 @@ type reconciler struct {
 	degraded       storeEntry
 	// composeEnv returns the compose endpoint/mount context (nil = no compose).
 	composeEnv func() discovery.ComposeEnv
+	// extraResPaths are appended to the reconciler's resource scan paths on every
+	// reconcile (aspire-mode DEVDASHBOARD_RESOURCES_PATH); nil in host mode.
+	extraResPaths []string
 
 	reconciling atomic.Bool // single-flight guard for background reconciles
 
@@ -62,7 +65,7 @@ type reconciler struct {
 // process-lifetime base context: store-open contexts derive from it so that
 // shutdown (Ctrl-C) aborts in-flight dials instead of blocking on them.
 // composeEnv returns the compose endpoint/mount context; nil disables translation.
-func newReconciler(ctx context.Context, apps discovery.Service, namespace, homeDir, stateStorePath string, client *http.Client, registry *ConnRegistry, pool *connPool, composeEnv func() discovery.ComposeEnv) *reconciler {
+func newReconciler(ctx context.Context, apps discovery.Service, namespace, homeDir, stateStorePath string, client *http.Client, registry *ConnRegistry, pool *connPool, composeEnv func() discovery.ComposeEnv, extraResPaths []string) *reconciler {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -76,6 +79,7 @@ func newReconciler(ctx context.Context, apps discovery.Service, namespace, homeD
 		registry:       registry,
 		pool:           pool,
 		composeEnv:     composeEnv,
+		extraResPaths:  extraResPaths,
 		degraded:       buildStoreEntry(nil, namespace, client, apps),
 	}
 }
@@ -122,7 +126,7 @@ func identity(c *statestore.Component) string {
 // fingerprint for apps.
 func (rc *reconciler) reconcile(apps []discovery.Instance, fp string) {
 	log := slog.Default().With("component", "reconciler")
-	resPaths, scanPaths, loaded, appPaths := derivePaths(apps, rc.homeDir, rc.stateStorePath)
+	resPaths, scanPaths, loaded, appPaths := derivePaths(apps, rc.homeDir, rc.stateStorePath, rc.extraResPaths)
 	detected, err := statestore.Detect(scanPaths)
 	if err != nil {
 		log.Warn("state-store detection failed", "err", err)

--- a/cmd/reconciler.go
+++ b/cmd/reconciler.go
@@ -80,7 +80,9 @@ func newReconciler(ctx context.Context, apps discovery.Service, namespace, homeD
 		pool:           pool,
 		composeEnv:     composeEnv,
 		extraResPaths:  extraResPaths,
-		degraded:       buildStoreEntry(nil, namespace, client, apps),
+		// The degraded entry has a nil store: every operation fails with
+		// ErrNoStore before any key/namespace resolution, so no appNS map.
+		degraded: buildStoreEntry(nil, namespace, client, apps, nil),
 	}
 }
 

--- a/cmd/reconciler_test.go
+++ b/cmd/reconciler_test.go
@@ -94,7 +94,7 @@ func TestReconciler_ServiceForRouting(t *testing.T) {
 
 	o := &fakeOpener{}
 	pool := newConnPool("default", &http.Client{}, nil, o.open)
-	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil)
+	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
 	// Seed an elected active store directly (no apps needed for this routing test).
@@ -132,7 +132,7 @@ func TestReconciler_NoActiveNoStoresDegraded(t *testing.T) {
 	reg := LoadRegistry(home)
 	o := &fakeOpener{}
 	pool := newConnPool("default", &http.Client{}, nil, o.open)
-	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil)
+	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
 	// No elected store and empty name -> degraded entry, ok=true.
@@ -150,7 +150,7 @@ func TestReconciler_StoresListsAllEntriesAndMutators(t *testing.T) {
 
 	o := &fakeOpener{}
 	pool := newConnPool("default", &http.Client{}, nil, o.open)
-	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil)
+	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
 	// Elect "autostore" active so the active flag is exercised.
@@ -221,7 +221,7 @@ func TestReconciler_ServiceForUnreachableByID(t *testing.T) {
 	require.NotEmpty(t, id)
 
 	pool := newConnPool("default", &http.Client{}, nil, failingOpener{}.open)
-	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil)
+	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
 	svc, _, _, ok := rc.ServiceFor(id)
@@ -237,7 +237,7 @@ func TestReconciler_ServiceForUnreachableActive(t *testing.T) {
 
 	reg := LoadRegistry(home)
 	pool := newConnPool("default", &http.Client{}, nil, failingOpener{}.open)
-	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil)
+	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
 	// Elect an active store; the pool's opener will fail to connect to it.
@@ -256,7 +256,7 @@ func TestReconciler_ServiceForNoStoreStillErrNoStore(t *testing.T) {
 	home := t.TempDir()
 	reg := LoadRegistry(home)
 	pool := newConnPool("default", &http.Client{}, nil, failingOpener{}.open)
-	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil)
+	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
 	// No elected store and empty id -> degraded/ErrNoStore (genuinely no store).
@@ -270,7 +270,7 @@ func TestReconciler_ServiceForUnknownID(t *testing.T) {
 	home := t.TempDir()
 	reg := LoadRegistry(home)
 	pool := newConnPool("default", &http.Client{}, nil, failingOpener{}.open)
-	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil)
+	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
 	_, _, _, ok := rc.ServiceFor("nosuchid")
@@ -304,7 +304,7 @@ func TestReconciler_BaseCtxCancelAbortsPreWarm(t *testing.T) {
 	pool := newConnPool("default", &http.Client{}, nil, o.open)
 	reg := LoadRegistry(home)
 	// stateStorePath = compPath so reconcile detects and elects it, then pre-warms.
-	rc := newReconciler(ctx, nil, "default", home, compPath, &http.Client{}, reg, pool, nil)
+	rc := newReconciler(ctx, nil, "default", home, compPath, &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
 	done := make(chan struct{})
@@ -355,7 +355,7 @@ func TestComponentFor_WarnsOnUnresolvedSecrets(t *testing.T) {
 
 	o := &fakeOpener{}
 	pool := newConnPool("default", &http.Client{}, nil, o.open)
-	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil)
+	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
 	_, ok := rc.componentFor(id)
@@ -369,7 +369,7 @@ func TestAddStoreDuplicateNameFriendlyError(t *testing.T) {
 	reg := LoadRegistry(home)
 	o := &fakeOpener{}
 	pool := newConnPool("default", &http.Client{}, nil, o.open)
-	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil)
+	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
 	require.NoError(t, rc.AddStore("dup", "state.redis", map[string]string{"redisHost": "h"}))
@@ -399,7 +399,7 @@ func TestReconciler_StoresOrderingAndDismissedFilter(t *testing.T) {
 
 	o := &fakeOpener{}
 	pool := newConnPool("default", &http.Client{}, nil, o.open)
-	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil)
+	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
 	// No active store: pure recency order, newest first.
@@ -455,7 +455,7 @@ func TestReconciler_DeleteStoreRefusesActive(t *testing.T) {
 
 	o := &fakeOpener{}
 	pool := newConnPool("default", &http.Client{}, nil, o.open)
-	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil)
+	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
 	active := statestore.Component{Name: "autostore", Type: "state.sqlite", Path: autoPath,
@@ -500,7 +500,7 @@ spec:
 			PathProject: map[string]string{dir: "saga"},
 		}
 	}
-	rc := newReconciler(context.Background(), nil, "default", "", "", nil, nil, nil, composeEnv)
+	rc := newReconciler(context.Background(), nil, "default", "", "", nil, nil, nil, composeEnv, nil)
 	c := statestore.Component{
 		Name: "statestore", Type: "state.redis", Path: filepath.Join(dir, "statestore.yaml"),
 		Metadata: map[string]string{"redisHost": "redis:6379"},
@@ -527,7 +527,7 @@ func TestReconciler_UndismissActiveStore(t *testing.T) {
 
 	o := &fakeOpener{}
 	pool := newConnPool("default", &http.Client{}, nil, o.open)
-	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil)
+	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
 	// Tombstone it, then simulate reconcile electing it active.

--- a/cmd/reconciler_test.go
+++ b/cmd/reconciler_test.go
@@ -93,7 +93,7 @@ func TestReconciler_ServiceForRouting(t *testing.T) {
 	require.NotEqual(t, ids[autoPath], ids[autoPath2], "same name + different paths -> distinct ids")
 
 	o := &fakeOpener{}
-	pool := newConnPool("default", &http.Client{}, nil, o.open)
+	pool := newConnPool("default", &http.Client{}, nil, o.open, nil)
 	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
@@ -131,7 +131,7 @@ func TestReconciler_NoActiveNoStoresDegraded(t *testing.T) {
 	home := t.TempDir()
 	reg := LoadRegistry(home)
 	o := &fakeOpener{}
-	pool := newConnPool("default", &http.Client{}, nil, o.open)
+	pool := newConnPool("default", &http.Client{}, nil, o.open, nil)
 	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
@@ -149,7 +149,7 @@ func TestReconciler_StoresListsAllEntriesAndMutators(t *testing.T) {
 	require.NoError(t, reg.UpsertAuto(ConnEntry{Name: "autostore", Type: "state.sqlite", Source: SourceAuto, Path: autoPath}))
 
 	o := &fakeOpener{}
-	pool := newConnPool("default", &http.Client{}, nil, o.open)
+	pool := newConnPool("default", &http.Client{}, nil, o.open, nil)
 	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
@@ -220,7 +220,7 @@ func TestReconciler_ServiceForUnreachableByID(t *testing.T) {
 	}
 	require.NotEmpty(t, id)
 
-	pool := newConnPool("default", &http.Client{}, nil, failingOpener{}.open)
+	pool := newConnPool("default", &http.Client{}, nil, failingOpener{}.open, nil)
 	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
@@ -236,7 +236,7 @@ func TestReconciler_ServiceForUnreachableActive(t *testing.T) {
 	home := t.TempDir()
 
 	reg := LoadRegistry(home)
-	pool := newConnPool("default", &http.Client{}, nil, failingOpener{}.open)
+	pool := newConnPool("default", &http.Client{}, nil, failingOpener{}.open, nil)
 	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
@@ -255,7 +255,7 @@ func TestReconciler_ServiceForUnreachableActive(t *testing.T) {
 func TestReconciler_ServiceForNoStoreStillErrNoStore(t *testing.T) {
 	home := t.TempDir()
 	reg := LoadRegistry(home)
-	pool := newConnPool("default", &http.Client{}, nil, failingOpener{}.open)
+	pool := newConnPool("default", &http.Client{}, nil, failingOpener{}.open, nil)
 	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
@@ -269,7 +269,7 @@ func TestReconciler_ServiceForNoStoreStillErrNoStore(t *testing.T) {
 func TestReconciler_ServiceForUnknownID(t *testing.T) {
 	home := t.TempDir()
 	reg := LoadRegistry(home)
-	pool := newConnPool("default", &http.Client{}, nil, failingOpener{}.open)
+	pool := newConnPool("default", &http.Client{}, nil, failingOpener{}.open, nil)
 	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
@@ -301,7 +301,7 @@ func TestReconciler_BaseCtxCancelAbortsPreWarm(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	o := &blockingCtxOpener{started: make(chan struct{})}
-	pool := newConnPool("default", &http.Client{}, nil, o.open)
+	pool := newConnPool("default", &http.Client{}, nil, o.open, nil)
 	reg := LoadRegistry(home)
 	// stateStorePath = compPath so reconcile detects and elects it, then pre-warms.
 	rc := newReconciler(ctx, nil, "default", home, compPath, &http.Client{}, reg, pool, nil, nil)
@@ -354,7 +354,7 @@ func TestComponentFor_WarnsOnUnresolvedSecrets(t *testing.T) {
 	t.Cleanup(func() { slog.SetDefault(prev) })
 
 	o := &fakeOpener{}
-	pool := newConnPool("default", &http.Client{}, nil, o.open)
+	pool := newConnPool("default", &http.Client{}, nil, o.open, nil)
 	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
@@ -368,7 +368,7 @@ func TestAddStoreDuplicateNameFriendlyError(t *testing.T) {
 	home := t.TempDir()
 	reg := LoadRegistry(home)
 	o := &fakeOpener{}
-	pool := newConnPool("default", &http.Client{}, nil, o.open)
+	pool := newConnPool("default", &http.Client{}, nil, o.open, nil)
 	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
@@ -398,7 +398,7 @@ func TestReconciler_StoresOrderingAndDismissedFilter(t *testing.T) {
 		Metadata: map[string]string{"connectionString": "host=h2 dbname=d2"}}))
 
 	o := &fakeOpener{}
-	pool := newConnPool("default", &http.Client{}, nil, o.open)
+	pool := newConnPool("default", &http.Client{}, nil, o.open, nil)
 	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
@@ -454,7 +454,7 @@ func TestReconciler_DeleteStoreRefusesActive(t *testing.T) {
 	require.NoError(t, reg.UpsertAuto(ConnEntry{Name: "autostore", Type: "state.sqlite", Source: SourceAuto, Path: autoPath}))
 
 	o := &fakeOpener{}
-	pool := newConnPool("default", &http.Client{}, nil, o.open)
+	pool := newConnPool("default", &http.Client{}, nil, o.open, nil)
 	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 
@@ -526,7 +526,7 @@ func TestReconciler_UndismissActiveStore(t *testing.T) {
 	require.NoError(t, reg.UpsertAuto(ConnEntry{Name: "autostore", Type: "state.sqlite", Source: SourceAuto, Path: autoPath}))
 
 	o := &fakeOpener{}
-	pool := newConnPool("default", &http.Client{}, nil, o.open)
+	pool := newConnPool("default", &http.Client{}, nil, o.open, nil)
 	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
 	t.Cleanup(func() { _ = rc.Close() })
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -130,6 +130,7 @@ func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath s
 		containerLogs func(context.Context, string) (<-chan string, error)
 		updateCheck   updatecheck.Service
 		caps          *server.Capabilities
+		appNS         map[string]string
 	)
 	switch mode {
 	case ModeAspire:
@@ -137,6 +138,7 @@ func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath s
 		if err != nil {
 			return err
 		}
+		appNS = contractNamespaces(scan)
 		appsSvc = discovery.New(scan, client)
 		caps = &server.Capabilities{Workflows: settings.StateStore != ""}
 	default:
@@ -148,6 +150,7 @@ func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath s
 			if err != nil {
 				return err
 			}
+			appNS = contractNamespaces(as)
 			scanners = append(scanners, as)
 		}
 		lifeReg := lifecycle.NewRegistry()
@@ -179,6 +182,7 @@ func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath s
 		Capabilities:     caps,
 		ResourcesPaths:   settings.ResourcesPaths,
 		QuietRegistry:    mode == ModeAspire,
+		AppNamespaces:    appNS,
 	}, dist)
 	for _, close := range closers {
 		close := close

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,8 @@ import (
 func NewRootCmd() *cobra.Command {
 	var (
 		port       int
+		bind       string
+		modeFlag   string
 		basePath   string
 		noOpen     bool
 		stateStore string
@@ -46,11 +48,21 @@ func NewRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runServe(cmd.Context(), port, basePath, noOpen, stateStore, namespace, verbose)
+			mode, err := resolveMode(modeFlag, os.Getenv)
+			if err != nil {
+				return err
+			}
+			settings, err := resolveServeSettings(mode, cmd.Flags().Changed, port, bind, stateStore, namespace, os.Getenv)
+			if err != nil {
+				return err
+			}
+			return runServe(cmd.Context(), mode, settings, basePath, noOpen, verbose)
 		},
 	}
 	c.SetVersionTemplate(fmt.Sprintf("dev-dashboard {{.Version}} (commit %s, built %s)\n", info.Commit, info.Date))
 	c.Flags().IntVar(&port, "port", 9090, "port to serve the dashboard on")
+	c.Flags().StringVar(&bind, "bind", "127.0.0.1", "address to bind (aspire mode defaults to 0.0.0.0)")
+	c.Flags().StringVar(&modeFlag, "mode", "", `serving/discovery mode: "aspire", or unset for the complete scan`)
 	c.Flags().StringVar(&basePath, "base-path", "", "optional base path (e.g. /dashboard)")
 	c.Flags().BoolVar(&noOpen, "no-open", false, "do not open the browser on start")
 	c.Flags().StringVar(&stateStore, "statestore", "", "path to a state-store component YAML (overrides auto-detect)")
@@ -67,7 +79,7 @@ func Execute() error {
 	return NewRootCmd().ExecuteContext(ctx)
 }
 
-func runServe(ctx context.Context, port int, basePath string, noOpen bool, stateStore, namespace string, verbose bool) error {
+func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath string, noOpen, verbose bool) error {
 	logger := logging.New(verbose)
 	slog.SetDefault(logger)
 	statestore.SetVerbose(verbose)
@@ -81,44 +93,85 @@ func runServe(ctx context.Context, port int, basePath string, noOpen bool, state
 		logger.Error("component metadata bundle failed to load", "err", err)
 		return fmt.Errorf("init component metadata: %w", err)
 	}
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	addr := fmt.Sprintf("%s:%d", settings.Bind, settings.Port)
 	urlPath := ""
 	if trimmed := trimSlash(basePath); trimmed != "" {
 		urlPath = "/" + trimmed
 	}
-	url := fmt.Sprintf("http://%s%s/", addr, urlPath)
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		// An empty home disables registry persistence in assembleOptions rather
-		// than falling back to a CWD-relative registry path.
-		logger.Warn("home directory unavailable; connection registry will not be persisted", "err", err)
-		home = ""
+	displayHost := settings.Bind
+	if displayHost == "0.0.0.0" || displayHost == "::" {
+		displayHost = "localhost"
 	}
-	_, crtRunner := containerruntime.Detect()
-	composeSrc := discovery.NewComposeSource(crtRunner)
-	lifeReg := lifecycle.NewRegistry()
-	lifeProc := lifecycle.NewProcController()
-	appsSvc := lifecycle.Overlay(
-		discovery.New(
-			discovery.Merge(discovery.StandaloneScanner(), composeSrc.Scanner()),
-			&http.Client{Timeout: 2 * time.Second}),
-		lifeReg, lifeProc)
-	lifeMgr := lifecycle.New(appsSvc, lifeReg, crtRunner, lifeProc, lifecycle.NewStarter())
+	url := fmt.Sprintf("http://%s:%d%s/", displayHost, settings.Port, urlPath)
+
+	// Aspire/container mode disables registry persistence entirely (no home
+	// directory), so the "no home" warning is suppressed via QuietRegistry.
+	home := ""
+	if mode != ModeAspire {
+		home, err = os.UserHomeDir()
+		if err != nil {
+			// An empty home disables registry persistence in assembleOptions rather
+			// than falling back to a CWD-relative registry path.
+			logger.Warn("home directory unavailable; connection registry will not be persisted", "err", err)
+			home = ""
+		}
+	}
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	var (
+		appsSvc       discovery.Service
+		lifeMgr       lifecycle.Manager
+		composeEnv    func() discovery.ComposeEnv
+		containerLogs func(context.Context, string) (<-chan string, error)
+		updateCheck   updatecheck.Service
+		caps          *server.Capabilities
+	)
+	switch mode {
+	case ModeAspire:
+		scan, err := discovery.NewAspireScanner(os.Getenv)
+		if err != nil {
+			return err
+		}
+		appsSvc = discovery.New(scan, client)
+		caps = &server.Capabilities{Workflows: settings.StateStore != ""}
+	default:
+		_, crtRunner := containerruntime.Detect()
+		composeSrc := discovery.NewComposeSource(crtRunner)
+		scanners := []discovery.Scanner{discovery.StandaloneScanner(), composeSrc.Scanner()}
+		if discovery.AspireContractPresent(os.Getenv) {
+			as, err := discovery.NewAspireScanner(os.Getenv)
+			if err != nil {
+				return err
+			}
+			scanners = append(scanners, as)
+		}
+		lifeReg := lifecycle.NewRegistry()
+		lifeProc := lifecycle.NewProcController()
+		appsSvc = lifecycle.Overlay(
+			discovery.New(discovery.Merge(scanners...), client), lifeReg, lifeProc)
+		lifeMgr = lifecycle.New(appsSvc, lifeReg, crtRunner, lifeProc, lifecycle.NewStarter())
+		composeEnv = composeSrc.Env
+		containerLogs = containerLogStream(crtRunner)
+		updateCheck = updatecheck.New(&http.Client{Timeout: 5 * time.Second}, "https://api.github.com", "diagridio/dev-dashboard", version.Get().Version, time.Hour)
+	}
+
 	telemetry := telemetryEnabled(os.Getenv)
-	updateCheck := updatecheck.New(&http.Client{Timeout: 5 * time.Second}, "https://api.github.com", "diagridio/dev-dashboard", version.Get().Version, time.Hour)
 	opts, closers := assembleOptions(ctx, serveDeps{
 		BasePath:         basePath,
-		StateStorePath:   stateStore,
-		Namespace:        namespace,
+		StateStorePath:   settings.StateStore,
+		Namespace:        settings.Namespace,
 		Apps:             appsSvc,
 		Lifecycle:        lifeMgr,
 		HomeDir:          home,
 		HTTPClient:       &http.Client{Timeout: 10 * time.Second},
-		ComposeEnv:       composeSrc.Env,
-		ContainerLogs:    containerLogStream(crtRunner),
+		ComposeEnv:       composeEnv,
+		ContainerLogs:    containerLogs,
 		TelemetryEnabled: telemetry,
 		UpdateCheck:      updateCheck,
+		AllowNonLoopback: mode == ModeAspire,
+		Capabilities:     caps,
+		ResourcesPaths:   settings.ResourcesPaths,
+		QuietRegistry:    mode == ModeAspire,
 	}, dist)
 	for _, close := range closers {
 		close := close
@@ -127,16 +180,18 @@ func runServe(ctx context.Context, port int, basePath string, noOpen bool, state
 
 	srv := server.New(addr, opts)
 
-	check := maybeAnnounceUpdate(ctx, updateCheck, version.Get().Version)
-	interactive := isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
-	maybeOfferUpdate(ctx, check, os.Stdin, os.Stdout, interactive, selfUpdateAndRestart)
+	if updateCheck != nil {
+		check := maybeAnnounceUpdate(ctx, updateCheck, version.Get().Version)
+		interactive := isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
+		maybeOfferUpdate(ctx, check, os.Stdin, os.Stdout, interactive, selfUpdateAndRestart)
+	}
 	fmt.Printf("Diagrid Dev Dashboard is starting → %s\n", url)
 	if telemetry {
 		fmt.Println("We're using anonymous usage telemetry to improve the dashboard. Set DEVDASHBOARD_TELEMETRY_OPTOUT=true to disable (restart required).")
 	} else {
 		fmt.Println("Anonymous usage telemetry is disabled (DEVDASHBOARD_TELEMETRY_OPTOUT=true).")
 	}
-	if !noOpen {
+	if !noOpen && mode != ModeAspire {
 		go func() { time.Sleep(400 * time.Millisecond); _ = openBrowser(url) }()
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -169,6 +169,8 @@ func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath s
 		TelemetryEnabled: telemetry,
 		UpdateCheck:      updateCheck,
 		AllowNonLoopback: mode == ModeAspire,
+		AllowedHosts:     settings.AllowedHosts,
+		ListenPort:       settings.Port,
 		Capabilities:     caps,
 		ResourcesPaths:   settings.ResourcesPaths,
 		QuietRegistry:    mode == ModeAspire,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -61,7 +63,7 @@ func NewRootCmd() *cobra.Command {
 	}
 	c.SetVersionTemplate(fmt.Sprintf("dev-dashboard {{.Version}} (commit %s, built %s)\n", info.Commit, info.Date))
 	c.Flags().IntVar(&port, "port", 9090, "port to serve the dashboard on")
-	c.Flags().StringVar(&bind, "bind", "127.0.0.1", "address to bind (aspire mode defaults to 0.0.0.0)")
+	c.Flags().StringVar(&bind, "bind", "127.0.0.1", "address to bind (aspire mode defaults to 0.0.0.0); binding a non-loopback address without aspire mode leaves the loopback Host guard in place, which rejects remote clients")
 	c.Flags().StringVar(&modeFlag, "mode", "", `serving/discovery mode: "aspire", or unset for the complete scan`)
 	c.Flags().StringVar(&basePath, "base-path", "", "optional base path (e.g. /dashboard)")
 	c.Flags().BoolVar(&noOpen, "no-open", false, "do not open the browser on start")
@@ -93,7 +95,10 @@ func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath s
 		logger.Error("component metadata bundle failed to load", "err", err)
 		return fmt.Errorf("init component metadata: %w", err)
 	}
-	addr := fmt.Sprintf("%s:%d", settings.Bind, settings.Port)
+	addr := listenAddr(settings.Bind, settings.Port)
+	if mode == ModeDefault && !isLoopbackBind(settings.Bind) {
+		logger.Warn("binding a non-loopback address without aspire mode; the loopback Host guard will reject remote clients (set --mode aspire for container serving posture)", "bind", settings.Bind)
+	}
 	urlPath := ""
 	if trimmed := trimSlash(basePath); trimmed != "" {
 		urlPath = "/" + trimmed
@@ -224,6 +229,22 @@ func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath s
 // getenv) — restart the dashboard for a changed value to take effect.
 func telemetryEnabled(getenv func(string) string) bool {
 	return !strings.EqualFold(getenv("DEVDASHBOARD_TELEMETRY_OPTOUT"), "true")
+}
+
+// listenAddr joins a bind address and port into a listen address, correctly
+// bracketing IPv6 literals (e.g. "::" -> "[::]:8080").
+func listenAddr(bind string, port int) string {
+	return net.JoinHostPort(bind, strconv.Itoa(port))
+}
+
+// isLoopbackBind reports whether a bind address is a loopback address the
+// dashboard's loopback Host guard is designed for.
+func isLoopbackBind(bind string) bool {
+	switch bind {
+	case "127.0.0.1", "localhost", "::1":
+		return true
+	}
+	return false
 }
 
 func trimSlash(s string) string {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -47,6 +47,12 @@ type serveDeps struct {
 	// any Host (aspire/container mode, where the dashboard is reached via a
 	// published port).
 	AllowNonLoopback bool
+	// AllowedHosts restricts the Host header in container posture (loopback
+	// always allowed); empty means any Host passes. From DEVDASHBOARD_ALLOWED_HOSTS.
+	AllowedHosts []string
+	// ListenPort is the server's listen port, used to normalize a portless Host
+	// header when comparing Origin against Host in container posture.
+	ListenPort int
 	// Capabilities gates optional feature routes and SPA flags; nil means full
 	// host-mode capabilities.
 	Capabilities *server.Capabilities
@@ -122,6 +128,8 @@ func assembleOptions(ctx context.Context, deps serveDeps, dist fs.FS) (server.Op
 		TelemetryEnabled: deps.TelemetryEnabled,
 		UpdateCheck:      deps.UpdateCheck,
 		AllowNonLoopback: deps.AllowNonLoopback,
+		AllowedHosts:     deps.AllowedHosts,
+		ListenPort:       deps.ListenPort,
 		Capabilities:     deps.Capabilities,
 	}, []func() error{rc.Close}
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -62,6 +62,11 @@ type serveDeps struct {
 	// QuietRegistry suppresses the "no home directory" registry-persistence
 	// warning when persistence is deliberately disabled (aspire mode).
 	QuietRegistry bool
+	// AppNamespaces is the static appID→namespace map parsed once from the
+	// aspire DEVDASHBOARD_APP_* env contract; nil when the contract is absent.
+	// Workflow reads resolve per-app namespaces from it by map lookup, never
+	// via discovery enrichment (sidecar probes).
+	AppNamespaces map[string]string
 }
 
 // containerLogStream adapts a runtime Runner into the log-stream dependency.
@@ -91,7 +96,7 @@ func assembleOptions(ctx context.Context, deps serveDeps, dist fs.FS) (server.Op
 	} else if !deps.QuietRegistry {
 		slog.Default().With("component", "registry").Warn("no home directory; connection registry persistence disabled")
 	}
-	pool := newConnPool(deps.Namespace, deps.HTTPClient, appsSvc, nil)
+	pool := newConnPool(deps.Namespace, deps.HTTPClient, appsSvc, nil, deps.AppNamespaces)
 
 	// Build the reconciler that owns all apps-derived state (resource paths,
 	// detected state stores, active-store election) plus the registry and pool.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -43,6 +43,19 @@ type serveDeps struct {
 	// UpdateCheck is the shared latest-release checker; also used by runServe to
 	// print the startup notice, so the server reuses its warmed cache.
 	UpdateCheck updatecheck.Service
+	// AllowNonLoopback relaxes the server's request guard from loopback-only to
+	// any Host (aspire/container mode, where the dashboard is reached via a
+	// published port).
+	AllowNonLoopback bool
+	// Capabilities gates optional feature routes and SPA flags; nil means full
+	// host-mode capabilities.
+	Capabilities *server.Capabilities
+	// ResourcesPaths are extra resource directories appended to the reconciler's
+	// scan paths (aspire-mode DEVDASHBOARD_RESOURCES_PATH); nil in host mode.
+	ResourcesPaths []string
+	// QuietRegistry suppresses the "no home directory" registry-persistence
+	// warning when persistence is deliberately disabled (aspire mode).
+	QuietRegistry bool
 }
 
 // containerLogStream adapts a runtime Runner into the log-stream dependency.
@@ -69,14 +82,14 @@ func assembleOptions(ctx context.Context, deps serveDeps, dist fs.FS) (server.Op
 	var registry *ConnRegistry
 	if deps.HomeDir != "" {
 		registry = LoadRegistry(deps.HomeDir)
-	} else {
+	} else if !deps.QuietRegistry {
 		slog.Default().With("component", "registry").Warn("no home directory; connection registry persistence disabled")
 	}
 	pool := newConnPool(deps.Namespace, deps.HTTPClient, appsSvc, nil)
 
 	// Build the reconciler that owns all apps-derived state (resource paths,
 	// detected state stores, active-store election) plus the registry and pool.
-	rc := newReconciler(ctx, appsSvc, deps.Namespace, deps.HomeDir, deps.StateStorePath, deps.HTTPClient, registry, pool, deps.ComposeEnv)
+	rc := newReconciler(ctx, appsSvc, deps.Namespace, deps.HomeDir, deps.StateStorePath, deps.HTTPClient, registry, pool, deps.ComposeEnv, deps.ResourcesPaths)
 
 	// Seed once synchronously from the boot snapshot so the first request is
 	// correct. Best-effort: an empty/failed list yields an empty derived state.
@@ -108,5 +121,7 @@ func assembleOptions(ctx context.Context, deps serveDeps, dist fs.FS) (server.Op
 		ControlPlane:     controlplane.New(),
 		TelemetryEnabled: deps.TelemetryEnabled,
 		UpdateCheck:      deps.UpdateCheck,
+		AllowNonLoopback: deps.AllowNonLoopback,
+		Capabilities:     deps.Capabilities,
 	}, []func() error{rc.Close}
 }

--- a/cmd/serve_aspire_integration_test.go
+++ b/cmd/serve_aspire_integration_test.go
@@ -3,7 +3,6 @@
 package cmd
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -50,7 +49,7 @@ func TestAspireModeEndToEnd(t *testing.T) {
 		"index.html": &fstest.MapFile{Data: []byte("<html>spa</html>")},
 	}
 
-	opts, closers := assembleOptions(context.Background(), serveDeps{
+	opts, closers := assembleOptions(t.Context(), serveDeps{
 		Namespace:        "default",
 		Apps:             appsSvc,
 		HTTPClient:       &http.Client{Timeout: 5 * time.Second},

--- a/cmd/serve_aspire_integration_test.go
+++ b/cmd/serve_aspire_integration_test.go
@@ -1,0 +1,93 @@
+//go:build integration
+
+package cmd
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/diagridio/dev-dashboard/pkg/discovery"
+	"github.com/diagridio/dev-dashboard/pkg/server"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAspireModeEndToEnd wires the real server via assembleOptions in
+// aspire-mode configuration (env-contract discovery, non-loopback guard
+// relaxed, restricted capabilities) against a stub daprd, then drives the
+// real HTTP surface end to end: apps listed+enriched, non-loopback Host
+// accepted, gated routes absent.
+func TestAspireModeEndToEnd(t *testing.T) {
+	// Stub daprd: healthz + minimal metadata.
+	daprd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.0/healthz":
+			w.WriteHeader(http.StatusNoContent)
+		case "/v1.0/metadata":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"orders","runtimeVersion":"1.16.0","extended":{}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer daprd.Close()
+
+	t.Setenv("DEVDASHBOARD_APP_COUNT", "1")
+	t.Setenv("DEVDASHBOARD_APP_0_ID", "orders")
+	t.Setenv("DEVDASHBOARD_APP_0_DAPR_HTTP", daprd.URL)
+
+	scan, err := discovery.NewAspireScanner(os.Getenv)
+	require.NoError(t, err)
+	appsSvc := discovery.New(scan, daprd.Client())
+	caps := &server.Capabilities{Workflows: false}
+
+	dist := fstest.MapFS{
+		"index.html": &fstest.MapFile{Data: []byte("<html>spa</html>")},
+	}
+
+	opts, closers := assembleOptions(context.Background(), serveDeps{
+		Namespace:        "default",
+		Apps:             appsSvc,
+		HTTPClient:       &http.Client{Timeout: 5 * time.Second},
+		AllowNonLoopback: true,
+		Capabilities:     caps,
+		QuietRegistry:    true,
+	}, dist)
+	t.Cleanup(func() {
+		for _, c := range closers {
+			_ = c()
+		}
+	})
+
+	srv := httptest.NewServer(server.NewRouter(opts))
+	t.Cleanup(srv.Close)
+
+	// Apps listed from env contract, enriched from the stub daprd, with a
+	// non-loopback Host accepted (aspire/container mode drops the loopback
+	// guard in favor of AllowNonLoopback).
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/apps/", nil)
+	require.NoError(t, err)
+	req.Host = "dashboard.internal:8080"
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	b, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	require.Equalf(t, http.StatusOK, res.StatusCode, "apps: %s", b)
+	body := string(b)
+	require.Contains(t, body, `"appId":"orders"`)
+	require.Contains(t, body, `"health":"healthy"`)
+	require.Contains(t, body, `"source":"aspire"`)
+
+	// Gated surfaces are absent: workflows via caps.Workflows=false,
+	// controlplane and logs are never mounted for aspire-mode wiring.
+	for _, path := range []string{"/api/controlplane/", "/api/workflows/", "/api/apps/orders/logs"} {
+		r, _ := httpGet(t, srv.URL+path)
+		require.Equalf(t, http.StatusNotFound, r.StatusCode, "%s", path)
+	}
+}

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -199,20 +199,35 @@ type storeEntry struct {
 	targets server.TargetResolver
 }
 
+// contractNamespaces invokes a static aspire scanner once and returns the
+// appID→namespace map from the parsed DEVDASHBOARD_APP_* env contract. The
+// scanner is a static, error-free closure over env parsed at startup, so this
+// costs nothing and never blocks; a scan error or empty contract yields nil
+// (every lookup then falls back to the global namespace).
+func contractNamespaces(scan discovery.Scanner) map[string]string {
+	results, err := scan()
+	if err != nil || len(results) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(results))
+	for _, r := range results {
+		if r.Namespace != "" {
+			m[r.AppID] = r.Namespace
+		}
+	}
+	return m
+}
+
 // buildStoreEntry assembles the per-store workflow service, remover, and target
 // resolver for an already-opened state store. It is the construction the old
 // newStoreBackend did inline; the connpool reuses it for each opened identity.
-func buildStoreEntry(st statestore.Store, namespace string, client *http.Client, apps discovery.Service) storeEntry {
-	// App-scoped workflow reads (Get/history and app-filtered List/Stats) honor
-	// the app's per-app namespace (aspire DEVDASHBOARD_APP_<i>_NAMESPACE); an
-	// unknown app or empty namespace falls back to the store namespace.
-	nsResolver := func(ctx context.Context, appID string) string {
-		inst, err := apps.Get(ctx, appID)
-		if err != nil {
-			return ""
-		}
-		return inst.Namespace
-	}
+// appNS is the static appID→namespace map from the aspire env contract (nil in
+// host mode): app-scoped workflow reads (Get/history and app-filtered
+// List/Stats) resolve their namespace from it by plain map lookup — never via
+// discovery, whose Get enriches with sidecar HTTP probes. A missing app or nil
+// map yields "" and falls back to the store namespace.
+func buildStoreEntry(st statestore.Store, namespace string, client *http.Client, apps discovery.Service, appNS map[string]string) storeEntry {
+	nsResolver := func(_ context.Context, appID string) string { return appNS[appID] }
 	svc := workflow.New(st, namespace, workflow.WithNamespaceResolver(nsResolver))
 	rem := workflow.NewRemover(client, st, namespace)
 	res := newTargetResolver(apps, svc)

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -165,12 +165,14 @@ func (r *targetResolver) Resolve(ctx context.Context, appID, instanceID string) 
 	var httpPort int
 	var daprBase string
 	var healthy bool
+	var namespace string
 
 	inst, err := r.apps.Get(ctx, appID)
 	if err == nil {
 		httpPort = inst.HTTPPort
 		daprBase = inst.DaprHTTPBaseURL
 		healthy = inst.Health == discovery.HealthHealthy
+		namespace = inst.Namespace // "" for host-scanned apps → global namespace
 	}
 	// If apps.Get failed, continue with httpPort=0, healthy=false (force path only).
 
@@ -186,6 +188,7 @@ func (r *targetResolver) Resolve(ctx context.Context, appID, instanceID string) 
 		HTTPPort:        httpPort,
 		DaprHTTPBaseURL: daprBase,
 		Healthy:         healthy,
+		Namespace:       namespace,
 	}, nil
 }
 
@@ -200,7 +203,17 @@ type storeEntry struct {
 // resolver for an already-opened state store. It is the construction the old
 // newStoreBackend did inline; the connpool reuses it for each opened identity.
 func buildStoreEntry(st statestore.Store, namespace string, client *http.Client, apps discovery.Service) storeEntry {
-	svc := workflow.New(st, namespace)
+	// App-scoped workflow reads (Get/history and app-filtered List/Stats) honor
+	// the app's per-app namespace (aspire DEVDASHBOARD_APP_<i>_NAMESPACE); an
+	// unknown app or empty namespace falls back to the store namespace.
+	nsResolver := func(ctx context.Context, appID string) string {
+		inst, err := apps.Get(ctx, appID)
+		if err != nil {
+			return ""
+		}
+		return inst.Namespace
+	}
+	svc := workflow.New(st, namespace, workflow.WithNamespaceResolver(nsResolver))
 	rem := workflow.NewRemover(client, st, namespace)
 	res := newTargetResolver(apps, svc)
 	return storeEntry{svc: svc, rem: rem, targets: res}

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -155,8 +155,10 @@ func newTargetResolver(apps discovery.Service, wf workflow.Service) *targetResol
 	return &targetResolver{apps: apps, wf: wf}
 }
 
-// Resolve satisfies server.TargetResolver. It fetches the instance's HTTP port
-// and health from discovery, and its current status from the workflow service.
+// Resolve satisfies server.TargetResolver. It fetches the instance's HTTP port,
+// its DaprHTTPBaseURL, and health from discovery, and its current status from
+// the workflow service. The DaprHTTPBaseURL is carried through so aspire apps
+// (addressed by base URL, not a localhost port) use HTTP terminate/purge.
 // If discovery fails, the target is returned with HTTPPort=0 and Healthy=false
 // (allowing force-delete). If the workflow lookup fails, the error is returned.
 func (r *targetResolver) Resolve(ctx context.Context, appID, instanceID string) (workflow.RemoveTarget, error) {

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -161,11 +161,13 @@ func newTargetResolver(apps discovery.Service, wf workflow.Service) *targetResol
 // (allowing force-delete). If the workflow lookup fails, the error is returned.
 func (r *targetResolver) Resolve(ctx context.Context, appID, instanceID string) (workflow.RemoveTarget, error) {
 	var httpPort int
+	var daprBase string
 	var healthy bool
 
 	inst, err := r.apps.Get(ctx, appID)
 	if err == nil {
 		httpPort = inst.HTTPPort
+		daprBase = inst.DaprHTTPBaseURL
 		healthy = inst.Health == discovery.HealthHealthy
 	}
 	// If apps.Get failed, continue with httpPort=0, healthy=false (force path only).
@@ -176,11 +178,12 @@ func (r *targetResolver) Resolve(ctx context.Context, appID, instanceID string) 
 	}
 
 	return workflow.RemoveTarget{
-		AppID:      appID,
-		InstanceID: instanceID,
-		Status:     ex.Status,
-		HTTPPort:   httpPort,
-		Healthy:    healthy,
+		AppID:           appID,
+		InstanceID:      instanceID,
+		Status:          ex.Status,
+		HTTPPort:        httpPort,
+		DaprHTTPBaseURL: daprBase,
+		Healthy:         healthy,
 	}, nil
 }
 

--- a/cmd/workflow_test.go
+++ b/cmd/workflow_test.go
@@ -63,6 +63,24 @@ func TestTargetResolver(t *testing.T) {
 		require.True(t, got.Healthy)
 	})
 
+	t.Run("populates namespace from the instance", func(t *testing.T) {
+		disc := fakeDiscovery{inst: discovery.Instance{AppID: "order", HTTPPort: 3500, Namespace: "prod", Health: discovery.HealthHealthy}}
+		wf := fakeWorkflowSvc{ex: workflow.Execution{ExecutionSummary: workflow.ExecutionSummary{AppID: "order", InstanceID: "inst", Status: workflow.StatusRunning}}}
+		r := newTargetResolver(disc, wf)
+		got, err := r.Resolve(ctx, "order", "inst")
+		require.NoError(t, err)
+		require.Equal(t, "prod", got.Namespace)
+	})
+
+	t.Run("leaves namespace empty for host-scanned apps", func(t *testing.T) {
+		disc := fakeDiscovery{inst: discovery.Instance{AppID: "order", HTTPPort: 3500, Namespace: "", Health: discovery.HealthHealthy}}
+		wf := fakeWorkflowSvc{ex: workflow.Execution{ExecutionSummary: workflow.ExecutionSummary{AppID: "order", InstanceID: "inst", Status: workflow.StatusRunning}}}
+		r := newTargetResolver(disc, wf)
+		got, err := r.Resolve(ctx, "order", "inst")
+		require.NoError(t, err)
+		require.Equal(t, "", got.Namespace)
+	})
+
 	t.Run("discovery Get fails — still succeeds with HTTPPort=0 Healthy=false", func(t *testing.T) {
 		disc := fakeDiscovery{err: errors.New("not found")}
 		wf := fakeWorkflowSvc{ex: workflow.Execution{ExecutionSummary: workflow.ExecutionSummary{AppID: "order", InstanceID: "inst", Status: workflow.StatusCompleted}}}

--- a/cmd/workflow_test.go
+++ b/cmd/workflow_test.go
@@ -5,6 +5,8 @@ package cmd
 import (
 	"context"
 	"errors"
+	"net/http"
+	"sync/atomic"
 	"testing"
 
 	"github.com/diagridio/dev-dashboard/pkg/discovery"
@@ -99,6 +101,73 @@ func TestTargetResolver(t *testing.T) {
 		_, err := r.Resolve(ctx, "order", "inst")
 		require.Error(t, err)
 	})
+}
+
+// --- per-app namespace: static contract map, no sidecar probes ---
+
+func TestContractNamespaces(t *testing.T) {
+	env := map[string]string{
+		"DEVDASHBOARD_APP_COUNT":       "2",
+		"DEVDASHBOARD_APP_0_ID":        "orders",
+		"DEVDASHBOARD_APP_0_DAPR_HTTP": "http://orders-dapr:3500",
+		"DEVDASHBOARD_APP_0_NAMESPACE": "prod",
+		"DEVDASHBOARD_APP_1_ID":        "billing",
+		"DEVDASHBOARD_APP_1_DAPR_HTTP": "http://billing-dapr:3500",
+	}
+	scan, err := discovery.NewAspireScanner(func(k string) string { return env[k] })
+	require.NoError(t, err)
+
+	m := contractNamespaces(scan)
+	require.Equal(t, "prod", m["orders"])
+	require.Equal(t, "default", m["billing"], "unset per-app namespace falls back to the contract default")
+	require.Empty(t, m["unknown"], "unknown app resolves to empty (global namespace)")
+}
+
+// patternKeysStore is a statestore.Store recording the LIKE patterns passed to
+// Keys; all reads return empty.
+type patternKeysStore struct{ patterns []string }
+
+func (s *patternKeysStore) Keys(_ context.Context, pattern, _ string, _ int) ([]string, string, error) {
+	s.patterns = append(s.patterns, pattern)
+	return nil, "", nil
+}
+func (s *patternKeysStore) Get(context.Context, string) ([]byte, error) { return nil, nil }
+func (s *patternKeysStore) BulkGet(context.Context, []string) (map[string][]byte, error) {
+	return nil, nil
+}
+func (s *patternKeysStore) Delete(context.Context, string) error      { return nil }
+func (s *patternKeysStore) Set(context.Context, string, []byte) error { return nil }
+func (s *patternKeysStore) Close() error                              { return nil }
+
+// countingApps is a discovery.Service double counting Get calls (each real Get
+// costs two sidecar HTTP probes via enrich).
+type countingApps struct {
+	fakeDiscovery
+	gets int32
+}
+
+func (c *countingApps) Get(ctx context.Context, key string) (discovery.Instance, error) {
+	atomic.AddInt32(&c.gets, 1)
+	return c.fakeDiscovery.Get(ctx, key)
+}
+
+func TestBuildStoreEntryNamespaceResolverIsStatic(t *testing.T) {
+	st := &patternKeysStore{}
+	apps := &countingApps{}
+	entry := buildStoreEntry(st, "default", &http.Client{}, apps, map[string]string{"orders": "prod"})
+
+	// App-scoped Get resolves the namespace from the static contract map...
+	_, err := entry.svc.Get(context.Background(), "orders", "inst-1")
+	require.ErrorIs(t, err, workflow.ErrNotFound) // store is empty; only the pattern matters
+	require.Contains(t, st.patterns, statestore.InstanceKeyPattern("prod", "orders", "inst-1"))
+
+	// ...an unmapped app falls back to the store namespace...
+	_, err = entry.svc.Get(context.Background(), "other", "inst-2")
+	require.ErrorIs(t, err, workflow.ErrNotFound)
+	require.Contains(t, st.patterns, statestore.InstanceKeyPattern("default", "other", "inst-2"))
+
+	// ...and neither resolution touched discovery (zero sidecar probes).
+	require.Zero(t, atomic.LoadInt32(&apps.gets), "namespace resolution must not call apps.Get")
 }
 
 func TestStoreRegistry_StoresReturnsActiveOnly_FirstFallback(t *testing.T) {

--- a/docs/superpowers/plans/2026-07-11-aspire-container-mode.md
+++ b/docs/superpowers/plans/2026-07-11-aspire-container-mode.md
@@ -1,0 +1,1913 @@
+# Aspire Container Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an `aspire` mode to the dashboard (env-contract app discovery, container serving posture), plus a published GHCR container image, per the approved spec `docs/superpowers/specs/2026-07-11-aspire-container-mode-design.md`.
+
+**Architecture:** A single-value mode (`--mode` flag / `DEVDASHBOARD_MODE` env; unset = today's full scan) gates behavior at existing seams: a new static `AspireScanner` reads `DEVDASHBOARD_APP_*` vars; a `DaprHTTPBaseURL` field threads through health/metadata/workflow-removal in place of hardcoded `127.0.0.1:<port>`; the server gains a same-origin guard variant and a `Capabilities` struct that gates route registration and is injected into the SPA. A multi-stage Dockerfile + goreleaser `dockers` block publish `ghcr.io/diagridio/dev-dashboard`.
+
+**Tech Stack:** Go 1.26 (cobra, chi), React 19 + Vite + vitest, goreleaser, distroless.
+
+## Global Constraints
+
+- Env var prefix is `DEVDASHBOARD_` exactly (matches existing `DEVDASHBOARD_TELEMETRY_OPTOUT`).
+- Precedence everywhere: **flag > env > mode default**.
+- Aspire-mode defaults: port `8080`, bind `0.0.0.0`. Mode-unset defaults: port `9090`, bind `127.0.0.1`.
+- Image name: `ghcr.io/diagridio/dev-dashboard`. Final base: `gcr.io/distroless/static:nonroot`. `ENV DEVDASHBOARD_MODE=aspire` baked in.
+- Go tests run with `-tags unit` (`make test-go`); match the `//go:build` header of sibling `*_test.go` files in the same package when creating new test files.
+- **vitest does not typecheck.** After ANY `.ts`/`.tsx` change (test files included) run `cd web && npm run build` (tsc -b) before claiming success.
+- `gofmt -l .` must be clean and `go vet -tags unit ./...` must pass before every commit (`make lint-go`).
+- Commit messages follow repo convention: `feat(scope): ...`, `fix(scope): ...`, `docs: ...`, `test(scope): ...`.
+- Working directory: `/Users/marcduiker/dev/diagrid/dev-dashboard/.claude/worktrees/aspire-container-mode` (branch `worktree-aspire-container-mode`).
+- Unknown `--mode`/`DEVDASHBOARD_MODE` values, and malformed `DEVDASHBOARD_APP_*` contracts (in aspire mode, or present-but-malformed in unset mode), exit non-zero at startup naming the exact variable.
+
+---
+
+### Task 1: Mode type and resolution
+
+**Files:**
+- Create: `cmd/mode.go`
+- Test: `cmd/mode_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `type Mode string`, `const ModeDefault Mode = ""`, `const ModeAspire Mode = "aspire"`, `func resolveMode(flagValue string, getenv func(string) string) (Mode, error)`. Task 8 calls `resolveMode` in the cobra RunE.
+
+- [ ] **Step 1: Write the failing test**
+
+Check the build-tag header of `cmd/root_test.go` and copy it (e.g. `//go:build unit`) to the top of the new test file if present.
+
+```go
+package cmd
+
+import "testing"
+
+func TestResolveMode(t *testing.T) {
+	env := func(vals map[string]string) func(string) string {
+		return func(k string) string { return vals[k] }
+	}
+	tests := []struct {
+		name    string
+		flag    string
+		env     map[string]string
+		want    Mode
+		wantErr bool
+	}{
+		{name: "unset everywhere is default", flag: "", env: nil, want: ModeDefault},
+		{name: "flag aspire", flag: "aspire", env: nil, want: ModeAspire},
+		{name: "env aspire", flag: "", env: map[string]string{"DEVDASHBOARD_MODE": "aspire"}, want: ModeAspire},
+		{name: "flag wins over env", flag: "aspire", env: map[string]string{"DEVDASHBOARD_MODE": "bogus"}, want: ModeAspire},
+		{name: "unknown flag value errors", flag: "compose", wantErr: true},
+		{name: "unknown env value errors", env: map[string]string{"DEVDASHBOARD_MODE": "dapr"}, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveMode(tc.flag, env(tc.env))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+```
+
+Note: `compose` and `dapr` are *reserved future* values per the spec — they must error today.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -tags unit ./cmd/ -run TestResolveMode -v`
+Expected: FAIL — `undefined: resolveMode` (compile error).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// cmd/mode.go
+package cmd
+
+import "fmt"
+
+// Mode selects the dashboard's discovery and serving posture. ModeDefault
+// (the zero value, mode unset) is the complete scan across all discovery
+// sources with today's host behavior; ModeAspire restricts discovery to the
+// DEVDASHBOARD_APP_* env contract and switches to container posture.
+// "dapr" and "compose" are reserved for future single-source filter modes.
+type Mode string
+
+const (
+	ModeDefault Mode = ""
+	ModeAspire  Mode = "aspire"
+)
+
+// resolveMode picks the mode from the --mode flag value and the
+// DEVDASHBOARD_MODE env var (flag wins; both empty means ModeDefault).
+func resolveMode(flagValue string, getenv func(string) string) (Mode, error) {
+	v := flagValue
+	if v == "" {
+		v = getenv("DEVDASHBOARD_MODE")
+	}
+	switch Mode(v) {
+	case ModeDefault, ModeAspire:
+		return Mode(v), nil
+	}
+	return ModeDefault, fmt.Errorf("unknown mode %q: supported values are \"aspire\", or unset for the complete scan", v)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -tags unit ./cmd/ -run TestResolveMode -v`
+Expected: PASS (all subtests).
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+gofmt -l . && go vet -tags unit ./...
+git add cmd/mode.go cmd/mode_test.go
+git commit -m "feat(cmd): mode type and DEVDASHBOARD_MODE resolution"
+```
+
+---
+
+### Task 2: AspireScanner and new ScanResult fields
+
+**Files:**
+- Create: `pkg/discovery/scan_aspire.go`
+- Modify: `pkg/discovery/service.go` (ScanResult struct, ~line 25-59; Source consts ~line 16-19)
+- Test: `pkg/discovery/scan_aspire_test.go`
+
+**Interfaces:**
+- Consumes: `discovery.Scanner`, `discovery.ScanResult` (existing).
+- Produces: `const SourceAspire = "aspire"`; `func AspireContractPresent(getenv func(string) string) bool`; `func NewAspireScanner(getenv func(string) string) (Scanner, error)`; new `ScanResult` fields `DaprHTTPBaseURL string`, `Namespace string`, `Label string`. Tasks 3 and 8 consume all of these.
+
+- [ ] **Step 1: Add the ScanResult fields**
+
+In `pkg/discovery/service.go`, add `SourceAspire` to the consts block:
+
+```go
+const (
+	SourceStandalone = "standalone"
+	SourceCompose    = "compose"
+	// SourceAspire marks apps injected via the DEVDASHBOARD_APP_* env
+	// contract (aspire mode, or mode-unset with the contract present).
+	SourceAspire = "aspire"
+)
+```
+
+And add to the `ScanResult` struct, after the `SidecarReachable` field:
+
+```go
+	// DaprHTTPBaseURL, when set (aspire source), replaces
+	// http://127.0.0.1:<HTTPPort> as the daprd HTTP endpoint for health,
+	// metadata, and workflow calls.
+	DaprHTTPBaseURL string
+	// Namespace and Label come from the Aspire env contract ("" for other
+	// sources). Label is the orchestrator's display name for the app.
+	Namespace string
+	Label     string
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Match the build-tag header of `pkg/discovery/health_test.go`. Create `pkg/discovery/scan_aspire_test.go`:
+
+```go
+package discovery
+
+import (
+	"strings"
+	"testing"
+)
+
+func envFunc(vals map[string]string) func(string) string {
+	return func(k string) string { return vals[k] }
+}
+
+func TestAspireContractPresent(t *testing.T) {
+	if AspireContractPresent(envFunc(nil)) {
+		t.Fatal("empty env: want false")
+	}
+	if !AspireContractPresent(envFunc(map[string]string{"DEVDASHBOARD_APP_COUNT": "0"})) {
+		t.Fatal("count set: want true")
+	}
+}
+
+func TestNewAspireScannerHappyPath(t *testing.T) {
+	scan, err := NewAspireScanner(envFunc(map[string]string{
+		"DEVDASHBOARD_APP_COUNT":       "2",
+		"DEVDASHBOARD_APP_0_ID":        "orders",
+		"DEVDASHBOARD_APP_0_DAPR_HTTP": "http://orders-dapr:3500/",
+		"DEVDASHBOARD_APP_1_ID":        "payments",
+		"DEVDASHBOARD_APP_1_DAPR_HTTP": "http://payments-dapr:3501",
+		"DEVDASHBOARD_APP_1_NAMESPACE": "prod",
+		"DEVDASHBOARD_APP_1_LABEL":     "Payments API",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d results, want 2", len(got))
+	}
+	r0, r1 := got[0], got[1]
+	if r0.AppID != "orders" || r0.DaprHTTPBaseURL != "http://orders-dapr:3500" {
+		t.Fatalf("r0: %+v (trailing slash must be trimmed)", r0)
+	}
+	if r0.Namespace != "default" || r0.Label != "orders" {
+		t.Fatalf("r0 defaults: ns=%q label=%q", r0.Namespace, r0.Label)
+	}
+	if r0.Source != SourceAspire || !r0.SidecarReachable {
+		t.Fatalf("r0 source/reachable: %+v", r0)
+	}
+	if r1.Namespace != "prod" || r1.Label != "Payments API" {
+		t.Fatalf("r1 overrides: ns=%q label=%q", r1.Namespace, r1.Label)
+	}
+}
+
+func TestNewAspireScannerNamespaceDefault(t *testing.T) {
+	scan, err := NewAspireScanner(envFunc(map[string]string{
+		"DEVDASHBOARD_NAMESPACE":       "team-a",
+		"DEVDASHBOARD_APP_COUNT":       "1",
+		"DEVDASHBOARD_APP_0_ID":        "a",
+		"DEVDASHBOARD_APP_0_DAPR_HTTP": "http://a:3500",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, _ := scan()
+	if got[0].Namespace != "team-a" {
+		t.Fatalf("namespace: got %q want team-a", got[0].Namespace)
+	}
+}
+
+func TestNewAspireScannerCountZero(t *testing.T) {
+	scan, err := NewAspireScanner(envFunc(map[string]string{"DEVDASHBOARD_APP_COUNT": "0"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := scan()
+	if err != nil || len(got) != 0 {
+		t.Fatalf("want empty scan, got %v / %v", got, err)
+	}
+}
+
+func TestNewAspireScannerErrorsNameTheVariable(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		wantVar string
+	}{
+		{"missing count", map[string]string{}, "DEVDASHBOARD_APP_COUNT"},
+		{"non-numeric count", map[string]string{"DEVDASHBOARD_APP_COUNT": "two"}, "DEVDASHBOARD_APP_COUNT"},
+		{"negative count", map[string]string{"DEVDASHBOARD_APP_COUNT": "-1"}, "DEVDASHBOARD_APP_COUNT"},
+		{"missing id", map[string]string{
+			"DEVDASHBOARD_APP_COUNT":       "1",
+			"DEVDASHBOARD_APP_0_DAPR_HTTP": "http://a:3500",
+		}, "DEVDASHBOARD_APP_0_ID"},
+		{"missing url", map[string]string{
+			"DEVDASHBOARD_APP_COUNT": "1",
+			"DEVDASHBOARD_APP_0_ID":  "a",
+		}, "DEVDASHBOARD_APP_0_DAPR_HTTP"},
+		{"bad url scheme", map[string]string{
+			"DEVDASHBOARD_APP_COUNT":       "1",
+			"DEVDASHBOARD_APP_0_ID":        "a",
+			"DEVDASHBOARD_APP_0_DAPR_HTTP": "ftp://a:3500",
+		}, "DEVDASHBOARD_APP_0_DAPR_HTTP"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewAspireScanner(envFunc(tc.env))
+			if err == nil {
+				t.Fatal("want error")
+			}
+			if !strings.Contains(err.Error(), tc.wantVar) {
+				t.Fatalf("error %q does not name %s", err, tc.wantVar)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test -tags unit ./pkg/discovery/ -run "TestAspire|TestNewAspire" -v`
+Expected: FAIL — `undefined: AspireContractPresent`, `undefined: NewAspireScanner`.
+
+- [ ] **Step 4: Write the implementation**
+
+```go
+// pkg/discovery/scan_aspire.go
+package discovery
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// AspireContractPresent reports whether the DEVDASHBOARD_APP_* env contract
+// is set at all (anchor variable: DEVDASHBOARD_APP_COUNT). Used with mode
+// unset to decide whether the aspire source joins the merge.
+func AspireContractPresent(getenv func(string) string) bool {
+	return strings.TrimSpace(getenv("DEVDASHBOARD_APP_COUNT")) != ""
+}
+
+// NewAspireScanner parses the DEVDASHBOARD_APP_* env contract eagerly and
+// returns a static Scanner over the parsed apps. Malformed contracts fail
+// here — at startup — with an error naming the exact variable, never at scan
+// time. The returned scanner is static: env is read once; liveness comes
+// from the discovery service's per-poll health/metadata probes.
+func NewAspireScanner(getenv func(string) string) (Scanner, error) {
+	countRaw := strings.TrimSpace(getenv("DEVDASHBOARD_APP_COUNT"))
+	count, err := strconv.Atoi(countRaw)
+	if err != nil || count < 0 {
+		return nil, fmt.Errorf("DEVDASHBOARD_APP_COUNT: expected a non-negative integer, got %q", countRaw)
+	}
+	defaultNS := strings.TrimSpace(getenv("DEVDASHBOARD_NAMESPACE"))
+	if defaultNS == "" {
+		defaultNS = "default"
+	}
+	results := make([]ScanResult, 0, count)
+	for i := 0; i < count; i++ {
+		idKey := fmt.Sprintf("DEVDASHBOARD_APP_%d_ID", i)
+		urlKey := fmt.Sprintf("DEVDASHBOARD_APP_%d_DAPR_HTTP", i)
+		id := strings.TrimSpace(getenv(idKey))
+		if id == "" {
+			return nil, fmt.Errorf("%s: required but empty", idKey)
+		}
+		raw := strings.TrimSpace(getenv(urlKey))
+		u, err := url.Parse(raw)
+		if raw == "" || err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			return nil, fmt.Errorf("%s: expected an http(s) base URL, got %q", urlKey, raw)
+		}
+		ns := strings.TrimSpace(getenv(fmt.Sprintf("DEVDASHBOARD_APP_%d_NAMESPACE", i)))
+		if ns == "" {
+			ns = defaultNS
+		}
+		label := strings.TrimSpace(getenv(fmt.Sprintf("DEVDASHBOARD_APP_%d_LABEL", i)))
+		if label == "" {
+			label = id
+		}
+		results = append(results, ScanResult{
+			AppID:            id,
+			DaprHTTPBaseURL:  strings.TrimRight(raw, "/"),
+			Namespace:        ns,
+			Label:            label,
+			Source:           SourceAspire,
+			SidecarReachable: true,
+		})
+	}
+	return func() ([]ScanResult, error) {
+		out := make([]ScanResult, len(results))
+		copy(out, results)
+		return out, nil
+	}, nil
+}
+```
+
+- [ ] **Step 5: Run tests, lint, commit**
+
+Run: `go test -tags unit ./pkg/discovery/ -v -run "Aspire"` → PASS. Then the full package: `go test -tags unit ./pkg/discovery/` → PASS (no regressions from the struct change).
+
+```bash
+gofmt -l . && go vet -tags unit ./...
+git add pkg/discovery/scan_aspire.go pkg/discovery/scan_aspire_test.go pkg/discovery/service.go
+git commit -m "feat(discovery): AspireScanner reads DEVDASHBOARD_APP_* env contract"
+```
+
+---
+
+### Task 3: Base-URL threading through health, metadata, and enrich
+
+**Files:**
+- Modify: `pkg/discovery/health.go` (whole file), `pkg/discovery/metadata.go:88-91`, `pkg/discovery/service.go` (Instance passthrough + enrich, ~lines 170-294), `pkg/discovery/types.go` (Instance struct)
+- Test: `pkg/discovery/health_test.go`, `pkg/discovery/metadata_test.go` (update signatures), `pkg/discovery/service_test.go` (add aspire enrich case)
+
+**Interfaces:**
+- Consumes: `ScanResult.DaprHTTPBaseURL` (Task 2).
+- Produces: `func CheckHealth(ctx context.Context, client *http.Client, baseURL string) Health`; `func FetchMetadata(ctx context.Context, client *http.Client, baseURL string) (Metadata, error)`; `func sidecarBaseURL(base string, httpPort int) string`; new `Instance` fields `DaprHTTPBaseURL string` (json `daprHttpBaseUrl,omitempty`), `Namespace string` (json `namespace,omitempty`), `Label string` (json `label,omitempty`). Task 4 reads `Instance.DaprHTTPBaseURL`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `pkg/discovery/health_test.go` and `metadata_test.go`, the existing tests construct `httptest.Server`s and pass the port. Update them to pass `srv.URL` directly (the new signature), and add one URL-shape assertion:
+
+```go
+func TestSidecarBaseURL(t *testing.T) {
+	if got := sidecarBaseURL("", 3500); got != "http://127.0.0.1:3500" {
+		t.Fatalf("port fallback: %q", got)
+	}
+	if got := sidecarBaseURL("http://orders-dapr:3500", 0); got != "http://orders-dapr:3500" {
+		t.Fatalf("base passthrough: %q", got)
+	}
+	if got := sidecarBaseURL("http://orders-dapr:3500/", 0); got != "http://orders-dapr:3500" {
+		t.Fatalf("trailing slash: %q", got)
+	}
+}
+```
+
+In `service_test.go`, add a case: an aspire-source `ScanResult` with `DaprHTTPBaseURL` pointing at a stub daprd (`httptest.Server` responding 200 to `/v1.0/healthz` and valid JSON to `/v1.0/metadata`) enriches to `Health == HealthHealthy`, `MetadataOK == true`, `IsAspire == true`, and passes through `DaprHTTPBaseURL`/`Namespace`/`Label`. Follow the existing fixture style in that file (bare `service{scan: ..., client: srv.Client()}` structs).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit ./pkg/discovery/`
+Expected: FAIL — compile errors on `CheckHealth`/`FetchMetadata` argument types and `undefined: sidecarBaseURL`.
+
+- [ ] **Step 3: Implement**
+
+`pkg/discovery/health.go`:
+
+```go
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// sidecarBaseURL resolves the daprd HTTP endpoint: an explicit base URL
+// (aspire contract) wins; otherwise the historical loopback-port form.
+func sidecarBaseURL(base string, httpPort int) string {
+	if base != "" {
+		return strings.TrimRight(base, "/")
+	}
+	return fmt.Sprintf("http://127.0.0.1:%d", httpPort)
+}
+
+// CheckHealth probes a sidecar's /v1.0/healthz endpoint at baseURL.
+func CheckHealth(ctx context.Context, client *http.Client, baseURL string) Health {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v1.0/healthz", nil)
+	if err != nil {
+		return HealthUnknown
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return HealthUnhealthy
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent {
+		return HealthHealthy
+	}
+	return HealthUnhealthy
+}
+```
+
+`pkg/discovery/metadata.go` — `FetchMetadata` head becomes:
+
+```go
+// FetchMetadata queries a sidecar's /v1.0/metadata endpoint at baseURL.
+func FetchMetadata(ctx context.Context, client *http.Client, baseURL string) (Metadata, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v1.0/metadata", nil)
+```
+
+(rest of the function unchanged).
+
+`pkg/discovery/types.go` — add to `Instance` after `SidecarReachable`:
+
+```go
+	// DaprHTTPBaseURL is the daprd HTTP endpoint for aspire-source apps
+	// ("" otherwise; consumers fall back to 127.0.0.1:httpPort).
+	DaprHTTPBaseURL string `json:"daprHttpBaseUrl,omitempty"`
+	Namespace       string `json:"namespace,omitempty"`
+	Label           string `json:"label,omitempty"`
+```
+
+`pkg/discovery/service.go` `enrich` — three changes:
+
+1. In the `Instance` literal (~line 171), add: `DaprHTTPBaseURL: r.DaprHTTPBaseURL, Namespace: r.Namespace, Label: r.Label,`
+2. After the `if in.Source == "" {...}` block (~line 197), add:
+
+```go
+	if in.Source == SourceAspire {
+		in.IsAspire = true
+	}
+```
+
+3. Replace the two probe call sites (~lines 222-223):
+
+```go
+	base := sidecarBaseURL(r.DaprHTTPBaseURL, r.HTTPPort)
+	in.Health = CheckHealth(ctx, s.client, base)
+	md, err := FetchMetadata(ctx, s.client, base)
+```
+
+4. Directly after the `if in.Source == SourceCompose { ... return in }` early-return block (~line 267), add a matching aspire early-return so host-process probing (PIDs, lsof, orphan detection) never runs for env-contract apps:
+
+```go
+	if in.Source == SourceAspire {
+		// Env-contract apps are containers/executables managed by Aspire:
+		// host PIDs, stdout files, and orphan semantics don't apply.
+		if md.RunTemplate != "" {
+			in.RunTemplate = md.RunTemplate
+		}
+		return in
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -tags unit ./pkg/discovery/` → PASS. Then `go build ./...` — expect a compile failure in `pkg/server` or `cmd` **only if** something else calls `CheckHealth`/`FetchMetadata`; run `grep -rn "CheckHealth(\|FetchMetadata(" --include="*.go" cmd pkg | grep -v _test | grep -v "pkg/discovery/"` — expected: no hits outside `pkg/discovery` (verified at plan time). If a hit appears, update that call site to pass `sidecarBaseURL(inst.DaprHTTPBaseURL, inst.HTTPPort)`.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+gofmt -l . && go vet -tags unit ./... && go test -tags unit ./...
+git add pkg/discovery/
+git commit -m "feat(discovery): thread daprd base URL through health/metadata enrichment"
+```
+
+---
+
+### Task 4: Workflow remover base URL
+
+**Files:**
+- Modify: `pkg/workflow/remove.go` (RemoveTarget struct ~line 16, Remove ~line 44, terminate/purge/post ~lines 84-107), `cmd/workflow.go:162-185` (targetResolver.Resolve)
+- Test: `pkg/workflow/remove_test.go` (or the file containing existing Remover tests — check `ls pkg/workflow/*_test.go`), `cmd/workflow_test.go`
+
+**Interfaces:**
+- Consumes: `Instance.DaprHTTPBaseURL` (Task 3).
+- Produces: `RemoveTarget.DaprHTTPBaseURL string`. No signature changes to `Remover.Remove`/`RemoveMany`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the workflow remover tests (match existing test style — they use `httptest.Server` for the daprd endpoints):
+
+```go
+func TestRemoverUsesBaseURL(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	r := NewRemover(srv.Client(), nil, "default")
+	res := r.Remove(context.Background(), RemoveTarget{
+		AppID:           "orders",
+		InstanceID:      "wf-1",
+		Status:          StatusCompleted, // terminal → MechPurge (single POST)
+		DaprHTTPBaseURL: srv.URL,
+		Healthy:         true,
+	}, false)
+	if !res.OK {
+		t.Fatalf("remove failed: %+v", res)
+	}
+	if want := "/v1.0-beta1/workflows/dapr/wf-1/purge"; gotPath != want {
+		t.Fatalf("path %q want %q", gotPath, want)
+	}
+}
+
+func TestRemoverBaseURLCountsAsReachable(t *testing.T) {
+	// HTTPPort 0 but a base URL present must still select the HTTP mechanism,
+	// not force-delete.
+	if got := SelectMechanism(StatusCompleted, true, false); got != MechPurge {
+		t.Fatalf("sanity: %v", got)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	r := NewRemover(srv.Client(), nil, "default")
+	res := r.Remove(context.Background(), RemoveTarget{
+		AppID: "a", InstanceID: "i", Status: StatusCompleted,
+		HTTPPort: 0, DaprHTTPBaseURL: srv.URL, Healthy: true,
+	}, false)
+	if !res.OK || res.Mechanism != MechPurge {
+		t.Fatalf("want OK purge, got %+v", res)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit ./pkg/workflow/ -run TestRemover -v`
+Expected: FAIL — `unknown field DaprHTTPBaseURL`.
+
+- [ ] **Step 3: Implement**
+
+`pkg/workflow/remove.go`:
+
+```go
+type RemoveTarget struct {
+	AppID      string
+	InstanceID string
+	Status     Status
+	HTTPPort   int
+	// DaprHTTPBaseURL, when set (aspire-discovered apps), replaces
+	// http://127.0.0.1:<HTTPPort> for the terminate/purge calls.
+	DaprHTTPBaseURL string
+	Healthy         bool
+}
+```
+
+In `Remove`, replace the mechanism selection line:
+
+```go
+	reachable := t.Healthy && (t.HTTPPort > 0 || t.DaprHTTPBaseURL != "")
+	mech := SelectMechanism(t.Status, reachable, force)
+```
+
+Replace `terminate`, `purge`, and `post`:
+
+```go
+func (r *Remover) terminate(ctx context.Context, t RemoveTarget) error {
+	return r.post(ctx, t, "terminate")
+}
+
+func (r *Remover) purge(ctx context.Context, t RemoveTarget) error {
+	return r.post(ctx, t, "purge")
+}
+
+func (r *Remover) post(ctx context.Context, t RemoveTarget, action string) error {
+	base := t.DaprHTTPBaseURL
+	if base == "" {
+		base = fmt.Sprintf("http://127.0.0.1:%d", t.HTTPPort)
+	}
+	u := fmt.Sprintf("%s/v1.0-beta1/workflows/%s/%s/%s", base, WorkflowComponent, t.InstanceID, action)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
+	...
+```
+
+(the request/response handling below the URL line is unchanged).
+
+`cmd/workflow.go` `targetResolver.Resolve` — capture and pass the base URL:
+
+```go
+	var httpPort int
+	var daprBase string
+	var healthy bool
+
+	inst, err := r.apps.Get(ctx, appID)
+	if err == nil {
+		httpPort = inst.HTTPPort
+		daprBase = inst.DaprHTTPBaseURL
+		healthy = inst.Health == discovery.HealthHealthy
+	}
+	...
+	return workflow.RemoveTarget{
+		AppID:           appID,
+		InstanceID:      instanceID,
+		Status:          ex.Status,
+		HTTPPort:        httpPort,
+		DaprHTTPBaseURL: daprBase,
+		Healthy:         healthy,
+	}, nil
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -tags unit ./pkg/workflow/ ./cmd/` → PASS.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+gofmt -l . && go vet -tags unit ./...
+git add pkg/workflow/ cmd/workflow.go
+git commit -m "feat(workflow): terminate/purge via daprd base URL for aspire apps"
+```
+
+---
+
+### Task 5: Same-origin request guard
+
+**Files:**
+- Modify: `pkg/server/middleware.go` (whole file), `pkg/server/server.go` (Options + NewRouter, lines 23-51)
+- Test: `pkg/server/middleware_test.go`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `func requestGuard(allowAnyHost bool) func(http.Handler) http.Handler` (replaces `localhostGuard`); `Options.AllowNonLoopback bool`. Task 8 sets `AllowNonLoopback` in aspire mode.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `pkg/server/middleware_test.go` (keep all existing localhostGuard cases — they now exercise `requestGuard(false)`; rename references):
+
+```go
+func TestRequestGuardAllowAnyHost(t *testing.T) {
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	h := requestGuard(true)(ok)
+
+	tests := []struct {
+		name   string
+		method string
+		host   string
+		origin string
+		want   int
+	}{
+		{"non-loopback host allowed", http.MethodGet, "dashboard.example:8080", "", http.StatusOK},
+		{"proxy host allowed", http.MethodGet, "diagrid-dashboard.localhost", "", http.StatusOK},
+		{"mutating same-origin allowed", http.MethodPost, "dash.local:8080", "http://dash.local:8080", http.StatusOK},
+		{"mutating no-origin allowed", http.MethodPost, "dash.local:8080", "", http.StatusOK},
+		{"mutating cross-origin forbidden", http.MethodPost, "dash.local:8080", "http://evil.example", http.StatusForbidden},
+		{"mutating origin port mismatch forbidden", http.MethodPost, "dash.local:8080", "http://dash.local:9999", http.StatusForbidden},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "/api/health", nil)
+			req.Host = tc.host
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("got %d want %d", rec.Code, tc.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit ./pkg/server/ -run TestRequestGuard -v`
+Expected: FAIL — `undefined: requestGuard`.
+
+- [ ] **Step 3: Implement**
+
+Replace `localhostGuard` in `pkg/server/middleware.go`:
+
+```go
+// requestGuard hardens the server against browser-borne attacks. Two modes:
+//
+// allowAnyHost=false (loopback bind, the host-mode default):
+//   - DNS rebinding: every request must carry a loopback Host header.
+//   - CSRF: mutating requests with an Origin header must originate from a
+//     loopback origin on any port (the Vite dev server has its own port).
+//
+// allowAnyHost=true (aspire/container mode, reached through a proxy on an
+// arbitrary host): the Host allowlist is meaningless, so it is skipped, and
+// CSRF tightens to same-origin — a present Origin must match the request
+// Host exactly. Requests without an Origin (curl, CLI tools) pass in both
+// modes.
+func requestGuard(allowAnyHost bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !allowAnyHost && !isLoopbackHostname(stripPort(r.Host)) {
+				writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden: non-local Host header"})
+				return
+			}
+			switch r.Method {
+			case http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch:
+				origin := r.Header.Get("Origin")
+				if origin != "" {
+					crossOrigin := !isLoopbackOrigin(origin)
+					if allowAnyHost {
+						crossOrigin = !sameOrigin(origin, r.Host)
+					}
+					if crossOrigin {
+						writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden: cross-origin request"})
+						return
+					}
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// sameOrigin reports whether an Origin header's host:port equals the
+// request's Host header.
+func sameOrigin(origin, host string) bool {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	return u.Host == host
+}
+```
+
+Keep `stripPort`, `isLoopbackHostname`, `isLoopbackOrigin` unchanged. In `pkg/server/server.go` add to `Options`:
+
+```go
+	// AllowNonLoopback switches the request guard from the loopback
+	// allowlist to same-origin CSRF (aspire/container mode, where the
+	// dashboard is reached through a proxy on an arbitrary host).
+	AllowNonLoopback bool
+```
+
+and change the middleware registration in `NewRouter`:
+
+```go
+	r.Use(requestGuard(opts.AllowNonLoopback))
+```
+
+Update any existing test/code references to `localhostGuard` → `requestGuard(false)`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -tags unit ./pkg/server/` → PASS (existing guard tests included).
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+gofmt -l . && go vet -tags unit ./...
+git add pkg/server/middleware.go pkg/server/middleware_test.go pkg/server/server.go
+git commit -m "feat(server): same-origin request guard for non-loopback serving"
+```
+
+---
+
+### Task 6: Capabilities — SPA injection and route gating
+
+**Files:**
+- Modify: `pkg/server/server.go` (Options + NewRouter), `pkg/server/api.go` (apiRouter signature + mounts), `pkg/server/apps.go:15-45` (appsRouter registration), `pkg/server/spa.go` (SPAHandler/serveIndex)
+- Test: `pkg/server/spa_test.go`, `pkg/server/api_test.go` (or `server_test.go` — put route-presence tests wherever router-level tests already live)
+
+**Interfaces:**
+- Consumes: `Options.AllowNonLoopback` (Task 5).
+- Produces: `type Capabilities struct { Lifecycle, ControlPlane, Logs, Workflows bool }` (json tags `lifecycle`, `controlPlane`, `logs`, `workflows`); `func FullCapabilities() Capabilities`; `Options.Capabilities *Capabilities` (nil ⇒ full). Task 7 reads the injected `window.__DASH_CAPABILITIES__`; Task 8 sets `Options.Capabilities`.
+
+- [ ] **Step 1: Write the failing tests**
+
+SPA injection test (in `spa_test.go`, follow the existing telemetry-injection test):
+
+```go
+func TestServeIndexInjectsCapabilities(t *testing.T) {
+	fsys := fstest.MapFS{"index.html": {Data: []byte("<html><head></head><body></body></html>")}}
+	h := SPAHandler(fsys, "", false, Capabilities{Workflows: true})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	h.ServeHTTP(rec, req)
+	body := rec.Body.String()
+	want := `window.__DASH_CAPABILITIES__={"lifecycle":false,"controlPlane":false,"logs":false,"workflows":true}`
+	if !strings.Contains(body, want) {
+		t.Fatalf("body missing %q:\n%s", want, body)
+	}
+}
+```
+
+Route-presence test (router-level; build `Options` the way existing `NewRouter` tests do, with stub services):
+
+```go
+func TestRouterCapabilityGating(t *testing.T) {
+	// buildTestOptions is whatever helper the existing router tests use to
+	// construct a servable Options with stub Apps/Backend/etc. Reuse it.
+	limited := Capabilities{Workflows: true} // aspire-with-store shape
+	opts := buildTestOptions()
+	opts.Capabilities = &limited
+	srv := httptest.NewServer(NewRouter(opts))
+	defer srv.Close()
+
+	get := func(path string) int {
+		resp, err := http.Get(srv.URL + path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+	if got := get("/api/controlplane/"); got != http.StatusNotFound {
+		t.Fatalf("controlplane: got %d want 404", got)
+	}
+	if got := get("/api/apps/some-app/logs"); got != http.StatusNotFound {
+		t.Fatalf("logs: got %d want 404", got)
+	}
+	resp, err := http.Post(srv.URL+"/api/apps/some-app/app/stop", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound && resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("lifecycle: got %d want 404/405", resp.StatusCode)
+	}
+	if got := get("/api/workflows/"); got == http.StatusNotFound {
+		t.Fatal("workflows should be mounted")
+	}
+	// nil Capabilities keeps everything mounted (host default).
+	opts2 := buildTestOptions()
+	srv2 := httptest.NewServer(NewRouter(opts2))
+	defer srv2.Close()
+	resp2, _ := http.Get(srv2.URL + "/api/controlplane/")
+	if resp2.StatusCode == http.StatusNotFound {
+		t.Fatal("nil capabilities must keep controlplane mounted")
+	}
+	resp2.Body.Close()
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit ./pkg/server/ -run "TestServeIndexInjects|TestRouterCapability" -v`
+Expected: FAIL — `undefined: Capabilities`, SPAHandler signature mismatch.
+
+- [ ] **Step 3: Implement**
+
+In `pkg/server/server.go`:
+
+```go
+// Capabilities gates optional feature surfaces per serving mode. The JSON
+// form is injected into the SPA as window.__DASH_CAPABILITIES__; the same
+// flags gate server-side route registration (the flags are advisory UX for
+// the UI; absent routes are the real boundary).
+type Capabilities struct {
+	Lifecycle    bool `json:"lifecycle"`
+	ControlPlane bool `json:"controlPlane"`
+	Logs         bool `json:"logs"`
+	Workflows    bool `json:"workflows"`
+}
+
+// FullCapabilities is the host-mode default: everything on.
+func FullCapabilities() Capabilities {
+	return Capabilities{Lifecycle: true, ControlPlane: true, Logs: true, Workflows: true}
+}
+```
+
+Add to `Options`:
+
+```go
+	// Capabilities gates optional feature routes and the SPA's capability
+	// flags; nil means FullCapabilities (host mode).
+	Capabilities *Capabilities
+```
+
+In `NewRouter`, resolve once and thread through:
+
+```go
+	caps := FullCapabilities()
+	if opts.Capabilities != nil {
+		caps = *opts.Capabilities
+	}
+	...
+	mount := func(router chi.Router) {
+		router.Mount("/api", apiRouter(opts.Version, opts.Apps, opts.ContainerLogs, opts.Lifecycle, opts.Backend, opts.Stores, opts.Resources, opts.News, opts.ControlPlane, opts.UpdateCheck, caps))
+		router.Handle("/*", SPAHandler(opts.DistFS, opts.BasePath, opts.TelemetryEnabled, caps))
+	}
+```
+
+In `pkg/server/api.go`, `apiRouter` gains the trailing `caps Capabilities` parameter and gates the mounts:
+
+```go
+	r.Mount("/apps", appsRouter(apps, containerLogs, life, caps))
+	r.Mount("/actors", actorsRouter(apps))
+	r.Mount("/subscriptions", subscriptionsRouter(apps))
+	if caps.Workflows {
+		r.Mount("/workflows", workflowsRouter(backend, stores))
+	}
+	r.Mount("/resources", resourcesRouter(res, apps))
+	r.Mount("/news", newsRouter(newsSvc))
+	if caps.ControlPlane {
+		r.Mount("/controlplane", controlPlaneRouter(cp))
+	}
+	if uc != nil {
+		r.Mount("/update-check", updateCheckRouter(uc))
+	}
+```
+
+In `pkg/server/apps.go`, `appsRouter` gains `caps Capabilities` and gates the two feature routes (GET list/detail stay unconditional):
+
+```go
+	if caps.Logs {
+		r.Get("/{appId}/logs", logsHandler(svc, containerLogs))
+	}
+	if caps.Lifecycle {
+		r.Post("/{appId}/{target}/{action}", func(w http.ResponseWriter, req *http.Request) {
+			... // existing body unchanged (nil life still answers 503)
+		})
+	}
+```
+
+In `pkg/server/spa.go`, `SPAHandler(fsys fs.FS, basePath string, telemetryEnabled bool, caps Capabilities)` and `serveIndex(w, r, fsys, telemetryEnabled, caps)`:
+
+```go
+	capsJSON, err := json.Marshal(caps)
+	if err != nil {
+		capsJSON = []byte("{}")
+	}
+	script := []byte("<script>window.__DASH_TELEMETRY_ENABLED__=" + flag +
+		";window.__DASH_CAPABILITIES__=" + string(capsJSON) + ";</script></head>")
+```
+
+Fix all existing callers/tests of `SPAHandler` to pass `FullCapabilities()`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -tags unit ./pkg/server/` → PASS. Then `go build ./...` → clean (cmd's `assembleOptions` still compiles because `Capabilities` is a new optional field).
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+gofmt -l . && go vet -tags unit ./...
+git add pkg/server/
+git commit -m "feat(server): capability gating for routes and SPA injection"
+```
+
+---
+
+### Task 7: Web capability gating (nav, routes, lifecycle controls)
+
+**Files:**
+- Create: `web/src/lib/capabilities.ts`
+- Modify: `web/src/components/TopNav.tsx` (NAV_ITEMS + render filter), `web/src/router.tsx` (route table), `web/src/pages/AppDetail.tsx` (lifecycle button groups)
+- Test: `web/src/lib/capabilities.test.ts`, `web/src/components/TopNav.test.tsx` (extend existing)
+
+**Interfaces:**
+- Consumes: `window.__DASH_CAPABILITIES__` injected by Task 6 (shape `{lifecycle, controlPlane, logs, workflows}`).
+- Produces: `getCapabilities(): Capabilities` accessor used by TopNav, router, AppDetail.
+
+- [ ] **Step 1: Write the failing test**
+
+`web/src/lib/capabilities.test.ts`:
+
+```ts
+import { describe, it, expect, afterEach } from 'vitest'
+import { getCapabilities } from './capabilities'
+
+declare global {
+  interface Window {
+    __DASH_CAPABILITIES__?: import('./capabilities').Capabilities
+  }
+}
+
+describe('getCapabilities', () => {
+  afterEach(() => {
+    delete window.__DASH_CAPABILITIES__
+  })
+
+  it('defaults to everything enabled when the flag is absent (dev server)', () => {
+    expect(getCapabilities()).toEqual({
+      lifecycle: true,
+      controlPlane: true,
+      logs: true,
+      workflows: true,
+    })
+  })
+
+  it('returns the injected flags verbatim', () => {
+    window.__DASH_CAPABILITIES__ = {
+      lifecycle: false,
+      controlPlane: false,
+      logs: false,
+      workflows: true,
+    }
+    expect(getCapabilities().lifecycle).toBe(false)
+    expect(getCapabilities().workflows).toBe(true)
+  })
+})
+```
+
+Extend `web/src/components/TopNav.test.tsx` with (follow the file's existing render helpers):
+
+```ts
+it('hides capability-gated entries when their capability is off', () => {
+  window.__DASH_CAPABILITIES__ = {
+    lifecycle: false,
+    controlPlane: false,
+    logs: false,
+    workflows: true,
+  }
+  renderTopNav() // the file's existing render helper
+  expect(screen.queryByText('Control Plane')).toBeNull()
+  expect(screen.queryByText('Logs')).toBeNull()
+  expect(screen.getByText('Workflows')).toBeInTheDocument()
+  expect(screen.getByText('Applications')).toBeInTheDocument()
+  delete window.__DASH_CAPABILITIES__
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd web && npx vitest run src/lib/capabilities.test.ts src/components/TopNav.test.tsx`
+Expected: FAIL — cannot resolve `./capabilities`.
+
+- [ ] **Step 3: Implement**
+
+`web/src/lib/capabilities.ts`:
+
+```ts
+export interface Capabilities {
+  lifecycle: boolean
+  controlPlane: boolean
+  logs: boolean
+  workflows: boolean
+}
+
+declare global {
+  interface Window {
+    __DASH_CAPABILITIES__?: Capabilities
+  }
+}
+
+const FULL: Capabilities = { lifecycle: true, controlPlane: true, logs: true, workflows: true }
+
+// getCapabilities reads the server-injected capability flags. Absent flag
+// (Vite dev server, tests) means everything on — matching the host-mode
+// server default.
+export function getCapabilities(): Capabilities {
+  return window.__DASH_CAPABILITIES__ ?? FULL
+}
+```
+
+`web/src/components/TopNav.tsx` — add the optional `cap` key and filter:
+
+```ts
+import { getCapabilities, type Capabilities } from '../lib/capabilities'
+
+export interface NavItem {
+  label: string
+  to: string
+  cap?: keyof Capabilities
+}
+
+export const NAV_ITEMS: NavItem[] = [
+  { label: 'Applications', to: '/' },
+  { label: 'Components', to: '/components' },
+  { label: 'Workflows', to: '/workflows', cap: 'workflows' },
+  { label: 'Actors', to: '/actors' },
+  { label: 'Subscriptions', to: '/subscriptions' },
+  { label: 'Resiliency', to: '/resiliency' },
+  { label: 'Configurations', to: '/configurations' },
+  { label: 'Control Plane', to: '/control-plane', cap: 'controlPlane' },
+  { label: 'Logs', to: '/logs', cap: 'logs' },
+]
+```
+
+and in the component body, before the return:
+
+```ts
+  const caps = getCapabilities()
+  const items = NAV_ITEMS.filter((item) => !item.cap || caps[item.cap])
+```
+
+then map over `items` instead of `NAV_ITEMS` in the JSX.
+
+`web/src/router.tsx` — gate the route entries (read the file first; the children array is at ~lines 29-43). Compute `const caps = getCapabilities()` at module top and filter:
+
+```ts
+const caps = getCapabilities()
+
+const gatedChildren = [
+  { index: true, element: <Applications />, handle: { rumView: 'Applications' } },
+  { path: 'apps/:appId', element: <AppDetail />, handle: { rumView: 'AppDetail' } },
+  ...(caps.workflows
+    ? [
+        { path: 'workflows', element: <Workflows />, handle: { rumView: 'Workflows' } },
+        { path: 'workflows/:appId/:instanceId', element: <WorkflowDetail />, handle: { rumView: 'WorkflowDetail' } },
+      ]
+    : []),
+  // ... keep the ungated entries verbatim ...
+  ...(caps.controlPlane
+    ? [{ path: 'control-plane', element: <ControlPlane />, handle: { rumView: 'ControlPlane' } }]
+    : []),
+  ...(caps.logs ? [{ path: 'logs', element: <Logs />, handle: { rumView: 'Logs' } }] : []),
+]
+```
+
+(preserve whatever catch-all/error route follows them; a gated-off path then falls through to the existing 404/error handling).
+
+`web/src/pages/AppDetail.tsx` — gate lifecycle controls. Read the file; add near the other hooks:
+
+```ts
+  const caps = getCapabilities()
+```
+
+Then in `panelActions` (~line 94), first line:
+
+```ts
+  const panelActions = (target: AppTarget, status: string | undefined, what: string) => {
+    if (!caps.lifecycle) return null
+    return (
+      <span style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}>
+        ...existing body unchanged...
+      </span>
+    )
+  }
+```
+
+Also find every other `runAction(`/`removeFromList` button group in the file (the page-header action block, ~lines 145-185) and wrap each group in `{caps.lifecycle && ( ... )}` the same way. Do not change button markup inside the wrappers.
+
+- [ ] **Step 4: Run tests and typecheck**
+
+Run: `cd web && npx vitest run` → all pass.
+Run: `cd web && npm run build` → tsc clean. **Required — vitest alone does not typecheck.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/capabilities.ts web/src/lib/capabilities.test.ts web/src/components/TopNav.tsx web/src/components/TopNav.test.tsx web/src/router.tsx web/src/pages/AppDetail.tsx
+git commit -m "feat(web): hide lifecycle/control-plane/logs/workflows behind capability flags"
+```
+
+---
+
+### Task 8: cmd wiring — flags, env fallbacks, aspire serve path
+
+**Files:**
+- Modify: `cmd/root.go` (NewRootCmd flags + runServe), `cmd/serve.go` (serveDeps + assembleOptions), `cmd/derive.go:21-53` (derivePaths extra paths), `cmd/reconciler.go:65,125` (thread extra paths)
+- Test: `cmd/root_test.go`, `cmd/derive_test.go`, `cmd/mode_test.go` (extend)
+
+**Interfaces:**
+- Consumes: `resolveMode` (Task 1), `NewAspireScanner`/`AspireContractPresent` (Task 2), `server.Capabilities` (Task 6), `Options.AllowNonLoopback` (Task 5).
+- Produces: `--mode` and `--bind` flags; env fallbacks `DEVDASHBOARD_PORT`, `DEVDASHBOARD_BIND`, `DEVDASHBOARD_STATESTORE_FILE`, `DEVDASHBOARD_NAMESPACE`, `DEVDASHBOARD_RESOURCES_PATH`; `func resolveServeSettings(mode Mode, flagChanged func(string) bool, port int, bind, stateStore, namespace string, getenv func(string) string) (serveSettings, error)`.
+
+- [ ] **Step 1: Write the failing settings-resolution test**
+
+Add to `cmd/mode_test.go`:
+
+```go
+func TestResolveServeSettings(t *testing.T) {
+	noneChanged := func(string) bool { return false }
+	tests := []struct {
+		name    string
+		mode    Mode
+		changed func(string) bool
+		port    int
+		bind    string
+		env     map[string]string
+		want    serveSettings
+	}{
+		{
+			name: "default mode keeps host defaults",
+			mode: ModeDefault, changed: noneChanged, port: 9090, bind: "127.0.0.1",
+			want: serveSettings{Port: 9090, Bind: "127.0.0.1", Namespace: "default"},
+		},
+		{
+			name: "aspire mode defaults to 8080 on 0.0.0.0",
+			mode: ModeAspire, changed: noneChanged, port: 9090, bind: "127.0.0.1",
+			want: serveSettings{Port: 8080, Bind: "0.0.0.0", Namespace: "default"},
+		},
+		{
+			name: "env overrides aspire defaults",
+			mode: ModeAspire, changed: noneChanged, port: 9090, bind: "127.0.0.1",
+			env: map[string]string{
+				"DEVDASHBOARD_PORT":            "9999",
+				"DEVDASHBOARD_BIND":            "127.0.0.1",
+				"DEVDASHBOARD_STATESTORE_FILE": "/app/components/state.yaml",
+				"DEVDASHBOARD_NAMESPACE":       "team-a",
+			},
+			want: serveSettings{Port: 9999, Bind: "127.0.0.1", StateStore: "/app/components/state.yaml",
+				Namespace: "team-a", ResourcesPaths: []string{"/app/components"}},
+		},
+		{
+			name: "changed flag beats env",
+			mode: ModeAspire, changed: func(f string) bool { return f == "port" }, port: 7000, bind: "127.0.0.1",
+			env:  map[string]string{"DEVDASHBOARD_PORT": "9999"},
+			want: serveSettings{Port: 7000, Bind: "0.0.0.0", Namespace: "default"},
+		},
+		{
+			name: "explicit resources path splits on list separator",
+			mode: ModeAspire, changed: noneChanged, port: 9090, bind: "127.0.0.1",
+			env: map[string]string{
+				"DEVDASHBOARD_RESOURCES_PATH": "/mnt/a" + string(os.PathListSeparator) + "/mnt/b",
+			},
+			want: serveSettings{Port: 8080, Bind: "0.0.0.0", Namespace: "default",
+				ResourcesPaths: []string{"/mnt/a", "/mnt/b"}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			getenv := func(k string) string { return tc.env[k] }
+			got, err := resolveServeSettings(tc.mode, tc.changed, tc.port, tc.bind, "", "default", getenv)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %+v want %+v", got, tc.want)
+			}
+		})
+	}
+	t.Run("bad DEVDASHBOARD_PORT errors", func(t *testing.T) {
+		_, err := resolveServeSettings(ModeAspire, noneChanged, 9090, "127.0.0.1", "", "default",
+			func(k string) string {
+				if k == "DEVDASHBOARD_PORT" {
+					return "not-a-port"
+				}
+				return ""
+			})
+		if err == nil || !strings.Contains(err.Error(), "DEVDASHBOARD_PORT") {
+			t.Fatalf("want error naming DEVDASHBOARD_PORT, got %v", err)
+		}
+	})
+}
+```
+
+Also extend `cmd/derive_test.go` with:
+
+```go
+func TestDerivePathsExtraResPaths(t *testing.T) {
+	resPaths, scanPaths, _, _ := derivePaths(nil, "", "/app/components/state.yaml", []string{"/app/components"})
+	found := false
+	for _, p := range resPaths {
+		if p == "/app/components" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("resPaths missing extra path: %v", resPaths)
+	}
+	if len(scanPaths) != 1 || scanPaths[0] != "/app/components/state.yaml" {
+		t.Fatalf("explicit statestore must own scanPaths: %v", scanPaths)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit ./cmd/ -run "TestResolveServeSettings|TestDerivePathsExtra" -v`
+Expected: FAIL — `undefined: serveSettings`, `undefined: resolveServeSettings`, derivePaths argument-count compile error.
+
+- [ ] **Step 3: Implement settings resolution (append to `cmd/mode.go`)**
+
+```go
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// serveSettings is the fully resolved serve configuration: flag > env > mode
+// default, per the spec's precedence rule.
+type serveSettings struct {
+	Port           int
+	Bind           string
+	StateStore     string
+	Namespace      string
+	ResourcesPaths []string
+}
+
+// resolveServeSettings applies the flag > env > mode-default precedence.
+// flagChanged reports whether the named cobra flag was set explicitly; port,
+// bind, stateStore, namespace carry the flag values (which hold cobra
+// defaults when unchanged).
+func resolveServeSettings(mode Mode, flagChanged func(string) bool, port int, bind, stateStore, namespace string, getenv func(string) string) (serveSettings, error) {
+	s := serveSettings{Port: port, Bind: bind, StateStore: stateStore, Namespace: namespace}
+
+	if !flagChanged("port") {
+		if v := getenv("DEVDASHBOARD_PORT"); v != "" {
+			p, err := strconv.Atoi(v)
+			if err != nil || p < 1 || p > 65535 {
+				return s, fmt.Errorf("DEVDASHBOARD_PORT: expected a port number, got %q", v)
+			}
+			s.Port = p
+		} else if mode == ModeAspire {
+			s.Port = 8080
+		}
+	}
+	if !flagChanged("bind") {
+		if v := getenv("DEVDASHBOARD_BIND"); v != "" {
+			s.Bind = v
+		} else if mode == ModeAspire {
+			s.Bind = "0.0.0.0"
+		}
+	}
+	if s.StateStore == "" {
+		s.StateStore = getenv("DEVDASHBOARD_STATESTORE_FILE")
+	}
+	if !flagChanged("namespace") {
+		if v := getenv("DEVDASHBOARD_NAMESPACE"); v != "" {
+			s.Namespace = v
+		}
+	}
+	if v := getenv("DEVDASHBOARD_RESOURCES_PATH"); v != "" {
+		for _, p := range strings.Split(v, string(os.PathListSeparator)) {
+			if p = strings.TrimSpace(p); p != "" {
+				s.ResourcesPaths = append(s.ResourcesPaths, p)
+			}
+		}
+	} else if mode == ModeAspire && s.StateStore != "" {
+		s.ResourcesPaths = []string{filepath.Dir(s.StateStore)}
+	}
+	return s, nil
+}
+```
+
+- [ ] **Step 4: Thread extra resource paths through derive/reconciler**
+
+`cmd/derive.go` — signature gains a final param; append to `resPaths` only:
+
+```go
+func derivePaths(apps []discovery.Instance, homeDir, stateStorePath string, extraResPaths []string) (resPaths, scanPaths []string, loaded map[string]bool, appPaths []string) {
+	...
+	resPaths = append(resPaths, extraResPaths...)
+	return resPaths, scanPaths, loaded, appPaths
+}
+```
+
+(place the append just before the return). `cmd/reconciler.go`: add an `extraResPaths []string` field to the reconciler struct, a matching final parameter on `newReconciler(...)`, and pass `rc.extraResPaths` at the `derivePaths` call site (line ~125). Fix the existing `newReconciler`/`derivePaths` callers (compiler-guided: `go build ./...` lists them) by passing `nil` except where Step 5 supplies real values.
+
+- [ ] **Step 5: Wire NewRootCmd and runServe (`cmd/root.go`)**
+
+New flags in `NewRootCmd`:
+
+```go
+	var (
+		port       int
+		bind       string
+		modeFlag   string
+		basePath   string
+		noOpen     bool
+		stateStore string
+		namespace  string
+		verbose    bool
+	)
+	...
+	c.Flags().IntVar(&port, "port", 9090, "port to serve the dashboard on")
+	c.Flags().StringVar(&bind, "bind", "127.0.0.1", "address to bind (aspire mode defaults to 0.0.0.0)")
+	c.Flags().StringVar(&modeFlag, "mode", "", `serving/discovery mode: "aspire", or unset for the complete scan`)
+```
+
+RunE resolves before calling runServe:
+
+```go
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			mode, err := resolveMode(modeFlag, os.Getenv)
+			if err != nil {
+				return err
+			}
+			settings, err := resolveServeSettings(mode, cmd.Flags().Changed, port, bind, stateStore, namespace, os.Getenv)
+			if err != nil {
+				return err
+			}
+			return runServe(cmd.Context(), mode, settings, basePath, noOpen, verbose)
+		},
+```
+
+`runServe(ctx context.Context, mode Mode, settings serveSettings, basePath string, noOpen, verbose bool) error` — restructure the current body:
+
+```go
+	// ...logger/dist/metadata.Init unchanged...
+
+	addr := fmt.Sprintf("%s:%d", settings.Bind, settings.Port)
+	displayHost := settings.Bind
+	if displayHost == "0.0.0.0" || displayHost == "::" {
+		displayHost = "localhost"
+	}
+	url := fmt.Sprintf("http://%s:%d%s/", displayHost, settings.Port, urlPath)
+
+	home := ""
+	if mode != ModeAspire {
+		home, err = os.UserHomeDir()
+		if err != nil {
+			logger.Warn("home directory unavailable; connection registry will not be persisted", "err", err)
+			home = ""
+		}
+	}
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	var (
+		appsSvc       discovery.Service
+		lifeMgr       lifecycle.Manager
+		composeEnv    func() discovery.ComposeEnv
+		containerLogs func(context.Context, string) (<-chan string, error)
+		updateCheck   updatecheck.Service
+		caps          *server.Capabilities
+	)
+	switch mode {
+	case ModeAspire:
+		scan, err := discovery.NewAspireScanner(os.Getenv)
+		if err != nil {
+			return err
+		}
+		appsSvc = discovery.New(scan, client)
+		caps = &server.Capabilities{Workflows: settings.StateStore != ""}
+	default:
+		_, crtRunner := containerruntime.Detect()
+		composeSrc := discovery.NewComposeSource(crtRunner)
+		scanners := []discovery.Scanner{discovery.StandaloneScanner(), composeSrc.Scanner()}
+		if discovery.AspireContractPresent(os.Getenv) {
+			as, err := discovery.NewAspireScanner(os.Getenv)
+			if err != nil {
+				return err
+			}
+			scanners = append(scanners, as)
+		}
+		lifeReg := lifecycle.NewRegistry()
+		lifeProc := lifecycle.NewProcController()
+		appsSvc = lifecycle.Overlay(
+			discovery.New(discovery.Merge(scanners...), client), lifeReg, lifeProc)
+		lifeMgr = lifecycle.New(appsSvc, lifeReg, crtRunner, lifeProc, lifecycle.NewStarter())
+		composeEnv = composeSrc.Env
+		containerLogs = containerLogStream(crtRunner)
+		updateCheck = updatecheck.New(&http.Client{Timeout: 5 * time.Second}, "https://api.github.com", "diagridio/dev-dashboard", version.Get().Version, time.Hour)
+	}
+```
+
+Pass through `assembleOptions` via extended `serveDeps` (add fields `AllowNonLoopback bool`, `Capabilities *server.Capabilities`, `ResourcesPaths []string`, `QuietRegistry bool`):
+
+```go
+	opts, closers := assembleOptions(ctx, serveDeps{
+		BasePath:         basePath,
+		StateStorePath:   settings.StateStore,
+		Namespace:        settings.Namespace,
+		Apps:             appsSvc,
+		Lifecycle:        lifeMgr,
+		HomeDir:          home,
+		HTTPClient:       &http.Client{Timeout: 10 * time.Second},
+		ComposeEnv:       composeEnv,
+		ContainerLogs:    containerLogs,
+		TelemetryEnabled: telemetry,
+		UpdateCheck:      updateCheck,
+		AllowNonLoopback: mode == ModeAspire,
+		Capabilities:     caps,
+		ResourcesPaths:   settings.ResourcesPaths,
+		QuietRegistry:    mode == ModeAspire,
+	}, dist)
+```
+
+Guard the update announcement and browser open:
+
+```go
+	if updateCheck != nil {
+		check := maybeAnnounceUpdate(ctx, updateCheck, version.Get().Version)
+		interactive := isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
+		maybeOfferUpdate(ctx, check, os.Stdin, os.Stdout, interactive, selfUpdateAndRestart)
+	}
+	...
+	if !noOpen && mode != ModeAspire {
+		go func() { time.Sleep(400 * time.Millisecond); _ = openBrowser(url) }()
+	}
+```
+
+`cmd/serve.go` `assembleOptions` changes:
+
+```go
+	if deps.HomeDir != "" {
+		registry = LoadRegistry(deps.HomeDir)
+	} else if !deps.QuietRegistry {
+		slog.Default().With("component", "registry").Warn("no home directory; connection registry persistence disabled")
+	}
+	...
+	rc := newReconciler(ctx, appsSvc, deps.Namespace, deps.HomeDir, deps.StateStorePath, deps.HTTPClient, registry, pool, deps.ComposeEnv, deps.ResourcesPaths)
+	...
+	return server.Options{
+		...
+		AllowNonLoopback: deps.AllowNonLoopback,
+		Capabilities:     deps.Capabilities,
+	}, []func() error{rc.Close}
+```
+
+- [ ] **Step 6: Run all tests**
+
+Run: `go test -tags unit ./...` → PASS (fix any existing cmd tests that construct `serveDeps`/`newReconciler`/`derivePaths` — compiler-guided, pass zero values/nil for the new params).
+
+- [ ] **Step 7: Manual smoke (mode-unset regression + aspire startup)**
+
+```bash
+go build -o bin/dev-dashboard . && ./bin/dev-dashboard --no-open --port 19091 &
+sleep 1 && curl -s http://127.0.0.1:19091/api/health && kill %1
+```
+Expected: `{"status":"ok"}`.
+
+```bash
+DEVDASHBOARD_MODE=aspire ./bin/dev-dashboard 2>&1 | head -2
+```
+Expected: exits non-zero with an error containing `DEVDASHBOARD_APP_COUNT` (contract missing = fail fast).
+
+```bash
+DEVDASHBOARD_MODE=aspire DEVDASHBOARD_APP_COUNT=0 ./bin/dev-dashboard --no-open &
+sleep 1 && curl -s -H "Host: whatever.example" http://127.0.0.1:8080/api/health && curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8080/api/controlplane/ && kill %1
+```
+Expected: `{"status":"ok"}` (foreign Host accepted) then `404` (control plane absent).
+
+- [ ] **Step 8: Lint and commit**
+
+```bash
+gofmt -l . && go vet -tags unit ./... && make build
+git add cmd/
+git commit -m "feat(cmd): aspire mode wiring — flags, env fallbacks, scanner selection"
+```
+
+---
+
+### Task 9: Aspire-mode integration test
+
+**Files:**
+- Create: `cmd/serve_aspire_integration_test.go` (build tag: copy the `//go:build integration` header from `cmd/serve_integration_test.go`)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-8. No new surface.
+
+- [ ] **Step 1: Write the test**
+
+Follow the structural conventions of `cmd/serve_integration_test.go` (how it builds deps and drives the router). The test:
+
+```go
+func TestAspireModeEndToEnd(t *testing.T) {
+	// Stub daprd: healthz + minimal metadata.
+	daprd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.0/healthz":
+			w.WriteHeader(http.StatusNoContent)
+		case "/v1.0/metadata":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"orders","runtimeVersion":"1.16.0","extended":{}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer daprd.Close()
+
+	t.Setenv("DEVDASHBOARD_APP_COUNT", "1")
+	t.Setenv("DEVDASHBOARD_APP_0_ID", "orders")
+	t.Setenv("DEVDASHBOARD_APP_0_DAPR_HTTP", daprd.URL)
+
+	scan, err := discovery.NewAspireScanner(os.Getenv)
+	if err != nil {
+		t.Fatalf("scanner: %v", err)
+	}
+	appsSvc := discovery.New(scan, daprd.Client())
+	caps := &server.Capabilities{Workflows: false}
+	opts, closers := assembleOptions(t.Context(), serveDeps{
+		Namespace: "default", Apps: appsSvc,
+		HTTPClient:       &http.Client{Timeout: 5 * time.Second},
+		AllowNonLoopback: true, Capabilities: caps, QuietRegistry: true,
+	}, testDistFS(t)) // reuse/mirror however serve_integration_test.go supplies a dist FS
+	for _, c := range closers {
+		defer func() { _ = c() }()
+	}
+	srv := httptest.NewServer(server.NewRouter(opts))
+	defer srv.Close()
+
+	// Apps listed from env contract, enriched from the stub daprd.
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/apps/", nil)
+	req.Host = "dashboard.internal:8080" // non-loopback Host must be accepted
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("apps: %d %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), `"appId":"orders"`) || !strings.Contains(string(body), `"health":"healthy"`) {
+		t.Fatalf("apps body: %s", body)
+	}
+	if !strings.Contains(string(body), `"source":"aspire"`) {
+		t.Fatalf("apps body missing aspire source: %s", body)
+	}
+
+	// Gated surfaces are absent.
+	for _, path := range []string{"/api/controlplane/", "/api/workflows/", "/api/apps/orders/logs"} {
+		r2, _ := http.Get(srv.URL + path)
+		r2.Body.Close()
+		if r2.StatusCode != http.StatusNotFound {
+			t.Fatalf("%s: got %d want 404", path, r2.StatusCode)
+		}
+	}
+}
+```
+
+Adjust helper usage (`testDistFS`, deps construction) to exactly match what `serve_integration_test.go` already does — reuse its helpers rather than inventing new ones.
+
+- [ ] **Step 2: Run it**
+
+Run: `go test -tags integration ./cmd/ -run TestAspireModeEndToEnd -v`
+Expected: PASS.
+
+- [ ] **Step 3: Full suites and commit**
+
+```bash
+make test && make test-integration
+git add cmd/serve_aspire_integration_test.go
+git commit -m "test(cmd): aspire-mode end-to-end integration test"
+```
+
+---
+
+### Task 10: Dockerfile, .dockerignore, CI image build
+
+**Files:**
+- Create: `Dockerfile`, `.dockerignore`
+- Modify: `.github/workflows/ci.yaml` (add a build-only image job)
+
+**Interfaces:**
+- Consumes: the binary behavior from Task 8 (`ENV DEVDASHBOARD_MODE=aspire` default).
+- Produces: a locally buildable image; Task 12 documents it. Task 11's `Dockerfile.goreleaser` is separate (prebuilt-binary context).
+
+- [ ] **Step 1: Write `.dockerignore`**
+
+```
+.git
+.claude
+.superpowers
+bin
+docs
+node_modules
+web/node_modules
+web/dist
+test
+*.md
+```
+
+(`web/dist` is excluded because the web stage rebuilds it; the go stage copies it from there.)
+
+- [ ] **Step 2: Write `Dockerfile`**
+
+Check `go.mod` for the exact Go version line (currently `go 1.26.x`) and match the builder tag major.minor:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+
+FROM node:22-alpine AS web
+WORKDIR /src/web
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+COPY web/ ./
+RUN npm run build
+
+FROM golang:1.26-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+COPY --from=web /src/web/dist ./web/dist
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG DATE=unknown
+RUN CGO_ENABLED=0 go build \
+    -ldflags "-s -w \
+    -X github.com/diagridio/dev-dashboard/pkg/version.Version=${VERSION} \
+    -X github.com/diagridio/dev-dashboard/pkg/version.Commit=${COMMIT} \
+    -X github.com/diagridio/dev-dashboard/pkg/version.Date=${DATE}" \
+    -o /out/dev-dashboard .
+
+FROM gcr.io/distroless/static:nonroot
+COPY --from=build /out/dev-dashboard /dev-dashboard
+ENV DEVDASHBOARD_MODE=aspire
+EXPOSE 8080
+ENTRYPOINT ["/dev-dashboard"]
+```
+
+- [ ] **Step 3: Build and smoke-test the image**
+
+```bash
+docker build -t dev-dashboard:dev .
+docker run --rm -e DEVDASHBOARD_APP_COUNT=0 -p 18080:8080 -d --name dd-smoke dev-dashboard:dev
+sleep 2
+curl -s http://127.0.0.1:18080/api/health
+docker logs dd-smoke | head -3
+docker rm -f dd-smoke
+```
+Expected: `{"status":"ok"}`; logs show the startup line with the 8080 URL and no telemetry/update prompts blocking.
+
+Also verify fail-fast: `docker run --rm dev-dashboard:dev` (no env) must exit non-zero printing an error naming `DEVDASHBOARD_APP_COUNT`.
+
+- [ ] **Step 4: Add the CI job**
+
+Read `.github/workflows/ci.yaml` and append a job matching its indentation/checkout style:
+
+```yaml
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build container image (no push)
+        run: docker build -t dev-dashboard:ci .
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Dockerfile .dockerignore .github/workflows/ci.yaml
+git commit -m "feat(docker): multi-stage container image with aspire-mode default"
+```
+
+---
+
+### Task 11: goreleaser image publishing
+
+**Files:**
+- Create: `Dockerfile.goreleaser`
+- Modify: `.goreleaser.yaml`, `.github/workflows/release.yaml`
+
+**Interfaces:**
+- Consumes: the `dev-dashboard` build id in `.goreleaser.yaml`.
+- Produces: `ghcr.io/diagridio/dev-dashboard:{version}` + `:latest` multi-arch manifests on tag release.
+
+- [ ] **Step 1: Write `Dockerfile.goreleaser`**
+
+goreleaser injects the prebuilt binary into the build context, so this stage is copy-only:
+
+```dockerfile
+FROM gcr.io/distroless/static:nonroot
+COPY dev-dashboard /dev-dashboard
+ENV DEVDASHBOARD_MODE=aspire
+EXPOSE 8080
+ENTRYPOINT ["/dev-dashboard"]
+```
+
+- [ ] **Step 2: Add dockers + manifests to `.goreleaser.yaml`**
+
+Append after the `archives:` block:
+
+```yaml
+dockers:
+  - id: linux-amd64
+    ids: [dev-dashboard]
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    image_templates:
+      - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - id: linux-arm64
+    ids: [dev-dashboard]
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    image_templates:
+      - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-arm64"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "ghcr.io/diagridio/dev-dashboard:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-amd64"
+      - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/diagridio/dev-dashboard:latest"
+    image_templates:
+      - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-amd64"
+      - "ghcr.io/diagridio/dev-dashboard:{{ .Version }}-arm64"
+```
+
+- [ ] **Step 3: Update the release workflow**
+
+Read `.github/workflows/release.yaml`. Ensure the release job has `permissions:` including `packages: write` (add alongside the existing `contents: write`), and add before the goreleaser step (match the file's action-version style):
+
+```yaml
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+```
+
+- [ ] **Step 4: Validate config and snapshot-build**
+
+```bash
+make release-check
+goreleaser release --snapshot --clean --skip=publish
+docker run --rm -e DEVDASHBOARD_APP_COUNT=0 -p 18081:8080 -d --name dd-gr ghcr.io/diagridio/dev-dashboard:$(ls dist/ | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[^_]*' | head -1)-amd64 2>/dev/null || true
+```
+Expected: `release-check` passes; snapshot builds both arch images locally (on Apple Silicon the amd64 image may not run — verifying the arm64 tag with the same curl smoke as Task 10 is sufficient).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Dockerfile.goreleaser .goreleaser.yaml .github/workflows/release.yaml
+git commit -m "feat(release): publish multi-arch image to ghcr.io/diagridio/dev-dashboard"
+```
+
+---
+
+### Task 12: Documentation
+
+**Files:**
+- Modify: `README.md` (new "Run as a container (.NET Aspire)" section after the install section)
+
+**Interfaces:** none — prose only, describing the contract exactly as specified.
+
+- [ ] **Step 1: Write the README section**
+
+Add a section documenting: the image name/tags; that `DEVDASHBOARD_MODE=aspire` is baked in; the full env contract table (`DEVDASHBOARD_APP_COUNT`, `DEVDASHBOARD_APP_<i>_ID`, `DEVDASHBOARD_APP_<i>_DAPR_HTTP`, `DEVDASHBOARD_APP_<i>_NAMESPACE`, `DEVDASHBOARD_APP_<i>_LABEL`, `DEVDASHBOARD_PORT`, `DEVDASHBOARD_BIND`, `DEVDASHBOARD_STATESTORE_FILE`, `DEVDASHBOARD_NAMESPACE`, `DEVDASHBOARD_RESOURCES_PATH`, `DEVDASHBOARD_MODE`) with the same required/default columns as the spec; what aspire mode disables (lifecycle, control plane, log tailing, self-update); a hand-run example:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e DEVDASHBOARD_APP_COUNT=1 \
+  -e DEVDASHBOARD_APP_0_ID=myapp \
+  -e DEVDASHBOARD_APP_0_DAPR_HTTP=http://host.docker.internal:3500 \
+  ghcr.io/diagridio/dev-dashboard:latest
+```
+
+and a pointer to the hosting-integration repo (`diagrid-labs/dashboard-aspire`) as the intended consumer. Also mention `--mode`/`DEVDASHBOARD_MODE` in the existing flags documentation, including that unset mode performs the complete scan and that `dapr`/`compose` values are reserved for future single-source modes.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: container image and aspire-mode contract documentation"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] `make lint && make test && make test-integration` — all green.
+- [ ] `make build` — binary builds with fresh web assets.
+- [ ] Task 8 Step 7 smoke commands re-run against the final binary.
+- [ ] Invoke superpowers:requesting-code-review before merging.

--- a/docs/superpowers/specs/2026-07-11-aspire-container-mode-design.md
+++ b/docs/superpowers/specs/2026-07-11-aspire-container-mode-design.md
@@ -1,0 +1,275 @@
+# Aspire Container Mode — Design
+
+**Date:** 2026-07-11
+**Status:** Approved design, pending implementation plan
+
+## Context
+
+The dashboard today is a host-local developer tool: a single static Go binary
+(embedded React SPA) that discovers Dapr apps by scanning the host process
+table (`dapr run` via `standalone.List()`) and the container runtime
+(`docker`/`podman` shell-outs for compose projects), probes daprd sidecars on
+`127.0.0.1:<port>`, tails host log files, and manages host processes by PID.
+
+To integrate with .NET Aspire, the dashboard must run as a **container
+resource inside an Aspire AppHost**, where none of that host introspection is
+available. Aspire already knows every app and sidecar in its application
+model, so discovery inverts: instead of the dashboard scanning, the
+orchestrator **tells the dashboard what exists** via environment variables.
+
+A prototype hosting integration exists at
+[diagrid-labs/dashboard-aspire](https://github.com/diagrid-labs/dashboard-aspire)
+(currently a workflow-only visualizer). It will be rewritten against the
+contract defined here; it is **out of scope** for this repo. What this repo
+delivers is the contract and the binary/image that honors it.
+
+## Goals
+
+1. **Aspire mode** in the Go binary: config-driven app discovery, container-
+   appropriate serving, host-introspection features cleanly disabled.
+2. **The contract**: CLI flags and env vars the hosting integration uses to
+   start the dashboard and hand it the app inventory. This is the primary
+   artifact — the integration is built against it.
+3. **Container image**: minimal multi-arch image published to GHCR alongside
+   the existing binary release.
+
+## Non-goals
+
+- The .NET hosting integration itself (separate repo).
+- Containerized *local* mode (running host-scanning discovery inside a
+  container via socket/PID-namespace mounts). Explicitly rejected: it ends up
+  granting the container the host anyway.
+- Host process/compose discovery, app lifecycle (start/stop/restart),
+  control-plane (scheduler/placement) management, and host-file log tailing
+  while in aspire mode. Aspire owns resource lifecycle and log streaming.
+- Log streaming from daprd/app HTTP endpoints (possible later; new log
+  source).
+
+## Feature scope in aspire mode
+
+Read-only observability **plus workflow actions**:
+
+- App inventory with per-app daprd metadata and health.
+- Components/resources browsing (from mounted component YAML).
+- Workflow instances, history, and **terminate/purge/force-delete** actions.
+- Actors, subscriptions, and other pages that derive purely from daprd
+  metadata + state store.
+
+## The contract
+
+### Mode switch
+
+| Source | Values | Default |
+|---|---|---|
+| `--mode` flag / `DASH_MODE` env | `local`, `aspire` | `local` |
+
+Precedence everywhere: **flag > env > mode default**. `local` mode is
+byte-for-byte today's behavior; every change below is gated on `aspire`.
+
+The published image sets `ENV DASH_MODE=aspire`, so the integration never has
+to pass it; it is overridable.
+
+### App discovery (indexed env vars)
+
+The integration enumerates Dapr sidecars in the AppHost model and injects:
+
+| Env var | Required | Meaning |
+|---|---|---|
+| `DASH_APP_COUNT` | yes | number of apps (`0` is valid: empty dashboard) |
+| `DASH_APP_<i>_ID` | yes | Dapr app-id (i = 0..count-1) |
+| `DASH_APP_<i>_DAPR_HTTP` | yes | daprd HTTP base URL, reachable **from the dashboard container** (e.g. `http://myapp-dapr:3500`) |
+| `DASH_APP_<i>_NAMESPACE` | no | per-app Dapr namespace; defaults to `DASH_NAMESPACE` |
+| `DASH_APP_<i>_LABEL` | no | display name (Aspire resource name); defaults to the app-id |
+
+Indexed single-value vars (not JSON) because each `DAPR_HTTP` value is one
+Aspire endpoint reference — runtime-resolved and container→host rewritten by
+Aspire — and must not need string escaping inside a composite value.
+
+Validation is **fail-fast at startup**: `DASH_MODE=aspire` with a missing or
+non-numeric `DASH_APP_COUNT`, or any missing required per-app var, or an
+unparsable `DAPR_HTTP` URL, exits with an error naming the exact variable. A
+misconfigured integration should be loud, not quietly empty.
+
+### Serving and features
+
+| Env / flag | Default (aspire) | Default (local) | Meaning |
+|---|---|---|---|
+| `DASH_PORT` / `--port` | `8080` | `9090` | listen port |
+| `DASH_BIND` / `--bind` (new flag) | `0.0.0.0` | `127.0.0.1` | bind host |
+| `DASH_STATESTORE_FILE` / `--statestore` | unset | unset | path to a mounted Dapr state-store component YAML; enables workflows |
+| `DASH_NAMESPACE` / `--namespace` | `default` | `default` | default Dapr namespace for workflow actor keys |
+| `DASH_RESOURCES_PATH` (new) | dir of `DASH_STATESTORE_FILE` | n/a | extra component directories for the Resources page, `os.PathListSeparator`-separated |
+| `--base-path` | unset | unset | flag only, unchanged (Aspire proxies to root; no env alias to avoid colliding with the build-time Vite `DASH_BASE_PATH`) |
+| `DEVDASHBOARD_TELEMETRY_OPTOUT` | unchanged | unchanged | existing telemetry opt-out |
+
+Aspire mode behavior changes (no new config needed):
+
+- No browser auto-open, no interactive update prompt, no self-update, no
+  GitHub update check.
+- Connection-registry persistence disabled silently (no `$HOME` in the
+  image; today's "home directory unavailable" warning is suppressed in
+  aspire mode).
+- Lifecycle, control-plane, and log-tail routes are **not registered**; the
+  UI hides those features (capabilities, below).
+
+The prototype integration's `COMPONENT_FILE` and `APP_ID` env vars are
+superseded by `DASH_STATESTORE_FILE` and the discovery list; the integration
+migrates when it is rewritten.
+
+## Binary internals
+
+### Mode plumbing
+
+Resolve the mode once at startup in `cmd/root.go` (flag > `DASH_MODE`).
+A small mode value threads through `runServe` and gates behavior at the
+existing seams — no parallel code path.
+
+### Discovery: `AspireScanner`
+
+New `discovery.AspireScanner(getenv)` produces `[]ScanResult` from the
+`DASH_APP_*` contract, with `Source: SourceAspire` (new constant). In aspire
+mode `runServe` builds the discovery service from **only** this scanner — no
+`StandaloneScanner`, no compose source, no `containerruntime.Detect()`.
+
+The scanner itself is static (env read once, validated at startup); the
+existing discovery poll loop still re-probes health and metadata every cycle,
+so app status stays live.
+
+### Base-URL threading (three call sites)
+
+`ScanResult`/`Instance` gain one field: `DaprHTTPBaseURL string`. When set it
+replaces the hardcoded `http://127.0.0.1:<port>` in:
+
+1. `discovery.CheckHealth` (`pkg/discovery/health.go`)
+2. `discovery.FetchMetadata` (`pkg/discovery/metadata.go`)
+3. `workflow.Remover.post` (`pkg/workflow/remove.go`) — terminate/purge go
+   through daprd HTTP; `RemoveTarget` gains the same field, populated from
+   the app inventory. (`forceDelete` already uses the state store; no change.)
+
+Empty field ⇒ existing `127.0.0.1:<port>` behavior, so local mode is
+untouched.
+
+### Middleware: Host guard and CSRF
+
+`localhostGuard` (`pkg/server/middleware.go`) currently enforces (a) loopback
+`Host` header (anti-DNS-rebinding) and (b) loopback `Origin` on mutating
+requests (anti-CSRF). In aspire mode the browser reaches the dashboard
+through Aspire's proxy on an arbitrary host, so:
+
+- The loopback **Host** check is bypassed (the container is addressed by
+  Docker-network name / published port; rebinding protection is meaningless
+  for a non-loopback server).
+- The mutating-request rule becomes **same-origin**: when an `Origin` header
+  is present, its host must equal the request `Host`. CSRF protection stays;
+  the loopback assumption goes.
+
+Local mode keeps both checks exactly as today.
+
+### UI capability gating
+
+`serveIndex` (`pkg/server/spa.go`) already injects
+`window.__DASH_TELEMETRY_ENABLED__` into `index.html`. Extend the same
+injection with:
+
+```js
+window.__DASH_CAPABILITIES__ = {lifecycle: bool, controlPlane: bool, logs: bool, workflows: bool}
+```
+
+Local mode: all true (workflows true as today — the page handles a missing
+store gracefully). Aspire mode: `lifecycle`, `controlPlane`, `logs` false;
+`workflows` true iff `DASH_STATESTORE_FILE` is set. The React app reads the
+flags through a small typed accessor (like the telemetry flag today) and
+hides navigation entries and controls for disabled capabilities — no dead
+buttons. Server-side, the corresponding routes are not registered, so the
+capability flags are advisory UX, not the security boundary.
+
+### Resources page
+
+`cmd/derivePaths` builds scan roots from `$HOME/.dapr` and per-app
+`ResourcePaths` (from daprd argv) — both empty in a container. In aspire mode
+seed the resource scan paths with `DASH_RESOURCES_PATH` (default: the
+directory containing `DASH_STATESTORE_FILE`), so the page truthfully shows
+the mounted component YAMLs.
+
+### Workflow store
+
+Reuses the existing `--statestore` explicit-component path end to end
+(YAML parsing, store clients, graceful-degradation banner). The component's
+connection string must be written from the container's perspective (Docker
+network host names) — that is the integration's responsibility and is
+documented in the contract.
+
+## Container image and publishing
+
+Multi-stage `Dockerfile` at the repo root:
+
+1. `node` stage: `npm ci && npm run build` in `web/` → `web/dist`.
+2. `golang` stage: `CGO_ENABLED=0 go build` with the same ldflags as
+   goreleaser (version/commit/date build args).
+3. Final stage: `gcr.io/distroless/static` with just the binary.
+   `ENTRYPOINT ["/dev-dashboard"]`, `ENV DASH_MODE=aspire`, `EXPOSE 8080`.
+
+Distroless works because aspire mode never shells out (no docker/podman, no
+browser opener) and the binary is pure-Go static (modernc sqlite, CGO off).
+
+Publishing: goreleaser `dockers` + `docker_manifests` blocks build
+linux/amd64 + linux/arm64 images on the existing tag-driven release, pushed
+to **`ghcr.io/diagridio/dev-dashboard`** with `:vX.Y.Z` and `:latest` tags —
+image and binary versions stay in lockstep. (The prototype integration's
+`ghcr.io/diagridio/diagrid-dashboard` name is superseded; it repoints when
+rewritten.)
+
+CI: build the Dockerfile (without pushing) in the PR workflow so image
+breakage is caught before release.
+
+## Error handling summary
+
+| Condition | Behavior |
+|---|---|
+| aspire mode, contract env missing/malformed | exit non-zero at startup, error names the variable |
+| `DASH_APP_COUNT=0` | valid; dashboard serves with an empty app list |
+| daprd endpoint unreachable at runtime | app shown unhealthy/unreachable (existing `SidecarReachable`/health semantics); retried each poll |
+| `DASH_STATESTORE_FILE` unset | workflows capability off; UI hides workflow pages |
+| state-store file unreadable / store unreachable | existing graceful-degradation banner (PR #39 behavior) |
+| workflow terminate/purge fails | existing per-instance error results, unchanged |
+
+## Testing
+
+Unit (table-driven, `-tags unit`, matching repo conventions):
+
+- `AspireScanner` env parsing: happy path, count `0`, missing/non-numeric
+  count, missing per-app ID/URL, bad URL, namespace/label defaulting.
+- Base-URL selection in `CheckHealth`, `FetchMetadata`, and
+  `workflow.Remover` (base URL set vs. empty fallback) against `httptest`
+  servers.
+- Middleware: aspire mode admits non-loopback `Host`; same-origin rule
+  accepts matching, rejects mismatched `Origin`; local mode unchanged.
+- Capability JSON injection per mode.
+
+Integration (`-tags integration`):
+
+- `runServe` in aspire mode with stub daprd endpoints: binds `0.0.0.0:8080`,
+  apps listed from env, lifecycle/control-plane/logs routes absent (404),
+  workflow routes present iff store configured.
+
+Manual/e2e (post-implementation): `docker build` + `docker run` with
+hand-written contract env against a locally running daprd, then a real
+AppHost run via the rewritten integration.
+
+## Risks and assumptions
+
+- **Sidecar reachability is the integration's job.** The contract only
+  requires that each `DASH_APP_<i>_DAPR_HTTP` URL be reachable from the
+  dashboard container. Whether Aspire's Dapr integration exposes sidecar
+  endpoints as referenceable resources (and how container→host rewriting
+  behaves for executable-hosted sidecars) must be validated by an early
+  end-to-end spike on the integration side. If a sidecar is genuinely
+  unreachable from containers, that app degrades to "unreachable" — the
+  dashboard stays honest.
+- **State-store connection perspective**: the mounted component YAML must
+  use container-perspective host names; wrong-perspective strings surface
+  via the existing store-error banner, not a crash.
+- **Contract stability**: the env contract is versioned implicitly by image
+  tag; the integration pins a minimum dashboard version. Breaking contract
+  changes require a coordinated release. Keep the contract additive where
+  possible.

--- a/docs/superpowers/specs/2026-07-11-aspire-container-mode-design.md
+++ b/docs/superpowers/specs/2026-07-11-aspire-container-mode-design.md
@@ -103,8 +103,8 @@ The integration enumerates Dapr sidecars in the AppHost model and injects:
 | `DEVDASHBOARD_APP_COUNT` | yes | number of apps (`0` is valid: empty dashboard) |
 | `DEVDASHBOARD_APP_<i>_ID` | yes | Dapr app-id (i = 0..count-1) |
 | `DEVDASHBOARD_APP_<i>_DAPR_HTTP` | yes | daprd HTTP base URL, reachable **from the dashboard container** (e.g. `http://myapp-dapr:3500`) |
-| `DEVDASHBOARD_APP_<i>_NAMESPACE` | no | per-app Dapr namespace; defaults to `DEVDASHBOARD_NAMESPACE` |
-| `DEVDASHBOARD_APP_<i>_LABEL` | no | display name (Aspire resource name); defaults to the app-id |
+| `DEVDASHBOARD_APP_<i>_NAMESPACE` | no | per-app Dapr namespace; defaults to `DEVDASHBOARD_NAMESPACE`. Accepted and exposed in the API; currently informational — workflow queries use the global `DEVDASHBOARD_NAMESPACE`, not the per-app value |
+| `DEVDASHBOARD_APP_<i>_LABEL` | no | display name (Aspire resource name); defaults to the app-id. Accepted and exposed in the API; currently informational — UI display of labels is planned |
 
 Indexed single-value vars (not JSON) because each `DAPR_HTTP` value is one
 Aspire endpoint reference — runtime-resolved and container→host rewritten by
@@ -160,7 +160,10 @@ New `discovery.AspireScanner(getenv)` produces `[]ScanResult` from the
 mode `runServe` builds the discovery service from **only** this scanner — no
 `StandaloneScanner`, no compose source, no `containerruntime.Detect()`.
 With mode unset, the scanner joins the existing standalone+compose merge
-when the contract is present, and is skipped when it is absent.
+when the contract is present, and is skipped when it is absent. On a key
+collision (an Aspire-launched daprd also found by the standalone host scan),
+the merge dedups by `Key()` and the aspire entry wins, since it carries
+`DaprHTTPBaseURL`.
 
 The scanner itself is static (env read once, validated at startup); the
 existing discovery poll loop still re-probes health and metadata every cycle,
@@ -245,8 +248,9 @@ browser opener) and the binary is pure-Go static (modernc sqlite, CGO off).
 
 Publishing: goreleaser `dockers` + `docker_manifests` blocks build
 linux/amd64 + linux/arm64 images on the existing tag-driven release, pushed
-to **`ghcr.io/diagridio/dev-dashboard`** with `:vX.Y.Z` and `:latest` tags —
-image and binary versions stay in lockstep. (The prototype integration's
+to **`ghcr.io/diagridio/dev-dashboard`** with `:X.Y.Z` (goreleaser strips the
+tag's `v` prefix) and `:latest` tags — image and binary versions stay in
+lockstep. (The prototype integration's
 `ghcr.io/diagridio/diagrid-dashboard` name is superseded; it repoints when
 rewritten.)
 

--- a/docs/superpowers/specs/2026-07-11-aspire-container-mode-design.md
+++ b/docs/superpowers/specs/2026-07-11-aspire-container-mode-design.md
@@ -61,10 +61,28 @@ Read-only observability **plus workflow actions**:
 
 | Source | Values | Default |
 |---|---|---|
-| `--mode` flag / `DEVDASHBOARD_MODE` env | `local`, `aspire` | `local` |
+| `--mode` flag / `DEVDASHBOARD_MODE` env | `aspire` (reserved for future work: `dapr`, `compose`) | unset |
 
-Precedence everywhere: **flag > env > mode default**. `local` mode is
-byte-for-byte today's behavior; every change below is gated on `aspire`.
+The mode takes exactly **one value** — it is a single-source filter, not a
+list. Combinations are deliberately unsupported: developers are unlikely to
+need a specific mix (e.g. compose+aspire but not `dapr run`), and a
+multi-value contract is not worth that cost.
+
+**Mode unset (the default) performs the complete scan across all discovery
+sources**: `dapr run` host processes, docker compose containers, and — when
+its env contract is present — Aspire-injected apps. Serving posture is
+today's host behavior, byte-for-byte (loopback bind, port 9090, browser
+open, update check, all features on).
+
+`--mode=aspire` restricts discovery to the Aspire env contract alone and
+switches to container serving posture; every change below is gated on it.
+
+**Future work (reserved, not in this iteration):** `--mode=dapr` and
+`--mode=compose` restrict discovery to only `dapr run` processes or only
+docker compose containers respectively, keeping host serving posture
+unchanged.
+
+Precedence everywhere: **flag > env > mode default**.
 
 The published image sets `ENV DEVDASHBOARD_MODE=aspire`, so the integration never has
 to pass it; it is overridable.
@@ -90,9 +108,13 @@ non-numeric `DEVDASHBOARD_APP_COUNT`, or any missing required per-app var, or an
 unparsable `DAPR_HTTP` URL, exits with an error naming the exact variable. A
 misconfigured integration should be loud, not quietly empty.
 
+With mode unset the contract is optional: an absent `DEVDASHBOARD_APP_COUNT`
+simply disables the Aspire source and the full host scan proceeds; a
+present-but-malformed contract still fails fast.
+
 ### Serving and features
 
-| Env / flag | Default (aspire) | Default (local) | Meaning |
+| Env / flag | Default (aspire) | Default (mode unset) | Meaning |
 |---|---|---|---|
 | `DEVDASHBOARD_PORT` / `--port` | `8080` | `9090` | listen port |
 | `DEVDASHBOARD_BIND` / `--bind` (new flag) | `0.0.0.0` | `127.0.0.1` | bind host |
@@ -130,6 +152,8 @@ New `discovery.AspireScanner(getenv)` produces `[]ScanResult` from the
 `DEVDASHBOARD_APP_*` contract, with `Source: SourceAspire` (new constant). In aspire
 mode `runServe` builds the discovery service from **only** this scanner — no
 `StandaloneScanner`, no compose source, no `containerruntime.Detect()`.
+With mode unset, the scanner joins the existing standalone+compose merge
+when the contract is present, and is skipped when it is absent.
 
 The scanner itself is static (env read once, validated at startup); the
 existing discovery poll loop still re-probes health and metadata every cycle,
@@ -146,8 +170,8 @@ replaces the hardcoded `http://127.0.0.1:<port>` in:
    through daprd HTTP; `RemoveTarget` gains the same field, populated from
    the app inventory. (`forceDelete` already uses the state store; no change.)
 
-Empty field ⇒ existing `127.0.0.1:<port>` behavior, so local mode is
-untouched.
+Empty field ⇒ existing `127.0.0.1:<port>` behavior, so host-scanned apps
+are untouched.
 
 ### Middleware: Host guard and CSRF
 
@@ -163,7 +187,7 @@ through Aspire's proxy on an arbitrary host, so:
   is present, its host must equal the request `Host`. CSRF protection stays;
   the loopback assumption goes.
 
-Local mode keeps both checks exactly as today.
+All non-aspire modes keep both checks exactly as today.
 
 ### UI capability gating
 
@@ -175,7 +199,7 @@ injection with:
 window.__DASH_CAPABILITIES__ = {lifecycle: bool, controlPlane: bool, logs: bool, workflows: bool}
 ```
 
-Local mode: all true (workflows true as today — the page handles a missing
+Mode unset: all true (workflows true as today — the page handles a missing
 store gracefully). Aspire mode: `lifecycle`, `controlPlane`, `logs` false;
 `workflows` true iff `DEVDASHBOARD_STATESTORE_FILE` is set. The React app reads the
 flags through a small typed accessor (like the telemetry flag today) and
@@ -227,6 +251,9 @@ breakage is caught before release.
 | Condition | Behavior |
 |---|---|
 | aspire mode, contract env missing/malformed | exit non-zero at startup, error names the variable |
+| mode unset, contract env absent | Aspire source skipped; full host scan proceeds |
+| mode unset, contract env present but malformed | exit non-zero at startup, error names the variable |
+| unknown `--mode` / `DEVDASHBOARD_MODE` value | exit non-zero at startup listing supported values |
 | `DEVDASHBOARD_APP_COUNT=0` | valid; dashboard serves with an empty app list |
 | daprd endpoint unreachable at runtime | app shown unhealthy/unreachable (existing `SidecarReachable`/health semantics); retried each poll |
 | `DEVDASHBOARD_STATESTORE_FILE` unset | workflows capability off; UI hides workflow pages |
@@ -239,11 +266,13 @@ Unit (table-driven, `-tags unit`, matching repo conventions):
 
 - `AspireScanner` env parsing: happy path, count `0`, missing/non-numeric
   count, missing per-app ID/URL, bad URL, namespace/label defaulting.
+- Mode resolution: unset ⇒ full scan (all sources, aspire source iff
+  contract present), `aspire` ⇒ aspire-only, unknown value ⇒ startup error.
 - Base-URL selection in `CheckHealth`, `FetchMetadata`, and
   `workflow.Remover` (base URL set vs. empty fallback) against `httptest`
   servers.
 - Middleware: aspire mode admits non-loopback `Host`; same-origin rule
-  accepts matching, rejects mismatched `Origin`; local mode unchanged.
+  accepts matching, rejects mismatched `Origin`; unset mode unchanged.
 - Capability JSON injection per mode.
 
 Integration (`-tags integration`):

--- a/docs/superpowers/specs/2026-07-11-aspire-container-mode-design.md
+++ b/docs/superpowers/specs/2026-07-11-aspire-container-mode-design.md
@@ -103,7 +103,7 @@ The integration enumerates Dapr sidecars in the AppHost model and injects:
 | `DEVDASHBOARD_APP_COUNT` | yes | number of apps (`0` is valid: empty dashboard) |
 | `DEVDASHBOARD_APP_<i>_ID` | yes | Dapr app-id (i = 0..count-1) |
 | `DEVDASHBOARD_APP_<i>_DAPR_HTTP` | yes | daprd HTTP base URL, reachable **from the dashboard container** (e.g. `http://myapp-dapr:3500`) |
-| `DEVDASHBOARD_APP_<i>_NAMESPACE` | no | per-app Dapr namespace; defaults to `DEVDASHBOARD_NAMESPACE`. Accepted and exposed in the API; currently informational — workflow queries use the global `DEVDASHBOARD_NAMESPACE`, not the per-app value |
+| `DEVDASHBOARD_APP_<i>_NAMESPACE` | no | per-app Dapr namespace; defaults to `DEVDASHBOARD_NAMESPACE`. Used for **app-scoped** workflow operations — one instance's history (`Get`), an app-filtered `List`/`Stats`, and force delete — which build state-store key patterns under the app's own namespace. The store-wide scans (all-apps `List`/`Stats`, `AppIDs`) remain on the global `DEVDASHBOARD_NAMESPACE`, since a single scan pattern bakes in one namespace and cannot span namespaces without redesign |
 | `DEVDASHBOARD_APP_<i>_LABEL` | no | display name (Aspire resource name); defaults to the app-id. Accepted and exposed in the API; currently informational — UI display of labels is planned |
 
 Indexed single-value vars (not JSON) because each `DAPR_HTTP` value is one

--- a/docs/superpowers/specs/2026-07-11-aspire-container-mode-design.md
+++ b/docs/superpowers/specs/2026-07-11-aspire-container-mode-design.md
@@ -61,12 +61,12 @@ Read-only observability **plus workflow actions**:
 
 | Source | Values | Default |
 |---|---|---|
-| `--mode` flag / `DASH_MODE` env | `local`, `aspire` | `local` |
+| `--mode` flag / `DEVDASHBOARD_MODE` env | `local`, `aspire` | `local` |
 
 Precedence everywhere: **flag > env > mode default**. `local` mode is
 byte-for-byte today's behavior; every change below is gated on `aspire`.
 
-The published image sets `ENV DASH_MODE=aspire`, so the integration never has
+The published image sets `ENV DEVDASHBOARD_MODE=aspire`, so the integration never has
 to pass it; it is overridable.
 
 ### App discovery (indexed env vars)
@@ -75,18 +75,18 @@ The integration enumerates Dapr sidecars in the AppHost model and injects:
 
 | Env var | Required | Meaning |
 |---|---|---|
-| `DASH_APP_COUNT` | yes | number of apps (`0` is valid: empty dashboard) |
-| `DASH_APP_<i>_ID` | yes | Dapr app-id (i = 0..count-1) |
-| `DASH_APP_<i>_DAPR_HTTP` | yes | daprd HTTP base URL, reachable **from the dashboard container** (e.g. `http://myapp-dapr:3500`) |
-| `DASH_APP_<i>_NAMESPACE` | no | per-app Dapr namespace; defaults to `DASH_NAMESPACE` |
-| `DASH_APP_<i>_LABEL` | no | display name (Aspire resource name); defaults to the app-id |
+| `DEVDASHBOARD_APP_COUNT` | yes | number of apps (`0` is valid: empty dashboard) |
+| `DEVDASHBOARD_APP_<i>_ID` | yes | Dapr app-id (i = 0..count-1) |
+| `DEVDASHBOARD_APP_<i>_DAPR_HTTP` | yes | daprd HTTP base URL, reachable **from the dashboard container** (e.g. `http://myapp-dapr:3500`) |
+| `DEVDASHBOARD_APP_<i>_NAMESPACE` | no | per-app Dapr namespace; defaults to `DEVDASHBOARD_NAMESPACE` |
+| `DEVDASHBOARD_APP_<i>_LABEL` | no | display name (Aspire resource name); defaults to the app-id |
 
 Indexed single-value vars (not JSON) because each `DAPR_HTTP` value is one
 Aspire endpoint reference — runtime-resolved and container→host rewritten by
 Aspire — and must not need string escaping inside a composite value.
 
-Validation is **fail-fast at startup**: `DASH_MODE=aspire` with a missing or
-non-numeric `DASH_APP_COUNT`, or any missing required per-app var, or an
+Validation is **fail-fast at startup**: `DEVDASHBOARD_MODE=aspire` with a missing or
+non-numeric `DEVDASHBOARD_APP_COUNT`, or any missing required per-app var, or an
 unparsable `DAPR_HTTP` URL, exits with an error naming the exact variable. A
 misconfigured integration should be loud, not quietly empty.
 
@@ -94,12 +94,12 @@ misconfigured integration should be loud, not quietly empty.
 
 | Env / flag | Default (aspire) | Default (local) | Meaning |
 |---|---|---|---|
-| `DASH_PORT` / `--port` | `8080` | `9090` | listen port |
-| `DASH_BIND` / `--bind` (new flag) | `0.0.0.0` | `127.0.0.1` | bind host |
-| `DASH_STATESTORE_FILE` / `--statestore` | unset | unset | path to a mounted Dapr state-store component YAML; enables workflows |
-| `DASH_NAMESPACE` / `--namespace` | `default` | `default` | default Dapr namespace for workflow actor keys |
-| `DASH_RESOURCES_PATH` (new) | dir of `DASH_STATESTORE_FILE` | n/a | extra component directories for the Resources page, `os.PathListSeparator`-separated |
-| `--base-path` | unset | unset | flag only, unchanged (Aspire proxies to root; no env alias to avoid colliding with the build-time Vite `DASH_BASE_PATH`) |
+| `DEVDASHBOARD_PORT` / `--port` | `8080` | `9090` | listen port |
+| `DEVDASHBOARD_BIND` / `--bind` (new flag) | `0.0.0.0` | `127.0.0.1` | bind host |
+| `DEVDASHBOARD_STATESTORE_FILE` / `--statestore` | unset | unset | path to a mounted Dapr state-store component YAML; enables workflows |
+| `DEVDASHBOARD_NAMESPACE` / `--namespace` | `default` | `default` | default Dapr namespace for workflow actor keys |
+| `DEVDASHBOARD_RESOURCES_PATH` (new) | dir of `DEVDASHBOARD_STATESTORE_FILE` | n/a | extra component directories for the Resources page, `os.PathListSeparator`-separated |
+| `--base-path` | unset | unset | flag only, unchanged (Aspire proxies to root; no env alias needed) |
 | `DEVDASHBOARD_TELEMETRY_OPTOUT` | unchanged | unchanged | existing telemetry opt-out |
 
 Aspire mode behavior changes (no new config needed):
@@ -113,21 +113,21 @@ Aspire mode behavior changes (no new config needed):
   UI hides those features (capabilities, below).
 
 The prototype integration's `COMPONENT_FILE` and `APP_ID` env vars are
-superseded by `DASH_STATESTORE_FILE` and the discovery list; the integration
+superseded by `DEVDASHBOARD_STATESTORE_FILE` and the discovery list; the integration
 migrates when it is rewritten.
 
 ## Binary internals
 
 ### Mode plumbing
 
-Resolve the mode once at startup in `cmd/root.go` (flag > `DASH_MODE`).
+Resolve the mode once at startup in `cmd/root.go` (flag > `DEVDASHBOARD_MODE`).
 A small mode value threads through `runServe` and gates behavior at the
 existing seams — no parallel code path.
 
 ### Discovery: `AspireScanner`
 
 New `discovery.AspireScanner(getenv)` produces `[]ScanResult` from the
-`DASH_APP_*` contract, with `Source: SourceAspire` (new constant). In aspire
+`DEVDASHBOARD_APP_*` contract, with `Source: SourceAspire` (new constant). In aspire
 mode `runServe` builds the discovery service from **only** this scanner — no
 `StandaloneScanner`, no compose source, no `containerruntime.Detect()`.
 
@@ -177,7 +177,7 @@ window.__DASH_CAPABILITIES__ = {lifecycle: bool, controlPlane: bool, logs: bool,
 
 Local mode: all true (workflows true as today — the page handles a missing
 store gracefully). Aspire mode: `lifecycle`, `controlPlane`, `logs` false;
-`workflows` true iff `DASH_STATESTORE_FILE` is set. The React app reads the
+`workflows` true iff `DEVDASHBOARD_STATESTORE_FILE` is set. The React app reads the
 flags through a small typed accessor (like the telemetry flag today) and
 hides navigation entries and controls for disabled capabilities — no dead
 buttons. Server-side, the corresponding routes are not registered, so the
@@ -187,8 +187,8 @@ capability flags are advisory UX, not the security boundary.
 
 `cmd/derivePaths` builds scan roots from `$HOME/.dapr` and per-app
 `ResourcePaths` (from daprd argv) — both empty in a container. In aspire mode
-seed the resource scan paths with `DASH_RESOURCES_PATH` (default: the
-directory containing `DASH_STATESTORE_FILE`), so the page truthfully shows
+seed the resource scan paths with `DEVDASHBOARD_RESOURCES_PATH` (default: the
+directory containing `DEVDASHBOARD_STATESTORE_FILE`), so the page truthfully shows
 the mounted component YAMLs.
 
 ### Workflow store
@@ -207,7 +207,7 @@ Multi-stage `Dockerfile` at the repo root:
 2. `golang` stage: `CGO_ENABLED=0 go build` with the same ldflags as
    goreleaser (version/commit/date build args).
 3. Final stage: `gcr.io/distroless/static` with just the binary.
-   `ENTRYPOINT ["/dev-dashboard"]`, `ENV DASH_MODE=aspire`, `EXPOSE 8080`.
+   `ENTRYPOINT ["/dev-dashboard"]`, `ENV DEVDASHBOARD_MODE=aspire`, `EXPOSE 8080`.
 
 Distroless works because aspire mode never shells out (no docker/podman, no
 browser opener) and the binary is pure-Go static (modernc sqlite, CGO off).
@@ -227,9 +227,9 @@ breakage is caught before release.
 | Condition | Behavior |
 |---|---|
 | aspire mode, contract env missing/malformed | exit non-zero at startup, error names the variable |
-| `DASH_APP_COUNT=0` | valid; dashboard serves with an empty app list |
+| `DEVDASHBOARD_APP_COUNT=0` | valid; dashboard serves with an empty app list |
 | daprd endpoint unreachable at runtime | app shown unhealthy/unreachable (existing `SidecarReachable`/health semantics); retried each poll |
-| `DASH_STATESTORE_FILE` unset | workflows capability off; UI hides workflow pages |
+| `DEVDASHBOARD_STATESTORE_FILE` unset | workflows capability off; UI hides workflow pages |
 | state-store file unreadable / store unreachable | existing graceful-degradation banner (PR #39 behavior) |
 | workflow terminate/purge fails | existing per-instance error results, unchanged |
 
@@ -259,7 +259,7 @@ AppHost run via the rewritten integration.
 ## Risks and assumptions
 
 - **Sidecar reachability is the integration's job.** The contract only
-  requires that each `DASH_APP_<i>_DAPR_HTTP` URL be reachable from the
+  requires that each `DEVDASHBOARD_APP_<i>_DAPR_HTTP` URL be reachable from the
   dashboard container. Whether Aspire's Dapr integration exposes sidecar
   endpoints as referenceable resources (and how container→host rewriting
   behaves for executable-hosted sidecars) must be validated by an early

--- a/docs/superpowers/specs/2026-07-11-aspire-container-mode-design.md
+++ b/docs/superpowers/specs/2026-07-11-aspire-container-mode-design.md
@@ -74,6 +74,13 @@ its env contract is present — Aspire-injected apps. Serving posture is
 today's host behavior, byte-for-byte (loopback bind, port 9090, browser
 open, update check, all features on).
 
+Note that the standalone process scan matches **any** host `daprd` process
+by executable name, not just `dapr run` children — so daprd sidecars
+launched by an Aspire AppHost as host executables are already discovered
+today, and that keeps working unchanged with mode unset. The env-contract
+Aspire source is additive on top of (and merged with) that incidental
+detection, not a replacement for it.
+
 `--mode=aspire` restricts discovery to the Aspire env contract alone and
 switches to container serving posture; every change below is gated on it.
 

--- a/docs/superpowers/specs/2026-07-11-aspire-container-mode-design.md
+++ b/docs/superpowers/specs/2026-07-11-aspire-container-mode-design.md
@@ -128,6 +128,7 @@ present-but-malformed contract still fails fast.
 | `DEVDASHBOARD_STATESTORE_FILE` / `--statestore` | unset | unset | path to a mounted Dapr state-store component YAML; enables workflows |
 | `DEVDASHBOARD_NAMESPACE` / `--namespace` | `default` | `default` | default Dapr namespace for workflow actor keys |
 | `DEVDASHBOARD_RESOURCES_PATH` (new) | dir of `DEVDASHBOARD_STATESTORE_FILE` | n/a | extra component directories for the Resources page, `os.PathListSeparator`-separated |
+| `DEVDASHBOARD_ALLOWED_HOSTS` (new) | unset (any host) | n/a | optional, env-only; comma-separated hostnames the `Host` header is restricted to (loopback always allowed); empty means any host |
 | `--base-path` | unset | unset | flag only, unchanged (Aspire proxies to root; no env alias needed) |
 | `DEVDASHBOARD_TELEMETRY_OPTOUT` | unchanged | unchanged | existing telemetry opt-out |
 
@@ -196,6 +197,14 @@ through Aspire's proxy on an arbitrary host, so:
 - The mutating-request rule becomes **same-origin**: when an `Origin` header
   is present, its host must equal the request `Host`. CSRF protection stays;
   the loopback assumption goes.
+
+When `DEVDASHBOARD_ALLOWED_HOSTS` is set, the dropped loopback `Host` check is
+replaced by an allowlist — the `Host` header must be a loopback name or one of
+the listed hostnames (case-insensitive, port ignored), closing the DNS-rebinding
+hole a published localhost port would otherwise leave open. The same-origin rule
+is normalized: hostnames compare case-insensitively and ports compare by
+effective value (explicit port, else 443 for https / 80 for http on the Origin,
+else the listen port for a portless `Host`).
 
 All non-aspire modes keep both checks exactly as today.
 

--- a/pkg/discovery/golden_test.go
+++ b/pkg/discovery/golden_test.go
@@ -8,10 +8,8 @@ import (
 	"flag"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
 
@@ -36,12 +34,7 @@ func TestFetchMetadataGolden(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	u, err := url.Parse(srv.URL)
-	require.NoError(t, err)
-	port, err := strconv.Atoi(u.Port())
-	require.NoError(t, err)
-
-	md, err := discovery.FetchMetadata(context.Background(), &http.Client{Timeout: 2 * time.Second}, port)
+	md, err := discovery.FetchMetadata(context.Background(), &http.Client{Timeout: 2 * time.Second}, srv.URL)
 	require.NoError(t, err)
 
 	got, err := json.MarshalIndent(md, "", "  ")

--- a/pkg/discovery/health.go
+++ b/pkg/discovery/health.go
@@ -4,12 +4,21 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
-// CheckHealth probes a sidecar's /v1.0/healthz endpoint.
-func CheckHealth(ctx context.Context, client *http.Client, httpPort int) Health {
-	url := fmt.Sprintf("http://127.0.0.1:%d/v1.0/healthz", httpPort)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+// sidecarBaseURL resolves the daprd HTTP endpoint: an explicit base URL
+// (aspire contract) wins; otherwise the historical loopback-port form.
+func sidecarBaseURL(base string, httpPort int) string {
+	if base != "" {
+		return strings.TrimRight(base, "/")
+	}
+	return fmt.Sprintf("http://127.0.0.1:%d", httpPort)
+}
+
+// CheckHealth probes a sidecar's /v1.0/healthz endpoint at baseURL.
+func CheckHealth(ctx context.Context, client *http.Client, baseURL string) Health {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v1.0/healthz", nil)
 	if err != nil {
 		return HealthUnknown
 	}

--- a/pkg/discovery/health_test.go
+++ b/pkg/discovery/health_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
-	"strconv"
 	"testing"
 	"time"
 
@@ -17,11 +15,21 @@ import (
 func TestCheckHealthHealthy(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(204) }))
 	t.Cleanup(srv.Close)
-	u, _ := url.Parse(srv.URL)
-	port, _ := strconv.Atoi(u.Port())
-	require.Equal(t, HealthHealthy, CheckHealth(context.Background(), &http.Client{Timeout: time.Second}, port))
+	require.Equal(t, HealthHealthy, CheckHealth(context.Background(), &http.Client{Timeout: time.Second}, srv.URL))
 }
 
 func TestCheckHealthUnhealthy(t *testing.T) {
-	require.Equal(t, HealthUnhealthy, CheckHealth(context.Background(), &http.Client{Timeout: 100 * time.Millisecond}, 1)) // nothing listening on port 1
+	require.Equal(t, HealthUnhealthy, CheckHealth(context.Background(), &http.Client{Timeout: 100 * time.Millisecond}, "http://127.0.0.1:1")) // nothing listening on port 1
+}
+
+func TestSidecarBaseURL(t *testing.T) {
+	if got := sidecarBaseURL("", 3500); got != "http://127.0.0.1:3500" {
+		t.Fatalf("port fallback: %q", got)
+	}
+	if got := sidecarBaseURL("http://orders-dapr:3500", 0); got != "http://orders-dapr:3500" {
+		t.Fatalf("base passthrough: %q", got)
+	}
+	if got := sidecarBaseURL("http://orders-dapr:3500/", 0); got != "http://orders-dapr:3500" {
+		t.Fatalf("trailing slash: %q", got)
+	}
 }

--- a/pkg/discovery/merge.go
+++ b/pkg/discovery/merge.go
@@ -4,7 +4,11 @@ import "errors"
 
 // Merge combines scanners into one. A failing scanner is logged and skipped so
 // one source (e.g. docker being absent) never hides the others; the merged
-// scan errors only when every scanner fails.
+// scan errors only when every scanner fails. When any result has
+// Source == SourceAspire, it wins key collisions: every other result sharing
+// its Key() is dropped (an Aspire-launched daprd host process is otherwise
+// double-counted by both the standalone scan and the env contract). Order is
+// stable otherwise.
 func Merge(scanners ...Scanner) Scanner {
 	return func() ([]ScanResult, error) {
 		var out []ScanResult
@@ -23,6 +27,29 @@ func Merge(scanners ...Scanner) Scanner {
 		for _, err := range errs {
 			logger().Warn("app scan source failed", "err", err)
 		}
-		return out, nil
+		return dedupAspireWins(out), nil
 	}
+}
+
+// dedupAspireWins drops non-aspire results whose Key() collides with an
+// aspire result's Key(), keeping the aspire entry (it carries
+// DaprHTTPBaseURL). Order is preserved otherwise.
+func dedupAspireWins(results []ScanResult) []ScanResult {
+	aspireKeys := make(map[string]bool)
+	for _, r := range results {
+		if r.Source == SourceAspire {
+			aspireKeys[r.Key()] = true
+		}
+	}
+	if len(aspireKeys) == 0 {
+		return results
+	}
+	out := make([]ScanResult, 0, len(results))
+	for _, r := range results {
+		if r.Source != SourceAspire && aspireKeys[r.Key()] {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
 }

--- a/pkg/discovery/merge_test.go
+++ b/pkg/discovery/merge_test.go
@@ -34,3 +34,54 @@ func TestMergeAllFail(t *testing.T) {
 		t.Fatal("all scanners failing must return an error")
 	}
 }
+
+func TestMergeAspireWinsKeyCollision(t *testing.T) {
+	cases := []struct {
+		name    string
+		aspire  []ScanResult
+		other   []ScanResult
+		wantLen int
+		check   func(t *testing.T, got []ScanResult)
+	}{
+		{
+			name:    "aspire and standalone same AppID collapse to one, aspire wins",
+			aspire:  []ScanResult{{AppID: "orders", Source: SourceAspire, DaprHTTPBaseURL: "http://orders-dapr:3500"}},
+			other:   []ScanResult{{AppID: "orders", Source: SourceStandalone}},
+			wantLen: 1,
+			check: func(t *testing.T, got []ScanResult) {
+				if got[0].Source != SourceAspire || got[0].DaprHTTPBaseURL == "" {
+					t.Fatalf("expected surviving result to be the aspire entry, got %+v", got[0])
+				}
+			},
+		},
+		{
+			name:    "aspire and compose with different keys are both kept",
+			aspire:  []ScanResult{{AppID: "orders", Source: SourceAspire}},
+			other:   []ScanResult{{AppID: "checkout", Source: SourceCompose, AppContainerName: "checkout-1"}},
+			wantLen: 2,
+		},
+		{
+			name:    "no aspire results leaves output unchanged",
+			aspire:  nil,
+			other:   []ScanResult{{AppID: "a", Source: SourceStandalone}, {AppID: "b", Source: SourceCompose, AppContainerName: "b-1"}},
+			wantLen: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			aspireScan := func() ([]ScanResult, error) { return tc.aspire, nil }
+			otherScan := func() ([]ScanResult, error) { return tc.other, nil }
+			got, err := Merge(otherScan, aspireScan)()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != tc.wantLen {
+				t.Fatalf("got %d results, want %d: %+v", len(got), tc.wantLen, got)
+			}
+			if tc.check != nil {
+				tc.check(t, got)
+			}
+		})
+	}
+}

--- a/pkg/discovery/metadata.go
+++ b/pkg/discovery/metadata.go
@@ -85,10 +85,9 @@ func runTemplateFromExtended(extended map[string]string) string {
 	return ""
 }
 
-// FetchMetadata queries a sidecar's /v1.0/metadata endpoint.
-func FetchMetadata(ctx context.Context, client *http.Client, httpPort int) (Metadata, error) {
-	url := fmt.Sprintf("http://127.0.0.1:%d/v1.0/metadata", httpPort)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+// FetchMetadata queries a sidecar's /v1.0/metadata endpoint at baseURL.
+func FetchMetadata(ctx context.Context, client *http.Client, baseURL string) (Metadata, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v1.0/metadata", nil)
 	if err != nil {
 		return Metadata{}, err
 	}

--- a/pkg/discovery/metadata_test.go
+++ b/pkg/discovery/metadata_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
-	"strconv"
 	"testing"
 	"time"
 
@@ -27,10 +25,8 @@ func TestFetchMetadataRichFields(t *testing.T) {
 		}`))
 	}))
 	t.Cleanup(srv.Close)
-	u, _ := url.Parse(srv.URL)
-	port, _ := strconv.Atoi(u.Port())
 
-	md, err := FetchMetadata(context.Background(), &http.Client{Timeout: 2 * time.Second}, port)
+	md, err := FetchMetadata(context.Background(), &http.Client{Timeout: 2 * time.Second}, srv.URL)
 	require.NoError(t, err)
 	require.Equal(t, []string{"ServiceInvocation", "StateStore"}, md.EnabledFeatures)
 	require.Len(t, md.Actors, 1)
@@ -52,10 +48,8 @@ func TestFetchMetadata(t *testing.T) {
 		_, _ = w.Write([]byte(`{"id":"order","runtimeVersion":"1.14.4","extended":{"appPID":"48213","cliPID":"48201","appCommand":"go run ./cmd/order","appLogPath":"/l/app.log","daprdLogPath":"/l/daprd.log","runTemplateName":"dapr.yaml"}}`))
 	}))
 	t.Cleanup(srv.Close)
-	u, _ := url.Parse(srv.URL)
-	port, _ := strconv.Atoi(u.Port())
 
-	md, err := FetchMetadata(context.Background(), &http.Client{Timeout: 2 * time.Second}, port)
+	md, err := FetchMetadata(context.Background(), &http.Client{Timeout: 2 * time.Second}, srv.URL)
 	require.NoError(t, err)
 	require.Equal(t, "order", md.ID)
 	require.Equal(t, "1.14.4", md.RuntimeVersion)
@@ -69,10 +63,8 @@ func TestFetchMetadataRunTemplateFallsBackToPathBasename(t *testing.T) {
 		_, _ = w.Write([]byte(`{"id":"order","extended":{"runTemplateName":"","runTemplatePath":"/home/dev/myapp/dapr.yaml"}}`))
 	}))
 	t.Cleanup(srv.Close)
-	u, _ := url.Parse(srv.URL)
-	port, _ := strconv.Atoi(u.Port())
 
-	md, err := FetchMetadata(context.Background(), &http.Client{Timeout: 2 * time.Second}, port)
+	md, err := FetchMetadata(context.Background(), &http.Client{Timeout: 2 * time.Second}, srv.URL)
 	require.NoError(t, err)
 	require.Equal(t, "dapr.yaml", md.RunTemplate)
 }
@@ -82,10 +74,8 @@ func TestFetchMetadataRunTemplateEmptyWhenNeitherFieldSet(t *testing.T) {
 		_, _ = w.Write([]byte(`{"id":"order","extended":{}}`))
 	}))
 	t.Cleanup(srv.Close)
-	u, _ := url.Parse(srv.URL)
-	port, _ := strconv.Atoi(u.Port())
 
-	md, err := FetchMetadata(context.Background(), &http.Client{Timeout: 2 * time.Second}, port)
+	md, err := FetchMetadata(context.Background(), &http.Client{Timeout: 2 * time.Second}, srv.URL)
 	require.NoError(t, err)
 	require.Equal(t, "", md.RunTemplate)
 }

--- a/pkg/discovery/scan_aspire.go
+++ b/pkg/discovery/scan_aspire.go
@@ -1,0 +1,67 @@
+package discovery
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// AspireContractPresent reports whether the DEVDASHBOARD_APP_* env contract
+// is set at all (anchor variable: DEVDASHBOARD_APP_COUNT). Used with mode
+// unset to decide whether the aspire source joins the merge.
+func AspireContractPresent(getenv func(string) string) bool {
+	return strings.TrimSpace(getenv("DEVDASHBOARD_APP_COUNT")) != ""
+}
+
+// NewAspireScanner parses the DEVDASHBOARD_APP_* env contract eagerly and
+// returns a static Scanner over the parsed apps. Malformed contracts fail
+// here — at startup — with an error naming the exact variable, never at scan
+// time. The returned scanner is static: env is read once; liveness comes
+// from the discovery service's per-poll health/metadata probes.
+func NewAspireScanner(getenv func(string) string) (Scanner, error) {
+	countRaw := strings.TrimSpace(getenv("DEVDASHBOARD_APP_COUNT"))
+	count, err := strconv.Atoi(countRaw)
+	if err != nil || count < 0 {
+		return nil, fmt.Errorf("DEVDASHBOARD_APP_COUNT: expected a non-negative integer, got %q", countRaw)
+	}
+	defaultNS := strings.TrimSpace(getenv("DEVDASHBOARD_NAMESPACE"))
+	if defaultNS == "" {
+		defaultNS = "default"
+	}
+	results := make([]ScanResult, 0, count)
+	for i := 0; i < count; i++ {
+		idKey := fmt.Sprintf("DEVDASHBOARD_APP_%d_ID", i)
+		urlKey := fmt.Sprintf("DEVDASHBOARD_APP_%d_DAPR_HTTP", i)
+		id := strings.TrimSpace(getenv(idKey))
+		if id == "" {
+			return nil, fmt.Errorf("%s: required but empty", idKey)
+		}
+		raw := strings.TrimSpace(getenv(urlKey))
+		u, err := url.Parse(raw)
+		if raw == "" || err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			return nil, fmt.Errorf("%s: expected an http(s) base URL, got %q", urlKey, raw)
+		}
+		ns := strings.TrimSpace(getenv(fmt.Sprintf("DEVDASHBOARD_APP_%d_NAMESPACE", i)))
+		if ns == "" {
+			ns = defaultNS
+		}
+		label := strings.TrimSpace(getenv(fmt.Sprintf("DEVDASHBOARD_APP_%d_LABEL", i)))
+		if label == "" {
+			label = id
+		}
+		results = append(results, ScanResult{
+			AppID:            id,
+			DaprHTTPBaseURL:  strings.TrimRight(raw, "/"),
+			Namespace:        ns,
+			Label:            label,
+			Source:           SourceAspire,
+			SidecarReachable: true,
+		})
+	}
+	return func() ([]ScanResult, error) {
+		out := make([]ScanResult, len(results))
+		copy(out, results)
+		return out, nil
+	}, nil
+}

--- a/pkg/discovery/scan_aspire.go
+++ b/pkg/discovery/scan_aspire.go
@@ -1,11 +1,16 @@
 package discovery
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
 )
+
+// maxAspireAppCount bounds DEVDASHBOARD_APP_COUNT to guard against a runaway
+// or hostile value forcing a huge allocation/scan loop.
+const maxAspireAppCount = 1024
 
 // AspireContractPresent reports whether the DEVDASHBOARD_APP_* env contract
 // is set at all (anchor variable: DEVDASHBOARD_APP_COUNT). Used with mode
@@ -25,22 +30,39 @@ func NewAspireScanner(getenv func(string) string) (Scanner, error) {
 	if err != nil || count < 0 {
 		return nil, fmt.Errorf("DEVDASHBOARD_APP_COUNT: expected a non-negative integer, got %q", countRaw)
 	}
+	if count > maxAspireAppCount {
+		return nil, fmt.Errorf("DEVDASHBOARD_APP_COUNT: %d exceeds the maximum of %d", count, maxAspireAppCount)
+	}
 	defaultNS := strings.TrimSpace(getenv("DEVDASHBOARD_NAMESPACE"))
 	if defaultNS == "" {
 		defaultNS = "default"
 	}
 	results := make([]ScanResult, 0, count)
+	// seenID maps a validated app id to the env var that first defined it, so a
+	// later duplicate can name both variables.
+	seenID := make(map[string]string, count)
+	var errs []error
 	for i := 0; i < count; i++ {
 		idKey := fmt.Sprintf("DEVDASHBOARD_APP_%d_ID", i)
 		urlKey := fmt.Sprintf("DEVDASHBOARD_APP_%d_DAPR_HTTP", i)
 		id := strings.TrimSpace(getenv(idKey))
-		if id == "" {
-			return nil, fmt.Errorf("%s: required but empty", idKey)
-		}
 		raw := strings.TrimSpace(getenv(urlKey))
+
+		bad := false
+		if id == "" {
+			errs = append(errs, fmt.Errorf("%s: required but empty", idKey))
+			bad = true
+		} else if prev, ok := seenID[id]; ok {
+			errs = append(errs, fmt.Errorf("%s: duplicate app id %q (already used by %s)", idKey, id, prev))
+			bad = true
+		}
 		u, err := url.Parse(raw)
 		if raw == "" || err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-			return nil, fmt.Errorf("%s: expected an http(s) base URL, got %q", urlKey, raw)
+			errs = append(errs, fmt.Errorf("%s: expected an http(s) base URL, got %q", urlKey, raw))
+			bad = true
+		}
+		if bad {
+			continue
 		}
 		ns := strings.TrimSpace(getenv(fmt.Sprintf("DEVDASHBOARD_APP_%d_NAMESPACE", i)))
 		if ns == "" {
@@ -50,6 +72,7 @@ func NewAspireScanner(getenv func(string) string) (Scanner, error) {
 		if label == "" {
 			label = id
 		}
+		seenID[id] = idKey
 		results = append(results, ScanResult{
 			AppID:            id,
 			DaprHTTPBaseURL:  strings.TrimRight(raw, "/"),
@@ -58,6 +81,9 @@ func NewAspireScanner(getenv func(string) string) (Scanner, error) {
 			Source:           SourceAspire,
 			SidecarReachable: true,
 		})
+	}
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
 	}
 	return func() ([]ScanResult, error) {
 		out := make([]ScanResult, len(results))

--- a/pkg/discovery/scan_aspire_test.go
+++ b/pkg/discovery/scan_aspire_test.go
@@ -1,0 +1,119 @@
+//go:build unit
+
+package discovery
+
+import (
+	"strings"
+	"testing"
+)
+
+func envFunc(vals map[string]string) func(string) string {
+	return func(k string) string { return vals[k] }
+}
+
+func TestAspireContractPresent(t *testing.T) {
+	if AspireContractPresent(envFunc(nil)) {
+		t.Fatal("empty env: want false")
+	}
+	if !AspireContractPresent(envFunc(map[string]string{"DEVDASHBOARD_APP_COUNT": "0"})) {
+		t.Fatal("count set: want true")
+	}
+}
+
+func TestNewAspireScannerHappyPath(t *testing.T) {
+	scan, err := NewAspireScanner(envFunc(map[string]string{
+		"DEVDASHBOARD_APP_COUNT":       "2",
+		"DEVDASHBOARD_APP_0_ID":        "orders",
+		"DEVDASHBOARD_APP_0_DAPR_HTTP": "http://orders-dapr:3500/",
+		"DEVDASHBOARD_APP_1_ID":        "payments",
+		"DEVDASHBOARD_APP_1_DAPR_HTTP": "http://payments-dapr:3501",
+		"DEVDASHBOARD_APP_1_NAMESPACE": "prod",
+		"DEVDASHBOARD_APP_1_LABEL":     "Payments API",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := scan()
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d results, want 2", len(got))
+	}
+	r0, r1 := got[0], got[1]
+	if r0.AppID != "orders" || r0.DaprHTTPBaseURL != "http://orders-dapr:3500" {
+		t.Fatalf("r0: %+v (trailing slash must be trimmed)", r0)
+	}
+	if r0.Namespace != "default" || r0.Label != "orders" {
+		t.Fatalf("r0 defaults: ns=%q label=%q", r0.Namespace, r0.Label)
+	}
+	if r0.Source != SourceAspire || !r0.SidecarReachable {
+		t.Fatalf("r0 source/reachable: %+v", r0)
+	}
+	if r1.Namespace != "prod" || r1.Label != "Payments API" {
+		t.Fatalf("r1 overrides: ns=%q label=%q", r1.Namespace, r1.Label)
+	}
+}
+
+func TestNewAspireScannerNamespaceDefault(t *testing.T) {
+	scan, err := NewAspireScanner(envFunc(map[string]string{
+		"DEVDASHBOARD_NAMESPACE":       "team-a",
+		"DEVDASHBOARD_APP_COUNT":       "1",
+		"DEVDASHBOARD_APP_0_ID":        "a",
+		"DEVDASHBOARD_APP_0_DAPR_HTTP": "http://a:3500",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, _ := scan()
+	if got[0].Namespace != "team-a" {
+		t.Fatalf("namespace: got %q want team-a", got[0].Namespace)
+	}
+}
+
+func TestNewAspireScannerCountZero(t *testing.T) {
+	scan, err := NewAspireScanner(envFunc(map[string]string{"DEVDASHBOARD_APP_COUNT": "0"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := scan()
+	if err != nil || len(got) != 0 {
+		t.Fatalf("want empty scan, got %v / %v", got, err)
+	}
+}
+
+func TestNewAspireScannerErrorsNameTheVariable(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		wantVar string
+	}{
+		{"missing count", map[string]string{}, "DEVDASHBOARD_APP_COUNT"},
+		{"non-numeric count", map[string]string{"DEVDASHBOARD_APP_COUNT": "two"}, "DEVDASHBOARD_APP_COUNT"},
+		{"negative count", map[string]string{"DEVDASHBOARD_APP_COUNT": "-1"}, "DEVDASHBOARD_APP_COUNT"},
+		{"missing id", map[string]string{
+			"DEVDASHBOARD_APP_COUNT":       "1",
+			"DEVDASHBOARD_APP_0_DAPR_HTTP": "http://a:3500",
+		}, "DEVDASHBOARD_APP_0_ID"},
+		{"missing url", map[string]string{
+			"DEVDASHBOARD_APP_COUNT": "1",
+			"DEVDASHBOARD_APP_0_ID":  "a",
+		}, "DEVDASHBOARD_APP_0_DAPR_HTTP"},
+		{"bad url scheme", map[string]string{
+			"DEVDASHBOARD_APP_COUNT":       "1",
+			"DEVDASHBOARD_APP_0_ID":        "a",
+			"DEVDASHBOARD_APP_0_DAPR_HTTP": "ftp://a:3500",
+		}, "DEVDASHBOARD_APP_0_DAPR_HTTP"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewAspireScanner(envFunc(tc.env))
+			if err == nil {
+				t.Fatal("want error")
+			}
+			if !strings.Contains(err.Error(), tc.wantVar) {
+				t.Fatalf("error %q does not name %s", err, tc.wantVar)
+			}
+		})
+	}
+}

--- a/pkg/discovery/scan_aspire_test.go
+++ b/pkg/discovery/scan_aspire_test.go
@@ -117,3 +117,53 @@ func TestNewAspireScannerErrorsNameTheVariable(t *testing.T) {
 		})
 	}
 }
+
+func TestNewAspireScannerCountCap(t *testing.T) {
+	_, err := NewAspireScanner(envFunc(map[string]string{"DEVDASHBOARD_APP_COUNT": "1025"}))
+	if err == nil {
+		t.Fatal("want error for count over cap")
+	}
+	if !strings.Contains(err.Error(), "DEVDASHBOARD_APP_COUNT") || !strings.Contains(err.Error(), "1024") {
+		t.Fatalf("error %q must name the variable and the cap 1024", err)
+	}
+}
+
+func TestNewAspireScannerDuplicateID(t *testing.T) {
+	_, err := NewAspireScanner(envFunc(map[string]string{
+		"DEVDASHBOARD_APP_COUNT":       "3",
+		"DEVDASHBOARD_APP_0_ID":        "orders",
+		"DEVDASHBOARD_APP_0_DAPR_HTTP": "http://a:3500",
+		"DEVDASHBOARD_APP_1_ID":        "payments",
+		"DEVDASHBOARD_APP_1_DAPR_HTTP": "http://b:3500",
+		"DEVDASHBOARD_APP_2_ID":        "orders",
+		"DEVDASHBOARD_APP_2_DAPR_HTTP": "http://c:3500",
+	}))
+	if err == nil {
+		t.Fatal("want error for duplicate app id")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "DEVDASHBOARD_APP_2_ID") || !strings.Contains(msg, "DEVDASHBOARD_APP_0_ID") {
+		t.Fatalf("error %q must name both DEVDASHBOARD_APP_2_ID and DEVDASHBOARD_APP_0_ID", err)
+	}
+	if !strings.Contains(msg, "orders") {
+		t.Fatalf("error %q must name the duplicate id", err)
+	}
+}
+
+func TestNewAspireScannerReportsAllErrors(t *testing.T) {
+	// Index 0: missing ID (valid URL). Index 1: valid ID, bad URL. Both
+	// variables must appear in the joined error.
+	_, err := NewAspireScanner(envFunc(map[string]string{
+		"DEVDASHBOARD_APP_COUNT":       "2",
+		"DEVDASHBOARD_APP_0_DAPR_HTTP": "http://a:3500",
+		"DEVDASHBOARD_APP_1_ID":        "b",
+		"DEVDASHBOARD_APP_1_DAPR_HTTP": "ftp://b:3500",
+	}))
+	if err == nil {
+		t.Fatal("want error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "DEVDASHBOARD_APP_0_ID") || !strings.Contains(msg, "DEVDASHBOARD_APP_1_DAPR_HTTP") {
+		t.Fatalf("error %q must report both index-0 ID and index-1 URL variables", err)
+	}
+}

--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -191,6 +191,7 @@ func (s *service) enrich(ctx context.Context, r ScanResult) Instance {
 		AppContainerID: r.AppContainerID, AppContainerName: r.AppContainerName,
 		SidecarReachable: r.SidecarReachable,
 		AppStatus:        r.AppStatus, DaprdStatus: r.DaprdStatus,
+		DaprHTTPBaseURL: r.DaprHTTPBaseURL, Namespace: r.Namespace, Label: r.Label,
 	}
 	// A zero Created (e.g. a compose container created but never started)
 	// would otherwise render as "00:00:00".
@@ -206,6 +207,9 @@ func (s *service) enrich(ctx context.Context, r ScanResult) Instance {
 	if in.Source == "" { // scanners predating the field (and bare test fixtures)
 		in.Source = SourceStandalone
 		in.SidecarReachable = true
+	}
+	if in.Source == SourceAspire {
+		in.IsAspire = true
 	}
 	if in.Source == SourceStandalone {
 		in.DaprdStatus = StatusRunning // the process scan saw daprd alive
@@ -231,8 +235,9 @@ func (s *service) enrich(ctx context.Context, r ScanResult) Instance {
 	if !in.SidecarReachable {
 		return in
 	}
-	in.Health = CheckHealth(ctx, s.client, r.HTTPPort)
-	md, err := FetchMetadata(ctx, s.client, r.HTTPPort)
+	base := sidecarBaseURL(r.DaprHTTPBaseURL, r.HTTPPort)
+	in.Health = CheckHealth(ctx, s.client, base)
+	md, err := FetchMetadata(ctx, s.client, base)
 	if err != nil {
 		in.MetadataOK = false
 		logger().Warn("app metadata unavailable", "appID", r.AppID, "httpPort", r.HTTPPort, "err", err)
@@ -272,6 +277,14 @@ func (s *service) enrich(ctx context.Context, r ScanResult) Instance {
 		// Container apps: metadata Extended fields (PIDs, commands, log paths)
 		// describe the container's own view; process probing and file log
 		// sources don't apply. Logs stream from the container runtime instead.
+		if md.RunTemplate != "" {
+			in.RunTemplate = md.RunTemplate
+		}
+		return in
+	}
+	if in.Source == SourceAspire {
+		// Env-contract apps are containers/executables managed by Aspire:
+		// host PIDs, stdout files, and orphan semantics don't apply.
 		if md.RunTemplate != "" {
 			in.RunTemplate = md.RunTemplate
 		}

--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -16,6 +16,9 @@ var ErrNotFound = errors.New("app not found")
 const (
 	SourceStandalone = "standalone"
 	SourceCompose    = "compose"
+	// SourceAspire marks apps injected via the DEVDASHBOARD_APP_* env
+	// contract (aspire mode, or mode-unset with the contract present).
+	SourceAspire = "aspire"
 )
 
 func logger() *slog.Logger { return slog.Default().With("component", "discovery") }
@@ -50,6 +53,15 @@ type ScanResult struct {
 	// SidecarReachable is false only for compose sidecars whose HTTP port is
 	// not published to the host (metadata/health enrichment impossible).
 	SidecarReachable bool
+
+	// DaprHTTPBaseURL, when set (aspire source), replaces
+	// http://127.0.0.1:<HTTPPort> as the daprd HTTP endpoint for health,
+	// metadata, and workflow calls.
+	DaprHTTPBaseURL string
+	// Namespace and Label come from the Aspire env contract ("" for other
+	// sources). Label is the orchestrator's display name for the app.
+	Namespace string
+	Label     string
 
 	// Per-target lifecycle status ("" = unknown; compose scanner and standalone enrichment set these).
 	AppStatus      string

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -261,6 +261,38 @@ func TestEnrichComposeCarriesContainerFields(t *testing.T) {
 	}
 }
 
+func TestEnrichAspireUsesBaseURLAndPassesThroughFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.0/healthz":
+			w.WriteHeader(200)
+		case "/v1.0/metadata":
+			_, _ = w.Write([]byte(`{"id":"orders","runtimeVersion":"1.14.4"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	scan := func() ([]ScanResult, error) {
+		return []ScanResult{{
+			AppID: "orders", Source: SourceAspire, SidecarReachable: true,
+			DaprHTTPBaseURL: srv.URL, Namespace: "default", Label: "orders-service",
+		}}, nil
+	}
+	svc := New(scan, srv.Client())
+	apps, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, apps, 1)
+	in := apps[0]
+	require.Equal(t, HealthHealthy, in.Health)
+	require.True(t, in.MetadataOK)
+	require.True(t, in.IsAspire)
+	require.Equal(t, srv.URL, in.DaprHTTPBaseURL)
+	require.Equal(t, "default", in.Namespace)
+	require.Equal(t, "orders-service", in.Label)
+}
+
 func TestHumanAge(t *testing.T) {
 	now := time.Now()
 	t.Run("zero time -> empty", func(t *testing.T) {

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -26,7 +26,7 @@ type Instance struct {
 	Health             Health `json:"health"`
 	Runtime            string `json:"runtime"`            // e.g. "go", "python", "node", "dotnet", "java", "rust", "unknown"
 	IsAspire           bool   `json:"isAspire,omitempty"` // true when the app is .NET Aspire-managed
-	Source             string `json:"source"`             // "standalone" | "compose"
+	Source             string `json:"source"`             // "standalone" | "compose" | "aspire"
 	ComposeProject     string `json:"composeProject,omitempty"`
 	ComposeService     string `json:"composeService,omitempty"`
 	DaprdContainerID   string `json:"daprdContainerId,omitempty"`

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -34,16 +34,21 @@ type Instance struct {
 	AppContainerID     string `json:"appContainerId,omitempty"`
 	AppContainerName   string `json:"appContainerName,omitempty"`
 	SidecarReachable   bool   `json:"sidecarReachable"`
-	HTTPPort           int    `json:"httpPort"`
-	GRPCPort           int    `json:"grpcPort"`
-	AppPort            int    `json:"appPort"`
-	DaprdPID           int    `json:"daprdPid"`
-	AppPID             int    `json:"appPid"` // 0 = unknown
-	CLIPID             int    `json:"cliPid"`
-	AppStatus          string `json:"appStatus,omitempty"`      // "running" | "stopped"; "" unknown
-	DaprdStatus        string `json:"daprdStatus,omitempty"`    // "running" | "stopped"; "" unknown
-	AppStartedAt       string `json:"appStartedAt,omitempty"`   // RFC3339 UTC; "" when stopped/unknown
-	DaprdStartedAt     string `json:"daprdStartedAt,omitempty"` // RFC3339 UTC; "" when stopped/unknown
+	// DaprHTTPBaseURL is the daprd HTTP endpoint for aspire-source apps
+	// ("" otherwise; consumers fall back to 127.0.0.1:httpPort).
+	DaprHTTPBaseURL string `json:"daprHttpBaseUrl,omitempty"`
+	Namespace       string `json:"namespace,omitempty"`
+	Label           string `json:"label,omitempty"`
+	HTTPPort        int    `json:"httpPort"`
+	GRPCPort        int    `json:"grpcPort"`
+	AppPort         int    `json:"appPort"`
+	DaprdPID        int    `json:"daprdPid"`
+	AppPID          int    `json:"appPid"` // 0 = unknown
+	CLIPID          int    `json:"cliPid"`
+	AppStatus       string `json:"appStatus,omitempty"`      // "running" | "stopped"; "" unknown
+	DaprdStatus     string `json:"daprdStatus,omitempty"`    // "running" | "stopped"; "" unknown
+	AppStartedAt    string `json:"appStartedAt,omitempty"`   // RFC3339 UTC; "" when stopped/unknown
+	DaprdStartedAt  string `json:"daprdStartedAt,omitempty"` // RFC3339 UTC; "" when stopped/unknown
 	// SidecarOrphaned marks a standalone daprd with no supervising dapr CLI
 	// and no live app (e.g. an external stop missed a detached sidecar).
 	SidecarOrphaned bool           `json:"sidecarOrphaned,omitempty"`

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -20,7 +20,7 @@ import (
 )
 
 // apiRouter builds the JSON API surface served under /api.
-func apiRouter(v version.Info, apps discovery.Service, containerLogs func(context.Context, string) (<-chan string, error), life lifecycle.Manager, backend WorkflowBackend, stores StoreRegistry, res resources.Service, newsSvc news.Service, cp controlplane.Manager, uc updatecheck.Service) http.Handler {
+func apiRouter(v version.Info, apps discovery.Service, containerLogs func(context.Context, string) (<-chan string, error), life lifecycle.Manager, backend WorkflowBackend, stores StoreRegistry, res resources.Service, newsSvc news.Service, cp controlplane.Manager, uc updatecheck.Service, caps Capabilities) http.Handler {
 	r := chi.NewRouter()
 	r.Get("/health", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
@@ -91,14 +91,20 @@ func apiRouter(v version.Info, apps discovery.Service, containerLogs func(contex
 			w.WriteHeader(http.StatusNoContent)
 		})
 	})
-	r.Mount("/apps", appsRouter(apps, containerLogs, life))
+	r.Mount("/apps", appsRouter(apps, containerLogs, life, caps))
 	r.Mount("/actors", actorsRouter(apps))
 	r.Mount("/subscriptions", subscriptionsRouter(apps))
-	r.Mount("/workflows", workflowsRouter(backend, stores))
+	if caps.Workflows {
+		r.Mount("/workflows", workflowsRouter(backend, stores))
+	}
 	r.Mount("/resources", resourcesRouter(res, apps))
 	r.Mount("/news", newsRouter(newsSvc))
-	r.Mount("/controlplane", controlPlaneRouter(cp))
-	r.Mount("/update-check", updateCheckRouter(uc))
+	if caps.ControlPlane {
+		r.Mount("/controlplane", controlPlaneRouter(cp))
+	}
+	if uc != nil {
+		r.Mount("/update-check", updateCheckRouter(uc))
+	}
 	return r
 }
 

--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestHealthEndpoint(t *testing.T) {
-	srv := httptest.NewServer(apiRouter(version.Info{Version: "test"}, newFakeApps(), nil, nil, newFakeBackend(fakeWF{}), nil, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{}))
+	srv := httptest.NewServer(apiRouter(version.Info{Version: "test"}, newFakeApps(), nil, nil, newFakeBackend(fakeWF{}), nil, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{}, FullCapabilities()))
 	t.Cleanup(srv.Close)
 
 	resp, err := http.Get(srv.URL + "/health")
@@ -27,7 +27,7 @@ func TestHealthEndpoint(t *testing.T) {
 }
 
 func TestVersionEndpoint(t *testing.T) {
-	srv := httptest.NewServer(apiRouter(version.Info{Version: "1.2.3", Commit: "abc", Date: "d"}, newFakeApps(), nil, nil, newFakeBackend(fakeWF{}), nil, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{}))
+	srv := httptest.NewServer(apiRouter(version.Info{Version: "1.2.3", Commit: "abc", Date: "d"}, newFakeApps(), nil, nil, newFakeBackend(fakeWF{}), nil, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{}, FullCapabilities()))
 	t.Cleanup(srv.Close)
 
 	resp, err := http.Get(srv.URL + "/version")

--- a/pkg/server/apps.go
+++ b/pkg/server/apps.go
@@ -11,8 +11,9 @@ import (
 )
 
 // appsRouter builds the /apps sub-router backed by the given discovery
-// service and lifecycle manager (nil disables lifecycle actions).
-func appsRouter(svc discovery.Service, containerLogs func(context.Context, string) (<-chan string, error), life lifecycle.Manager) http.Handler {
+// service and lifecycle manager (nil disables lifecycle actions). caps gates
+// the logs and lifecycle-action routes (list/detail stay unconditional).
+func appsRouter(svc discovery.Service, containerLogs func(context.Context, string) (<-chan string, error), life lifecycle.Manager, caps Capabilities) http.Handler {
 	r := chi.NewRouter()
 
 	r.Get("/", func(w http.ResponseWriter, req *http.Request) {
@@ -37,30 +38,34 @@ func appsRouter(svc discovery.Service, containerLogs func(context.Context, strin
 		writeJSON(w, http.StatusOK, in)
 	})
 
-	r.Get("/{appId}/logs", logsHandler(svc, containerLogs))
+	if caps.Logs {
+		r.Get("/{appId}/logs", logsHandler(svc, containerLogs))
+	}
 
-	r.Post("/{appId}/{target}/{action}", func(w http.ResponseWriter, req *http.Request) {
-		if life == nil {
-			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "lifecycle actions unavailable"})
-			return
-		}
-		err := life.Do(req.Context(),
-			chi.URLParam(req, "appId"),
-			lifecycle.Target(chi.URLParam(req, "target")),
-			lifecycle.Action(chi.URLParam(req, "action")))
-		switch {
-		case err == nil:
-			writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
-		case errors.Is(err, lifecycle.ErrInvalidTarget), errors.Is(err, lifecycle.ErrInvalidAction), errors.Is(err, lifecycle.ErrUnsupported):
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-		case errors.Is(err, discovery.ErrNotFound):
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": "app not found"})
-		case errors.Is(err, lifecycle.ErrRuntimeUnavailable):
-			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
-		default:
-			writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
-		}
-	})
+	if caps.Lifecycle {
+		r.Post("/{appId}/{target}/{action}", func(w http.ResponseWriter, req *http.Request) {
+			if life == nil {
+				writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "lifecycle actions unavailable"})
+				return
+			}
+			err := life.Do(req.Context(),
+				chi.URLParam(req, "appId"),
+				lifecycle.Target(chi.URLParam(req, "target")),
+				lifecycle.Action(chi.URLParam(req, "action")))
+			switch {
+			case err == nil:
+				writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+			case errors.Is(err, lifecycle.ErrInvalidTarget), errors.Is(err, lifecycle.ErrInvalidAction), errors.Is(err, lifecycle.ErrUnsupported):
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			case errors.Is(err, discovery.ErrNotFound):
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "app not found"})
+			case errors.Is(err, lifecycle.ErrRuntimeUnavailable):
+				writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+			default:
+				writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+			}
+		})
+	}
 
 	r.Delete("/{appId}", func(w http.ResponseWriter, req *http.Request) {
 		if life == nil {

--- a/pkg/server/apps_test.go
+++ b/pkg/server/apps_test.go
@@ -44,7 +44,7 @@ func newFakeApps() *fakeApps {
 }
 
 func TestAppsListReturnsAllInstances(t *testing.T) {
-	h := appsRouter(newFakeApps(), nil, nil)
+	h := appsRouter(newFakeApps(), nil, nil, FullCapabilities())
 	res, body := get(t, h, "/")
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Equal(t, "application/json", res.Header.Get("Content-Type"))
@@ -57,7 +57,7 @@ func TestAppsListReturnsAllInstances(t *testing.T) {
 }
 
 func TestAppsDetailReturnsInstance(t *testing.T) {
-	h := appsRouter(newFakeApps(), nil, nil)
+	h := appsRouter(newFakeApps(), nil, nil, FullCapabilities())
 	res, body := get(t, h, "/checkout")
 	require.Equal(t, http.StatusOK, res.StatusCode)
 
@@ -68,13 +68,13 @@ func TestAppsDetailReturnsInstance(t *testing.T) {
 }
 
 func TestAppsDetailReturns404ForUnknownApp(t *testing.T) {
-	h := appsRouter(newFakeApps(), nil, nil)
+	h := appsRouter(newFakeApps(), nil, nil, FullCapabilities())
 	res, _ := get(t, h, "/does-not-exist")
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
 }
 
 func TestAppsLogsReturns404WhenNoLogPath(t *testing.T) {
-	h := appsRouter(&fakeApps{instances: []discovery.Instance{{AppID: "order"}}}, nil, nil)
+	h := appsRouter(&fakeApps{instances: []discovery.Instance{{AppID: "order"}}}, nil, nil, FullCapabilities())
 	res, _ := get(t, h, "/order/logs")
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
 }
@@ -115,7 +115,7 @@ func TestAppsLifecycleRoute(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			life := &fakeLifecycle{err: tc.err}
-			h := appsRouter(newFakeApps(), nil, life)
+			h := appsRouter(newFakeApps(), nil, life, FullCapabilities())
 			req := httptest.NewRequest(http.MethodPost, "/orders/app/stop", nil)
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
@@ -130,7 +130,7 @@ func TestAppsLifecycleRoute(t *testing.T) {
 }
 
 func TestAppsLifecycleRouteNilManager(t *testing.T) {
-	h := appsRouter(newFakeApps(), nil, nil)
+	h := appsRouter(newFakeApps(), nil, nil, FullCapabilities())
 	req := httptest.NewRequest(http.MethodPost, "/orders/app/stop", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -149,7 +149,7 @@ func TestAppsForgetRoute(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			life := &fakeLifecycle{forgetErr: tc.err}
-			h := appsRouter(newFakeApps(), nil, life)
+			h := appsRouter(newFakeApps(), nil, life, FullCapabilities())
 			req := httptest.NewRequest(http.MethodDelete, "/orders", nil)
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
@@ -162,7 +162,7 @@ func TestAppsForgetRoute(t *testing.T) {
 }
 
 func TestAppsForgetRouteNilManager(t *testing.T) {
-	h := appsRouter(newFakeApps(), nil, nil)
+	h := appsRouter(newFakeApps(), nil, nil, FullCapabilities())
 	req := httptest.NewRequest(http.MethodDelete, "/orders", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -4,10 +4,24 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
-// requestGuard hardens the server against browser-borne attacks. Two modes:
+// guardConfig configures requestGuard.
+type guardConfig struct {
+	// allowAnyHost switches from the loopback allowlist to container posture.
+	allowAnyHost bool
+	// allowedHosts, when non-empty in container posture, restricts the Host
+	// header to these hostnames (case-insensitive, port ignored); loopback
+	// hostnames are always allowed. Defense against DNS rebinding.
+	allowedHosts []string
+	// port is the server's listen port, used to normalize a portless Host
+	// header when comparing Origin against Host.
+	port int
+}
+
+// requestGuard hardens the server against browser-borne attacks. Two postures:
 //
 // allowAnyHost=false (loopback bind, the host-mode default):
 //   - DNS rebinding: every request must carry a loopback Host header.
@@ -15,24 +29,36 @@ import (
 //     loopback origin on any port (the Vite dev server has its own port).
 //
 // allowAnyHost=true (aspire/container mode, reached through a proxy on an
-// arbitrary host): the Host allowlist is meaningless, so it is skipped, and
-// CSRF tightens to same-origin — a present Origin must match the request
-// Host exactly. Requests without an Origin (curl, CLI tools) pass in both
-// modes.
-func requestGuard(allowAnyHost bool) func(http.Handler) http.Handler {
+// arbitrary host): the loopback Host check is dropped. When allowedHosts is
+// non-empty, the Host header must be a loopback name or one of the allowlist
+// entries (defense against DNS rebinding through a published localhost port).
+// CSRF tightens to normalized same-origin — a present Origin must match the
+// request Host on hostname and effective port. Requests without an Origin
+// (curl, CLI tools) pass in both postures.
+func requestGuard(cfg guardConfig) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if !allowAnyHost && !isLoopbackHostname(stripPort(r.Host)) {
-				writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden: non-local Host header"})
-				return
+			if !cfg.allowAnyHost {
+				if !isLoopbackHostname(stripPort(r.Host)) {
+					writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden: non-local Host header"})
+					return
+				}
+			} else if len(cfg.allowedHosts) > 0 {
+				host := stripPort(r.Host)
+				if !isLoopbackHostname(host) && !hostInAllowlist(host, cfg.allowedHosts) {
+					writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden: Host not in allowed hosts"})
+					return
+				}
 			}
 			switch r.Method {
 			case http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch:
 				origin := r.Header.Get("Origin")
 				if origin != "" {
-					crossOrigin := !isLoopbackOrigin(origin)
-					if allowAnyHost {
-						crossOrigin = !sameOrigin(origin, r.Host)
+					var crossOrigin bool
+					if cfg.allowAnyHost {
+						crossOrigin = !normalizedSameOrigin(origin, r.Host, cfg.port)
+					} else {
+						crossOrigin = !isLoopbackOrigin(origin)
 					}
 					if crossOrigin {
 						writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden: cross-origin request"})
@@ -45,14 +71,48 @@ func requestGuard(allowAnyHost bool) func(http.Handler) http.Handler {
 	}
 }
 
-// sameOrigin reports whether an Origin header's host:port equals the
-// request's Host header.
-func sameOrigin(origin, host string) bool {
+// hostInAllowlist reports whether host (no port, no brackets) matches one of
+// the allowlist entries, case-insensitively.
+func hostInAllowlist(host string, allowed []string) bool {
+	for _, h := range allowed {
+		if strings.EqualFold(host, h) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizedSameOrigin reports whether an Origin header shares hostname and
+// effective port with the request Host. Effective ports: the Origin's explicit
+// port, else 443 for https / 80 for http; the request Host's explicit port,
+// else the server's listen port. Hostnames compare case-insensitively. An
+// unparsable or host-less Origin is rejected.
+func normalizedSameOrigin(origin, host string, port int) bool {
 	u, err := url.Parse(origin)
-	if err != nil {
+	if err != nil || u.Host == "" {
 		return false
 	}
-	return u.Host == host
+	originPort := u.Port()
+	if originPort == "" {
+		if strings.EqualFold(u.Scheme, "https") {
+			originPort = "443"
+		} else {
+			originPort = "80"
+		}
+	}
+	hostPort := portOf(host)
+	if hostPort == "" {
+		hostPort = strconv.Itoa(port)
+	}
+	return strings.EqualFold(u.Hostname(), stripPort(host)) && originPort == hostPort
+}
+
+// portOf returns the explicit port of a Host header value, or "" if none.
+func portOf(hostport string) string {
+	if _, p, err := net.SplitHostPort(hostport); err == nil {
+		return p
+	}
+	return ""
 }
 
 // stripPort returns the host part of a Host header value, which may or may

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -7,32 +7,52 @@ import (
 	"strings"
 )
 
-// localhostGuard hardens the loopback-only server against browser-borne
-// attacks:
+// requestGuard hardens the server against browser-borne attacks. Two modes:
 //
-//   - DNS rebinding: every request must carry a loopback Host header
-//     (localhost, 127.0.0.1, or ::1 — with or without a port). A rebinding
-//     attack resolves an attacker-controlled name to 127.0.0.1, so the Host
-//     header still names the attacker's domain and is rejected here.
-//   - CSRF: state-changing requests (POST/PUT/DELETE/PATCH) with an Origin
-//     header must originate from a loopback origin on any port (the Vite dev
-//     server runs on its own port). Requests without an Origin header (curl,
-//     CLI tools) are allowed.
-func localhostGuard(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !isLoopbackHostname(stripPort(r.Host)) {
-			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden: non-local Host header"})
-			return
-		}
-		switch r.Method {
-		case http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch:
-			if origin := r.Header.Get("Origin"); origin != "" && !isLoopbackOrigin(origin) {
-				writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden: cross-origin request"})
+// allowAnyHost=false (loopback bind, the host-mode default):
+//   - DNS rebinding: every request must carry a loopback Host header.
+//   - CSRF: mutating requests with an Origin header must originate from a
+//     loopback origin on any port (the Vite dev server has its own port).
+//
+// allowAnyHost=true (aspire/container mode, reached through a proxy on an
+// arbitrary host): the Host allowlist is meaningless, so it is skipped, and
+// CSRF tightens to same-origin — a present Origin must match the request
+// Host exactly. Requests without an Origin (curl, CLI tools) pass in both
+// modes.
+func requestGuard(allowAnyHost bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !allowAnyHost && !isLoopbackHostname(stripPort(r.Host)) {
+				writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden: non-local Host header"})
 				return
 			}
-		}
-		next.ServeHTTP(w, r)
-	})
+			switch r.Method {
+			case http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch:
+				origin := r.Header.Get("Origin")
+				if origin != "" {
+					crossOrigin := !isLoopbackOrigin(origin)
+					if allowAnyHost {
+						crossOrigin = !sameOrigin(origin, r.Host)
+					}
+					if crossOrigin {
+						writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden: cross-origin request"})
+						return
+					}
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// sameOrigin reports whether an Origin header's host:port equals the
+// request's Host header.
+func sameOrigin(origin, host string) bool {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	return u.Host == host
 }
 
 // stripPort returns the host part of a Host header value, which may or may

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -24,11 +24,11 @@ func guardedRequest(t *testing.T, method, host, origin string) *http.Response {
 		req.Header.Set("Origin", origin)
 	}
 	rec := httptest.NewRecorder()
-	localhostGuard(okHandler).ServeHTTP(rec, req)
+	requestGuard(false)(okHandler).ServeHTTP(rec, req)
 	return rec.Result()
 }
 
-func TestLocalhostGuardHost(t *testing.T) {
+func TestRequestGuardHost(t *testing.T) {
 	tests := []struct {
 		name string
 		host string
@@ -58,7 +58,7 @@ func TestLocalhostGuardHost(t *testing.T) {
 	}
 }
 
-func TestLocalhostGuardOrigin(t *testing.T) {
+func TestRequestGuardOrigin(t *testing.T) {
 	tests := []struct {
 		name   string
 		method string
@@ -85,9 +85,9 @@ func TestLocalhostGuardOrigin(t *testing.T) {
 	}
 }
 
-// TestRouterAppliesLocalhostGuard proves the guard is wired into the full
+// TestRouterAppliesRequestGuard proves the guard is wired into the full
 // router, in front of the API and the SPA fallback.
-func TestRouterAppliesLocalhostGuard(t *testing.T) {
+func TestRouterAppliesRequestGuard(t *testing.T) {
 	h := newTestRouter("")
 
 	send := func(method, path, host, origin string) *http.Response {
@@ -111,4 +111,38 @@ func TestRouterAppliesLocalhostGuard(t *testing.T) {
 	// Legitimate local traffic still works.
 	require.Equal(t, http.StatusOK, send(http.MethodGet, "/api/health", "127.0.0.1:9090", "").StatusCode)
 	require.Equal(t, http.StatusOK, send(http.MethodGet, "/api/health", "[::1]:8080", "").StatusCode)
+}
+
+func TestRequestGuardAllowAnyHost(t *testing.T) {
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	h := requestGuard(true)(ok)
+
+	tests := []struct {
+		name   string
+		method string
+		host   string
+		origin string
+		want   int
+	}{
+		{"non-loopback host allowed", http.MethodGet, "dashboard.example:8080", "", http.StatusOK},
+		{"proxy host allowed", http.MethodGet, "diagrid-dashboard.localhost", "", http.StatusOK},
+		{"mutating same-origin allowed", http.MethodPost, "dash.local:8080", "http://dash.local:8080", http.StatusOK},
+		{"mutating no-origin allowed", http.MethodPost, "dash.local:8080", "", http.StatusOK},
+		{"mutating cross-origin forbidden", http.MethodPost, "dash.local:8080", "http://evil.example", http.StatusForbidden},
+		{"mutating origin port mismatch forbidden", http.MethodPost, "dash.local:8080", "http://dash.local:9999", http.StatusForbidden},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "/api/health", nil)
+			req.Host = tc.host
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("got %d want %d", rec.Code, tc.want)
+			}
+		})
+	}
 }

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -24,7 +24,7 @@ func guardedRequest(t *testing.T, method, host, origin string) *http.Response {
 		req.Header.Set("Origin", origin)
 	}
 	rec := httptest.NewRecorder()
-	requestGuard(false)(okHandler).ServeHTTP(rec, req)
+	requestGuard(guardConfig{})(okHandler).ServeHTTP(rec, req)
 	return rec.Result()
 }
 
@@ -115,7 +115,7 @@ func TestRouterAppliesRequestGuard(t *testing.T) {
 
 func TestRequestGuardAllowAnyHost(t *testing.T) {
 	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
-	h := requestGuard(true)(ok)
+	h := requestGuard(guardConfig{allowAnyHost: true})(ok)
 
 	tests := []struct {
 		name   string
@@ -138,6 +138,69 @@ func TestRequestGuardAllowAnyHost(t *testing.T) {
 			if tc.origin != "" {
 				req.Header.Set("Origin", tc.origin)
 			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("got %d want %d", rec.Code, tc.want)
+			}
+		})
+	}
+}
+
+func TestRequestGuardAllowedHosts(t *testing.T) {
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	tests := []struct {
+		name         string
+		allowedHosts []string
+		host         string
+		want         int
+	}{
+		{"entry matches", []string{"dash.local"}, "dash.local", http.StatusOK},
+		{"entry matches case-insensitive", []string{"dash.local"}, "DASH.LOCAL", http.StatusOK},
+		{"entry matches ignoring port", []string{"dash.local"}, "dash.local:8080", http.StatusOK},
+		{"non-listed host forbidden", []string{"dash.local"}, "evil.example", http.StatusForbidden},
+		{"loopback always allowed", []string{"dash.local"}, "127.0.0.1:8080", http.StatusOK},
+		{"localhost always allowed", []string{"dash.local"}, "localhost", http.StatusOK},
+		{"empty list allows any host", nil, "anything.example:1234", http.StatusOK},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := requestGuard(guardConfig{allowAnyHost: true, allowedHosts: tc.allowedHosts})(ok)
+			req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+			req.Host = tc.host
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("got %d want %d", rec.Code, tc.want)
+			}
+			if tc.want == http.StatusForbidden {
+				require.Contains(t, rec.Body.String(), "Host not in allowed hosts")
+			}
+		})
+	}
+}
+
+func TestRequestGuardNormalizedSameOrigin(t *testing.T) {
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	tests := []struct {
+		name   string
+		origin string
+		host   string
+		port   int
+		want   int
+	}{
+		{"portless http origin vs explicit port 80 host", "http://dash.local", "dash.local:80", 80, http.StatusOK},
+		{"portless https origin vs portless host, cfg port 443", "https://dash.local", "dash.local", 443, http.StatusOK},
+		{"case-insensitive hostname", "http://DASH.LOCAL", "dash.local:80", 80, http.StatusOK},
+		{"effective port mismatch forbidden", "http://dash.local", "dash.local", 8080, http.StatusForbidden},
+		{"unparsable origin forbidden", "http://[bad", "dash.local", 80, http.StatusForbidden},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := requestGuard(guardConfig{allowAnyHost: true, port: tc.port})(ok)
+			req := httptest.NewRequest(http.MethodPost, "/api/health", nil)
+			req.Host = tc.host
+			req.Header.Set("Origin", tc.origin)
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
 			if rec.Code != tc.want {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -43,6 +43,25 @@ type Options struct {
 	// allowlist to same-origin CSRF (aspire/container mode, where the
 	// dashboard is reached through a proxy on an arbitrary host).
 	AllowNonLoopback bool
+	// Capabilities gates optional feature routes and the SPA's capability
+	// flags; nil means FullCapabilities (host mode).
+	Capabilities *Capabilities
+}
+
+// Capabilities gates optional feature surfaces per serving mode. The JSON
+// form is injected into the SPA as window.__DASH_CAPABILITIES__; the same
+// flags gate server-side route registration (the flags are advisory UX for
+// the UI; absent routes are the real boundary).
+type Capabilities struct {
+	Lifecycle    bool `json:"lifecycle"`
+	ControlPlane bool `json:"controlPlane"`
+	Logs         bool `json:"logs"`
+	Workflows    bool `json:"workflows"`
+}
+
+// FullCapabilities is the host-mode default: everything on.
+func FullCapabilities() Capabilities {
+	return Capabilities{Lifecycle: true, ControlPlane: true, Logs: true, Workflows: true}
 }
 
 // NewRouter wires the API and the embedded SPA under the optional base path.
@@ -54,9 +73,14 @@ func NewRouter(opts Options) http.Handler {
 	r.Use(middleware.Recoverer)
 	r.Use(requestGuard(opts.AllowNonLoopback))
 
+	caps := FullCapabilities()
+	if opts.Capabilities != nil {
+		caps = *opts.Capabilities
+	}
+
 	mount := func(router chi.Router) {
-		router.Mount("/api", apiRouter(opts.Version, opts.Apps, opts.ContainerLogs, opts.Lifecycle, opts.Backend, opts.Stores, opts.Resources, opts.News, opts.ControlPlane, opts.UpdateCheck))
-		router.Handle("/*", SPAHandler(opts.DistFS, opts.BasePath, opts.TelemetryEnabled))
+		router.Mount("/api", apiRouter(opts.Version, opts.Apps, opts.ContainerLogs, opts.Lifecycle, opts.Backend, opts.Stores, opts.Resources, opts.News, opts.ControlPlane, opts.UpdateCheck, caps))
+		router.Handle("/*", SPAHandler(opts.DistFS, opts.BasePath, opts.TelemetryEnabled, caps))
 	}
 
 	if base == "" {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -43,6 +43,13 @@ type Options struct {
 	// allowlist to same-origin CSRF (aspire/container mode, where the
 	// dashboard is reached through a proxy on an arbitrary host).
 	AllowNonLoopback bool
+	// AllowedHosts, when non-empty in container posture, restricts the Host
+	// header to these hostnames (loopback names always allowed); empty means
+	// any Host passes. Populated from DEVDASHBOARD_ALLOWED_HOSTS.
+	AllowedHosts []string
+	// ListenPort is the server's listen port, used to normalize a portless
+	// Host header when comparing Origin against Host in container posture.
+	ListenPort int
 	// Capabilities gates optional feature routes and the SPA's capability
 	// flags; nil means FullCapabilities (host mode).
 	Capabilities *Capabilities
@@ -71,7 +78,7 @@ func NewRouter(opts Options) http.Handler {
 
 	r := chi.NewRouter()
 	r.Use(middleware.Recoverer)
-	r.Use(requestGuard(opts.AllowNonLoopback))
+	r.Use(requestGuard(guardConfig{allowAnyHost: opts.AllowNonLoopback, allowedHosts: opts.AllowedHosts, port: opts.ListenPort}))
 
 	caps := FullCapabilities()
 	if opts.Capabilities != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -39,6 +39,10 @@ type Options struct {
 	UpdateCheck  updatecheck.Service
 	// TelemetryEnabled controls whether the served SPA loads Datadog RUM.
 	TelemetryEnabled bool
+	// AllowNonLoopback switches the request guard from the loopback
+	// allowlist to same-origin CSRF (aspire/container mode, where the
+	// dashboard is reached through a proxy on an arbitrary host).
+	AllowNonLoopback bool
 }
 
 // NewRouter wires the API and the embedded SPA under the optional base path.
@@ -48,7 +52,7 @@ func NewRouter(opts Options) http.Handler {
 
 	r := chi.NewRouter()
 	r.Use(middleware.Recoverer)
-	r.Use(localhostGuard)
+	r.Use(requestGuard(opts.AllowNonLoopback))
 
 	mount := func(router chi.Router) {
 		router.Mount("/api", apiRouter(opts.Version, opts.Apps, opts.ContainerLogs, opts.Lifecycle, opts.Backend, opts.Stores, opts.Resources, opts.News, opts.ControlPlane, opts.UpdateCheck))

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -3,7 +3,9 @@
 package server
 
 import (
+	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"testing/fstest"
 
@@ -19,6 +21,28 @@ func newTestRouter(basePath string) http.Handler {
 		Apps:     newFakeApps(),
 		Backend:  newFakeBackend(fakeWF{}),
 	})
+}
+
+// buildTestOptions constructs an Options with every optional service wired to
+// a real (fake) implementation, following the same inline-literal pattern as
+// newTestRouter above, so capability gating can be exercised against routes
+// that would otherwise actually work rather than routes that are merely
+// nil-guarded already.
+func buildTestOptions() Options {
+	return Options{
+		DistFS:  fstest.MapFS{"index.html": {Data: []byte("shell")}},
+		Version: version.Info{Version: "test"},
+		Apps:    newFakeApps(),
+		ContainerLogs: func(_ context.Context, _ string) (<-chan string, error) {
+			ch := make(chan string)
+			close(ch)
+			return ch, nil
+		},
+		Lifecycle:    &fakeLifecycle{},
+		Backend:      newFakeBackend(fakeWF{}),
+		ControlPlane: &fakeManager{},
+		UpdateCheck:  fakeUpdateCheck{},
+	}
 }
 
 func TestRouterServesAPIAndSPA(t *testing.T) {
@@ -56,6 +80,49 @@ func TestRouterServesApps(t *testing.T) {
 	res, body := get(t, h, "/api/apps")
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Contains(t, body, "appId")
+}
+
+func TestRouterCapabilityGating(t *testing.T) {
+	limited := Capabilities{Workflows: true} // aspire-with-store shape
+	opts := buildTestOptions()
+	opts.Capabilities = &limited
+	srv := httptest.NewServer(NewRouter(opts))
+	defer srv.Close()
+
+	get := func(path string) int {
+		resp, err := http.Get(srv.URL + path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+	if got := get("/api/controlplane/"); got != http.StatusNotFound {
+		t.Fatalf("controlplane: got %d want 404", got)
+	}
+	if got := get("/api/apps/some-app/logs"); got != http.StatusNotFound {
+		t.Fatalf("logs: got %d want 404", got)
+	}
+	resp, err := http.Post(srv.URL+"/api/apps/some-app/app/stop", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound && resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("lifecycle: got %d want 404/405", resp.StatusCode)
+	}
+	if got := get("/api/workflows/"); got == http.StatusNotFound {
+		t.Fatal("workflows should be mounted")
+	}
+	// nil Capabilities keeps everything mounted (host default).
+	opts2 := buildTestOptions()
+	srv2 := httptest.NewServer(NewRouter(opts2))
+	defer srv2.Close()
+	resp2, _ := http.Get(srv2.URL + "/api/controlplane/")
+	if resp2.StatusCode == http.StatusNotFound {
+		t.Fatal("nil capabilities must keep controlplane mounted")
+	}
+	resp2.Body.Close()
 }
 
 func TestRouterInjectsTelemetryFlag(t *testing.T) {

--- a/pkg/server/spa.go
+++ b/pkg/server/spa.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"encoding/json"
 	"io/fs"
 	"net/http"
 	"path"
@@ -12,8 +13,10 @@ import (
 // unknown paths so client-side (History-API) routing works. basePath is the
 // optional subpath the app is mounted under ("" for root). telemetryEnabled
 // is injected into the served index.html as window.__DASH_TELEMETRY_ENABLED__
-// so the front-end knows whether to load Datadog RUM.
-func SPAHandler(fsys fs.FS, basePath string, telemetryEnabled bool) http.Handler {
+// so the front-end knows whether to load Datadog RUM. caps is injected as
+// window.__DASH_CAPABILITIES__ so the front-end can hide UI for routes the
+// server has gated off.
+func SPAHandler(fsys fs.FS, basePath string, telemetryEnabled bool, caps Capabilities) http.Handler {
 	basePath = "/" + strings.Trim(basePath, "/")
 	fileServer := http.FileServer(http.FS(fsys))
 
@@ -42,11 +45,11 @@ func SPAHandler(fsys fs.FS, basePath string, telemetryEnabled bool) http.Handler
 			http.NotFound(w, r)
 			return
 		}
-		serveIndex(w, r, fsys, telemetryEnabled)
+		serveIndex(w, r, fsys, telemetryEnabled, caps)
 	})
 }
 
-func serveIndex(w http.ResponseWriter, _ *http.Request, fsys fs.FS, telemetryEnabled bool) {
+func serveIndex(w http.ResponseWriter, _ *http.Request, fsys fs.FS, telemetryEnabled bool, caps Capabilities) {
 	data, err := fs.ReadFile(fsys, "index.html")
 	if err != nil {
 		http.Error(w, "index.html not found", http.StatusInternalServerError)
@@ -56,7 +59,12 @@ func serveIndex(w http.ResponseWriter, _ *http.Request, fsys fs.FS, telemetryEna
 	if telemetryEnabled {
 		flag = "true"
 	}
-	script := []byte("<script>window.__DASH_TELEMETRY_ENABLED__=" + flag + ";</script></head>")
+	capsJSON, err := json.Marshal(caps)
+	if err != nil {
+		capsJSON = []byte("{}")
+	}
+	script := []byte("<script>window.__DASH_TELEMETRY_ENABLED__=" + flag +
+		";window.__DASH_CAPABILITIES__=" + string(capsJSON) + ";</script></head>")
 	data = bytes.Replace(data, []byte("</head>"), script, 1)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")

--- a/pkg/server/spa.go
+++ b/pkg/server/spa.go
@@ -61,10 +61,8 @@ func serveIndex(w http.ResponseWriter, _ *http.Request, fsys fs.FS, telemetryEna
 	if telemetryEnabled {
 		flag = "true"
 	}
-	capsJSON, err := json.Marshal(caps)
-	if err != nil {
-		capsJSON = []byte("{}")
-	}
+	// caps is a bool-only struct, so marshaling cannot fail.
+	capsJSON, _ := json.Marshal(caps)
 	// strconv.Quote produces a safely-escaped JS string literal for the version.
 	script := []byte("<script>window.__DASH_TELEMETRY_ENABLED__=" + flag +
 		";window.__DASH_VERSION__=" + strconv.Quote(version) +

--- a/pkg/server/spa_test.go
+++ b/pkg/server/spa_test.go
@@ -22,7 +22,7 @@ func testFS() fstest.MapFS {
 func get(t *testing.T, h http.Handler, path string) (*http.Response, string) {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, path, nil)
-	req.Host = "127.0.0.1:9090" // httptest defaults to example.com, which localhostGuard rejects
+	req.Host = "127.0.0.1:9090" // httptest defaults to example.com, which requestGuard(false) rejects
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 	res := rec.Result()

--- a/pkg/server/spa_test.go
+++ b/pkg/server/spa_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -32,14 +33,14 @@ func get(t *testing.T, h http.Handler, path string) (*http.Response, string) {
 }
 
 func TestSPAServesExistingFile(t *testing.T) {
-	h := SPAHandler(testFS(), "", true)
+	h := SPAHandler(testFS(), "", true, FullCapabilities())
 	res, body := get(t, h, "/assets/app.js")
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Contains(t, body, "console.log")
 }
 
 func TestSPAFallsBackToIndex(t *testing.T) {
-	h := SPAHandler(testFS(), "", true)
+	h := SPAHandler(testFS(), "", true, FullCapabilities())
 	res, body := get(t, h, "/workflows/order/abc123")
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Contains(t, body, "shell")
@@ -47,14 +48,14 @@ func TestSPAFallsBackToIndex(t *testing.T) {
 }
 
 func TestSPARespectsBasePath(t *testing.T) {
-	h := SPAHandler(testFS(), "/dashboard", true)
+	h := SPAHandler(testFS(), "/dashboard", true, FullCapabilities())
 	res, body := get(t, h, "/dashboard/anything")
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Contains(t, body, "shell")
 }
 
 func TestSPADirectoryRequestDoesNotListContents(t *testing.T) {
-	h := SPAHandler(testFS(), "", true)
+	h := SPAHandler(testFS(), "", true, FullCapabilities())
 
 	// An embedded directory must not produce an http.FileServer auto-index
 	// (or a redirect toward one); it is a client-route miss → SPA shell.
@@ -67,20 +68,33 @@ func TestSPADirectoryRequestDoesNotListContents(t *testing.T) {
 }
 
 func TestSPAMissingAssetReturns404(t *testing.T) {
-	h := SPAHandler(testFS(), "", true)
+	h := SPAHandler(testFS(), "", true, FullCapabilities())
 	res, body := get(t, h, "/assets/missing.js")
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
 	require.NotContains(t, body, "shell")
 }
 
 func TestSPAInjectsTelemetryEnabledTrue(t *testing.T) {
-	h := SPAHandler(testFS(), "", true)
+	h := SPAHandler(testFS(), "", true, FullCapabilities())
 	_, body := get(t, h, "/")
-	require.Contains(t, body, "<script>window.__DASH_TELEMETRY_ENABLED__=true;</script>")
+	require.Contains(t, body, "<script>window.__DASH_TELEMETRY_ENABLED__=true;")
 }
 
 func TestSPAInjectsTelemetryEnabledFalse(t *testing.T) {
-	h := SPAHandler(testFS(), "", false)
+	h := SPAHandler(testFS(), "", false, FullCapabilities())
 	_, body := get(t, h, "/")
-	require.Contains(t, body, "<script>window.__DASH_TELEMETRY_ENABLED__=false;</script>")
+	require.Contains(t, body, "<script>window.__DASH_TELEMETRY_ENABLED__=false;")
+}
+
+func TestServeIndexInjectsCapabilities(t *testing.T) {
+	fsys := fstest.MapFS{"index.html": {Data: []byte("<html><head></head><body></body></html>")}}
+	h := SPAHandler(fsys, "", false, Capabilities{Workflows: true})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	h.ServeHTTP(rec, req)
+	body := rec.Body.String()
+	want := `window.__DASH_CAPABILITIES__={"lifecycle":false,"controlPlane":false,"logs":false,"workflows":true}`
+	if !strings.Contains(body, want) {
+		t.Fatalf("body missing %q:\n%s", want, body)
+	}
 }

--- a/pkg/server/statestores_test.go
+++ b/pkg/server/statestores_test.go
@@ -57,7 +57,7 @@ func (m *mutableStoreRegistry) DeleteStore(id string) error {
 }
 
 func newAPI(stores StoreRegistry) http.Handler {
-	return apiRouter(version.Info{}, nil, nil, nil, newFakeBackend(fakeWF{}), stores, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{})
+	return apiRouter(version.Info{}, nil, nil, nil, newFakeBackend(fakeWF{}), stores, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{}, FullCapabilities())
 }
 
 func doReq(t *testing.T, h http.Handler, req *http.Request) (*http.Response, string) {

--- a/pkg/server/workflows_test.go
+++ b/pkg/server/workflows_test.go
@@ -240,7 +240,7 @@ func TestStateStoresEndpoint(t *testing.T) {
 	stores := fakeStoreRegistry{stores: []StoreInfo{
 		{ID: "statestore-auto", Name: "statestore", Type: "state.redis", Source: "auto", Active: true, Connection: "localhost:6379"},
 	}}
-	h := apiRouter(version.Info{}, nil, nil, nil, newFakeBackend(fakeWF{}), stores, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{})
+	h := apiRouter(version.Info{}, nil, nil, nil, newFakeBackend(fakeWF{}), stores, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{}, FullCapabilities())
 	res, body := get(t, h, "/statestores")
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Contains(t, body, `"name":"statestore"`)
@@ -251,7 +251,7 @@ func TestStateStoresEndpoint(t *testing.T) {
 }
 
 func TestStateStoresNilRegistry(t *testing.T) {
-	h := apiRouter(version.Info{}, nil, nil, nil, newFakeBackend(fakeWF{}), nil, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{})
+	h := apiRouter(version.Info{}, nil, nil, nil, newFakeBackend(fakeWF{}), nil, fakeResources{}, fakeNews{}, nil, fakeUpdateCheck{}, FullCapabilities())
 	res, body := get(t, h, "/statestores")
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.Contains(t, body, `[]`)

--- a/pkg/workflow/remove.go
+++ b/pkg/workflow/remove.go
@@ -17,7 +17,10 @@ type RemoveTarget struct {
 	InstanceID string
 	Status     Status
 	HTTPPort   int
-	Healthy    bool
+	// DaprHTTPBaseURL, when set (aspire-discovered apps), replaces
+	// http://127.0.0.1:<HTTPPort> for the terminate/purge calls.
+	DaprHTTPBaseURL string
+	Healthy         bool
 }
 
 type RemoveResult struct {
@@ -42,7 +45,8 @@ func NewRemover(client *http.Client, store statestore.Store, namespace string) *
 
 func (r *Remover) Remove(ctx context.Context, t RemoveTarget, force bool) RemoveResult {
 	log := slog.Default().With("component", "workflow")
-	mech := SelectMechanism(t.Status, t.Healthy && t.HTTPPort > 0, force)
+	reachable := t.Healthy && (t.HTTPPort > 0 || t.DaprHTTPBaseURL != "")
+	mech := SelectMechanism(t.Status, reachable, force)
 	res := RemoveResult{InstanceID: t.InstanceID, Mechanism: mech}
 	log.Info("workflow removal requested", "app", t.AppID, "instance", t.InstanceID, "mechanism", string(mech), "force", force)
 	var err error
@@ -82,15 +86,19 @@ func (r *Remover) RemoveMany(ctx context.Context, targets []RemoveTarget, force 
 }
 
 func (r *Remover) terminate(ctx context.Context, t RemoveTarget) error {
-	return r.post(ctx, t.HTTPPort, t.InstanceID, "terminate")
+	return r.post(ctx, t, "terminate")
 }
 
 func (r *Remover) purge(ctx context.Context, t RemoveTarget) error {
-	return r.post(ctx, t.HTTPPort, t.InstanceID, "purge")
+	return r.post(ctx, t, "purge")
 }
 
-func (r *Remover) post(ctx context.Context, port int, instanceID, action string) error {
-	u := fmt.Sprintf("http://127.0.0.1:%d/v1.0-beta1/workflows/%s/%s/%s", port, WorkflowComponent, instanceID, action)
+func (r *Remover) post(ctx context.Context, t RemoveTarget, action string) error {
+	base := t.DaprHTTPBaseURL
+	if base == "" {
+		base = fmt.Sprintf("http://127.0.0.1:%d", t.HTTPPort)
+	}
+	u := fmt.Sprintf("%s/v1.0-beta1/workflows/%s/%s/%s", base, WorkflowComponent, t.InstanceID, action)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
 	if err != nil {
 		return err

--- a/pkg/workflow/remove.go
+++ b/pkg/workflow/remove.go
@@ -21,6 +21,10 @@ type RemoveTarget struct {
 	// http://127.0.0.1:<HTTPPort> for the terminate/purge calls.
 	DaprHTTPBaseURL string
 	Healthy         bool
+	// Namespace, when non-empty (aspire per-app DEVDASHBOARD_APP_<i>_NAMESPACE),
+	// scopes the force-delete state-key pattern to the app's own namespace.
+	// Empty (host-scanned apps) falls back to the remover's store namespace.
+	Namespace string
 }
 
 type RemoveResult struct {
@@ -120,7 +124,11 @@ func (r *Remover) forceDelete(ctx context.Context, t RemoveTarget) error {
 		slog.Default().With("component", "workflow").Warn("force delete unavailable", "app", t.AppID, "instance", t.InstanceID)
 		return fmt.Errorf("force delete unavailable: no state store")
 	}
-	keys, _, err := r.store.Keys(ctx, statestore.InstanceKeyPattern(r.namespace, t.AppID, t.InstanceID), "", 0)
+	ns := r.namespace
+	if t.Namespace != "" {
+		ns = t.Namespace
+	}
+	keys, _, err := r.store.Keys(ctx, statestore.InstanceKeyPattern(ns, t.AppID, t.InstanceID), "", 0)
 	if err != nil {
 		return err
 	}

--- a/pkg/workflow/remove_test.go
+++ b/pkg/workflow/remove_test.go
@@ -95,6 +95,52 @@ func TestRemoveForceDeletesKeys(t *testing.T) {
 	require.Contains(t, f.kv, "order||other||keep||metadata") // untouched
 }
 
+// patternStore wraps fakeStore to record the LIKE patterns passed to Keys.
+type patternStore struct {
+	*fakeStore
+	patterns []string
+}
+
+func (p *patternStore) Keys(ctx context.Context, pattern, token string, n int) ([]string, string, error) {
+	p.patterns = append(p.patterns, pattern)
+	return p.fakeStore.Keys(ctx, pattern, token, n)
+}
+
+func TestRemoveForceDeleteUsesPerAppNamespace(t *testing.T) {
+	f := &patternStore{fakeStore: newFakeStore()}
+	// Instance data lives under the app's own namespace "prod", while the
+	// remover's store namespace is the global "default".
+	prefix := statestore.InstancePrefix("prod", "order", "stuck")
+	f.kv[prefix+"metadata"] = []byte("{}")
+	f.kv[prefix+"history-000000"] = []byte("x")
+
+	r := NewRemover(&http.Client{Timeout: time.Second}, f, "default")
+	res := r.Remove(context.Background(), RemoveTarget{
+		AppID: "order", InstanceID: "stuck", Namespace: "prod", Status: StatusRunning, Healthy: false,
+	}, false)
+	require.True(t, res.OK, res.Error)
+	require.Equal(t, MechForce, res.Mechanism)
+	require.NotContains(t, f.kv, prefix+"metadata")
+	require.NotContains(t, f.kv, prefix+"history-000000")
+	require.Contains(t, f.patterns, statestore.InstanceKeyPattern("prod", "order", "stuck"),
+		"force delete must scan under the target's per-app namespace")
+}
+
+func TestRemoveForceDeleteFallsBackToRemoverNamespace(t *testing.T) {
+	f := &patternStore{fakeStore: newFakeStore()}
+	prefix := statestore.InstancePrefix("default", "order", "stuck")
+	f.kv[prefix+"metadata"] = []byte("{}")
+
+	r := NewRemover(&http.Client{Timeout: time.Second}, f, "default")
+	res := r.Remove(context.Background(), RemoveTarget{
+		AppID: "order", InstanceID: "stuck", Namespace: "", Status: StatusRunning, Healthy: false,
+	}, false)
+	require.True(t, res.OK, res.Error)
+	require.NotContains(t, f.kv, prefix+"metadata")
+	require.Contains(t, f.patterns, statestore.InstanceKeyPattern("default", "order", "stuck"),
+		"empty target namespace must fall back to the remover's store namespace")
+}
+
 func TestRemoverUsesBaseURL(t *testing.T) {
 	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/workflow/remove_test.go
+++ b/pkg/workflow/remove_test.go
@@ -95,6 +95,50 @@ func TestRemoveForceDeletesKeys(t *testing.T) {
 	require.Contains(t, f.kv, "order||other||keep||metadata") // untouched
 }
 
+func TestRemoverUsesBaseURL(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	r := NewRemover(srv.Client(), nil, "default")
+	res := r.Remove(context.Background(), RemoveTarget{
+		AppID:           "orders",
+		InstanceID:      "wf-1",
+		Status:          StatusCompleted, // terminal → MechPurge (single POST)
+		DaprHTTPBaseURL: srv.URL,
+		Healthy:         true,
+	}, false)
+	if !res.OK {
+		t.Fatalf("remove failed: %+v", res)
+	}
+	if want := "/v1.0-beta1/workflows/dapr/wf-1/purge"; gotPath != want {
+		t.Fatalf("path %q want %q", gotPath, want)
+	}
+}
+
+func TestRemoverBaseURLCountsAsReachable(t *testing.T) {
+	// HTTPPort 0 but a base URL present must still select the HTTP mechanism,
+	// not force-delete.
+	if got := SelectMechanism(StatusCompleted, true, false); got != MechPurge {
+		t.Fatalf("sanity: %v", got)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	r := NewRemover(srv.Client(), nil, "default")
+	res := r.Remove(context.Background(), RemoveTarget{
+		AppID: "a", InstanceID: "i", Status: StatusCompleted,
+		HTTPPort: 0, DaprHTTPBaseURL: srv.URL, Healthy: true,
+	}, false)
+	if !res.OK || res.Mechanism != MechPurge {
+		t.Fatalf("want OK purge, got %+v", res)
+	}
+}
+
 func mustPort(t *testing.T, raw string) int {
 	t.Helper()
 	u, err := url.Parse(raw)

--- a/pkg/workflow/service.go
+++ b/pkg/workflow/service.go
@@ -51,13 +51,46 @@ type Service interface {
 type service struct {
 	store     statestore.Store
 	namespace string
+	// nsResolver, when set, maps an app-id to its per-app namespace (aspire
+	// DEVDASHBOARD_APP_<i>_NAMESPACE). It returns "" when the app has no
+	// per-app namespace, in which case the store namespace is used. It is only
+	// consulted for app-scoped operations (Get/history and app-filtered
+	// List/Stats); the store-wide scans (all-apps List/Stats, AppIDs) always
+	// use the store namespace.
+	nsResolver func(ctx context.Context, appID string) string
 }
 
-func New(store statestore.Store, namespace string) Service {
+// Option customizes a workflow Service.
+type Option func(*service)
+
+// WithNamespaceResolver injects a per-app namespace lookup used by app-scoped
+// operations. fn returns "" to fall back to the store namespace.
+func WithNamespaceResolver(fn func(ctx context.Context, appID string) string) Option {
+	return func(s *service) { s.nsResolver = fn }
+}
+
+func New(store statestore.Store, namespace string, opts ...Option) Service {
 	if namespace == "" {
 		namespace = "default"
 	}
-	return &service{store: store, namespace: namespace}
+	s := &service{store: store, namespace: namespace}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// effectiveNS returns the namespace to use for an app-scoped operation: the
+// app's per-app namespace when a resolver is set and returns non-empty for a
+// specific app-id, otherwise the store namespace. An empty appID (all-apps
+// scan) always uses the store namespace.
+func (s *service) effectiveNS(ctx context.Context, appID string) string {
+	if appID != "" && s.nsResolver != nil {
+		if ns := s.nsResolver(ctx, appID); ns != "" {
+			return ns
+		}
+	}
+	return s.namespace
 }
 
 // unreachableService is a workflow.Service for a known state store whose
@@ -96,11 +129,12 @@ func (u unreachableService) AppIDs(context.Context) ([]string, error) {
 }
 
 // metaKeys returns instance-metadata keys: scoped to one app when appID != "",
-// otherwise across every app-id in the namespace.
-func (s *service) metaKeys(ctx context.Context, appID, token string, pageSize int) ([]string, string, error) {
-	pattern := statestore.AllInstanceMetaPattern(s.namespace)
+// otherwise across every app-id in the namespace. ns is the namespace to scan
+// (the per-app namespace for an app-scoped query, else the store namespace).
+func (s *service) metaKeys(ctx context.Context, ns, appID, token string, pageSize int) ([]string, string, error) {
+	pattern := statestore.AllInstanceMetaPattern(ns)
 	if appID != "" {
-		pattern = statestore.InstanceMetaPattern(s.namespace, appID)
+		pattern = statestore.InstanceMetaPattern(ns, appID)
 	}
 	return s.store.Keys(ctx, pattern, token, pageSize)
 }
@@ -123,6 +157,10 @@ func (s *service) List(ctx context.Context, q ListQuery) (ListResult, error) {
 	if pageSize <= 0 {
 		pageSize = defaultPageSize
 	}
+	// For an app-filtered query, honor the app's per-app namespace for both the
+	// key scan and the per-instance load. The all-apps scan (AppID == "") uses
+	// the store namespace.
+	ns := s.effectiveNS(ctx, q.AppID)
 
 	// Any predicate that can reject an instance makes a key-page under-fill.
 	filtered := len(q.Status) > 0 || q.Search != "" || !q.IncludeChildren
@@ -137,7 +175,7 @@ func (s *service) List(ctx context.Context, q ListQuery) (ListResult, error) {
 	next := ""
 	scanned := 0
 	for {
-		metaKeys, n, err := s.metaKeys(ctx, q.AppID, token, pageSize)
+		metaKeys, n, err := s.metaKeys(ctx, ns, q.AppID, token, pageSize)
 		if err != nil {
 			return ListResult{}, err
 		}
@@ -157,7 +195,7 @@ func (s *service) List(ctx context.Context, q ListQuery) (ListResult, error) {
 				continue
 			}
 			seen[dedupKey] = struct{}{}
-			ex, err := s.load(ctx, appID, id)
+			ex, err := s.load(ctx, ns, appID, id)
 			if err != nil {
 				continue
 			}
@@ -195,8 +233,9 @@ func (s *service) Stats(ctx context.Context, q ListQuery) (StatsResult, error) {
 	searchQ := ListQuery{Search: q.Search, IncludeChildren: q.IncludeChildren}
 	res := StatsResult{Counts: map[Status]int{}}
 	seen := make(map[string]struct{})
+	ns := s.effectiveNS(ctx, q.AppID)
 
-	metaKeys, _, err := s.metaKeys(ctx, q.AppID, "", 0)
+	metaKeys, _, err := s.metaKeys(ctx, ns, q.AppID, "", 0)
 	if err != nil {
 		return StatsResult{}, err
 	}
@@ -214,7 +253,7 @@ func (s *service) Stats(ctx context.Context, q ListQuery) (StatsResult, error) {
 			continue
 		}
 		seen[dedupKey] = struct{}{}
-		ex, err := s.load(ctx, appID, id)
+		ex, err := s.load(ctx, ns, appID, id)
 		if err != nil {
 			continue
 		}
@@ -260,7 +299,7 @@ func (s *service) Get(ctx context.Context, appID, instanceID string) (Execution,
 	if s.store == nil {
 		return Execution{}, ErrNoStore
 	}
-	ex, err := s.load(ctx, appID, instanceID)
+	ex, err := s.load(ctx, s.effectiveNS(ctx, appID), appID, instanceID)
 	if err != nil {
 		return Execution{}, err
 	}
@@ -270,9 +309,10 @@ func (s *service) Get(ctx context.Context, appID, instanceID string) (Execution,
 	return ex, nil
 }
 
-// load reads an instance's history-* and customStatus keys and decodes them.
-func (s *service) load(ctx context.Context, appID, instanceID string) (Execution, error) {
-	keys, _, err := s.store.Keys(ctx, statestore.InstanceKeyPattern(s.namespace, appID, instanceID), "", 0)
+// load reads an instance's history-* and customStatus keys and decodes them
+// under the given namespace.
+func (s *service) load(ctx context.Context, ns, appID, instanceID string) (Execution, error) {
+	keys, _, err := s.store.Keys(ctx, statestore.InstanceKeyPattern(ns, appID, instanceID), "", 0)
 	if err != nil {
 		return Execution{}, err
 	}
@@ -283,7 +323,7 @@ func (s *service) load(ctx context.Context, appID, instanceID string) (Execution
 	if err != nil {
 		return Execution{}, err
 	}
-	prefix := statestore.InstancePrefix(s.namespace, appID, instanceID)
+	prefix := statestore.InstancePrefix(ns, appID, instanceID)
 	var history []*protos.HistoryEvent
 	var historyKeys []string
 	customStatus := ""

--- a/pkg/workflow/service_test.go
+++ b/pkg/workflow/service_test.go
@@ -108,6 +108,43 @@ func TestServiceListAndFilter(t *testing.T) {
 	require.Empty(t, res.Items)
 }
 
+func TestServiceGetUsesPerAppNamespace(t *testing.T) {
+	f := newFakeStore()
+	// Instance data lives under the app's own namespace "prod"; the service's
+	// store namespace is the global "default".
+	seedWorkflow(t, f, "prod", "order", "inst-a", "OrderWorkflow", []*protos.HistoryEvent{startedEvent("OrderWorkflow")})
+
+	nsFor := func(_ context.Context, appID string) string {
+		if appID == "order" {
+			return "prod"
+		}
+		return ""
+	}
+	svc := New(f, "default", WithNamespaceResolver(nsFor))
+
+	ex, err := svc.Get(context.Background(), "order", "inst-a")
+	require.NoError(t, err)
+	require.Equal(t, "OrderWorkflow", ex.Name)
+
+	// A list filtered by that app also honors the per-app namespace.
+	res, err := svc.List(context.Background(), ListQuery{AppID: "order"})
+	require.NoError(t, err)
+	require.Len(t, res.Items, 1)
+	require.Equal(t, "inst-a", res.Items[0].InstanceID)
+}
+
+func TestServiceGetFallsBackToStoreNamespace(t *testing.T) {
+	f := newFakeStore()
+	seedWorkflow(t, f, "default", "order", "inst-a", "OrderWorkflow", []*protos.HistoryEvent{startedEvent("OrderWorkflow")})
+
+	// Resolver returns "" (e.g. host-scanned app) → fall back to store namespace.
+	svc := New(f, "default", WithNamespaceResolver(func(context.Context, string) string { return "" }))
+
+	ex, err := svc.Get(context.Background(), "order", "inst-a")
+	require.NoError(t, err)
+	require.Equal(t, "OrderWorkflow", ex.Name)
+}
+
 func TestServiceListNoStore(t *testing.T) {
 	svc := New(nil, "default")
 	_, err := svc.List(context.Background(), ListQuery{})

--- a/test/e2e/workflow_e2e_test.go
+++ b/test/e2e/workflow_e2e_test.go
@@ -101,9 +101,7 @@ func TestDaprWorkflowReadBack(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 
-	svc := workflow.New(store, "default", func(context.Context) ([]string, error) {
-		return []string{"ordersvc"}, nil
-	})
+	svc := workflow.New(store, "default")
 
 	ex, err := svc.Get(context.Background(), "ordersvc", instanceID)
 	require.NoError(t, err)

--- a/web/src/components/TopNav.test.tsx
+++ b/web/src/components/TopNav.test.tsx
@@ -105,6 +105,21 @@ describe('TopNav', () => {
     expect(trackAction).toHaveBeenCalledWith('nav_click', { label: 'Workflows' })
   })
 
+  it('hides capability-gated entries when their capability is off', () => {
+    window.__DASH_CAPABILITIES__ = {
+      lifecycle: false,
+      controlPlane: false,
+      logs: false,
+      workflows: true,
+    }
+    renderNav()
+    expect(screen.queryByText('Control Plane')).toBeNull()
+    expect(screen.queryByText('Logs')).toBeNull()
+    expect(screen.getByText('Workflows')).toBeInTheDocument()
+    expect(screen.getByText('Applications')).toBeInTheDocument()
+    delete window.__DASH_CAPABILITIES__
+  })
+
   describe('topbar height tracking', () => {
     afterEach(() => {
       vi.unstubAllGlobals()

--- a/web/src/components/TopNav.test.tsx
+++ b/web/src/components/TopNav.test.tsx
@@ -47,6 +47,10 @@ describe('NAV_ITEMS', () => {
 })
 
 describe('TopNav', () => {
+  afterEach(() => {
+    delete window.__DASH_CAPABILITIES__
+  })
+
   function renderNav() {
     return render(
       <RefreshProvider>
@@ -117,7 +121,6 @@ describe('TopNav', () => {
     expect(screen.queryByText('Logs')).toBeNull()
     expect(screen.getByText('Workflows')).toBeInTheDocument()
     expect(screen.getByText('Applications')).toBeInTheDocument()
-    delete window.__DASH_CAPABILITIES__
   })
 
   describe('topbar height tracking', () => {

--- a/web/src/components/TopNav.tsx
+++ b/web/src/components/TopNav.tsx
@@ -5,22 +5,24 @@ import { ThemeToggle } from './ThemeToggle'
 import { RefreshControl } from './RefreshControl'
 import type { Theme } from '../lib/prefs'
 import { trackAction } from '../lib/telemetry'
+import { getCapabilities, type Capabilities } from '../lib/capabilities'
 
 export interface NavItem {
   label: string
   to: string
+  cap?: keyof Capabilities
 }
 
 export const NAV_ITEMS: NavItem[] = [
   { label: 'Applications', to: '/' },
   { label: 'Components', to: '/components' },
-  { label: 'Workflows', to: '/workflows' },
+  { label: 'Workflows', to: '/workflows', cap: 'workflows' },
   { label: 'Actors', to: '/actors' },
   { label: 'Subscriptions', to: '/subscriptions' },
   { label: 'Resiliency', to: '/resiliency' },
   { label: 'Configurations', to: '/configurations' },
-  { label: 'Control Plane', to: '/control-plane' },
-  { label: 'Logs', to: '/logs' },
+  { label: 'Control Plane', to: '/control-plane', cap: 'controlPlane' },
+  { label: 'Logs', to: '/logs', cap: 'logs' },
 ]
 
 interface TopNavProps {
@@ -30,6 +32,8 @@ interface TopNavProps {
 
 export function TopNav({ theme, onThemeChange }: TopNavProps) {
   const headerRef = useRef<HTMLElement>(null)
+  const caps = getCapabilities()
+  const items = NAV_ITEMS.filter((item) => !item.cap || caps[item.cap])
 
   // The nav can wrap onto extra rows on narrow/zoomed windows; the fixed
   // sidebar reads --topbar-h to start below the topbar's real height.
@@ -57,7 +61,7 @@ export function TopNav({ theme, onThemeChange }: TopNavProps) {
       </span>
 
       <nav className="nav" aria-label="Primary navigation">
-        {NAV_ITEMS.map((item) => (
+        {items.map((item) => (
           <NavLink
             key={item.to}
             to={item.to}

--- a/web/src/lib/capabilities.test.ts
+++ b/web/src/lib/capabilities.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { getCapabilities } from './capabilities'
+
+declare global {
+  interface Window {
+    __DASH_CAPABILITIES__?: import('./capabilities').Capabilities
+  }
+}
+
+describe('getCapabilities', () => {
+  afterEach(() => {
+    delete window.__DASH_CAPABILITIES__
+  })
+
+  it('defaults to everything enabled when the flag is absent (dev server)', () => {
+    expect(getCapabilities()).toEqual({
+      lifecycle: true,
+      controlPlane: true,
+      logs: true,
+      workflows: true,
+    })
+  })
+
+  it('returns the injected flags verbatim', () => {
+    window.__DASH_CAPABILITIES__ = {
+      lifecycle: false,
+      controlPlane: false,
+      logs: false,
+      workflows: true,
+    }
+    expect(getCapabilities().lifecycle).toBe(false)
+    expect(getCapabilities().workflows).toBe(true)
+  })
+})

--- a/web/src/lib/capabilities.ts
+++ b/web/src/lib/capabilities.ts
@@ -1,0 +1,21 @@
+export interface Capabilities {
+  lifecycle: boolean
+  controlPlane: boolean
+  logs: boolean
+  workflows: boolean
+}
+
+declare global {
+  interface Window {
+    __DASH_CAPABILITIES__?: Capabilities
+  }
+}
+
+const FULL: Capabilities = { lifecycle: true, controlPlane: true, logs: true, workflows: true }
+
+// getCapabilities reads the server-injected capability flags. Absent flag
+// (Vite dev server, tests) means everything on — matching the host-mode
+// server default.
+export function getCapabilities(): Capabilities {
+  return window.__DASH_CAPABILITIES__ ?? FULL
+}

--- a/web/src/pages/AppDetail.test.tsx
+++ b/web/src/pages/AppDetail.test.tsx
@@ -318,6 +318,28 @@ describe('AppDetail', () => {
     )
   })
 
+  it('shows the aspire label under the header when it differs from the app id', async () => {
+    server.use(
+      http.get('/api/apps/order', () =>
+        HttpResponse.json({ ...runningApp, isAspire: true, label: 'Order Service' }),
+      ),
+    )
+    const { container } = renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    expect(container.querySelector('.phead .sub')).toHaveTextContent('Order Service')
+  })
+
+  it('does not show a label sub-line when it equals the app id or is absent', async () => {
+    server.use(
+      http.get('/api/apps/order', () =>
+        HttpResponse.json({ ...runningApp, isAspire: true, label: 'order' }),
+      ),
+    )
+    const { container } = renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    expect(container.querySelector('.phead .sub')).toBeNull()
+  })
+
   it('shows per-target status and ticking uptime', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
     vi.setSystemTime(new Date('2026-07-09T10:05:00Z'))

--- a/web/src/pages/AppDetail.test.tsx
+++ b/web/src/pages/AppDetail.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { http, HttpResponse } from 'msw'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { server } from '../test/setup'
 import { makeQueryClient, QueryProvider } from '../lib/query'
 import { RefreshProvider } from '../lib/refresh'
@@ -27,6 +27,10 @@ function renderDetail() {
 }
 
 describe('AppDetail', () => {
+  afterEach(() => {
+    delete window.__DASH_CAPABILITIES__
+  })
+
   const runningApp = {
     appId: 'order',
     health: 'healthy',
@@ -515,6 +519,18 @@ describe('AppDetail', () => {
     renderDetail()
     await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
     expect(screen.queryByRole('button', { name: 'Remove from list' })).not.toBeInTheDocument()
+  })
+
+  it('hides the View logs link when the logs capability is off', async () => {
+    window.__DASH_CAPABILITIES__ = { lifecycle: false, controlPlane: false, logs: false, workflows: true }
+    try {
+      server.use(http.get('/api/apps/order', () => HttpResponse.json(runningApp)))
+      renderDetail()
+      await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+      expect(screen.queryByRole('link', { name: /view logs/i })).not.toBeInTheDocument()
+    } finally {
+      delete window.__DASH_CAPABILITIES__
+    }
   })
 
   it('offers a back link when the app cannot be loaded', async () => {

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -9,6 +9,7 @@ import { useToast } from '../lib/toast'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { appKey } from '../lib/appKey'
 import { formatUptime, useNow } from '../lib/uptime'
+import { getCapabilities } from '../lib/capabilities'
 
 // ---------- content ----------
 
@@ -17,6 +18,8 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
   const { toast, toastNode } = useToast()
 
   useDocumentTitle(appKey(app))
+
+  const caps = getCapabilities()
 
   const copyPath = (path: string) => {
     copyText(path)
@@ -91,30 +94,33 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
     return text ? <span>{text}</span> : <span className="faint">—</span>
   }
 
-  const panelActions = (target: AppTarget, status: string | undefined, what: string) => (
-    <span style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}>
-      {status === 'running' && (
-        <>
-          {!app.isAspire && !orphaned && (
-            <button className="btn ghost" disabled={busy} onClick={() => runAction(target, 'restart', what)}>
-              Restart
+  const panelActions = (target: AppTarget, status: string | undefined, what: string) => {
+    if (!caps.lifecycle) return null
+    return (
+      <span style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}>
+        {status === 'running' && (
+          <>
+            {!app.isAspire && !orphaned && (
+              <button className="btn ghost" disabled={busy} onClick={() => runAction(target, 'restart', what)}>
+                Restart
+              </button>
+            )}
+            <button className="btn danger" disabled={busy} onClick={() => runAction(target, 'stop', what)}>
+              Stop
             </button>
-          )}
-          <button className="btn danger" disabled={busy} onClick={() => runAction(target, 'stop', what)}>
-            Stop
+          </>
+        )}
+        {/* Per-panel Start is hidden for fully-stopped dapr run apps: a bare
+            half-restart is not discoverable — the header's whole-instance Start
+            is the affordance. Compose keeps per-container starts. */}
+        {status === 'stopped' && !app.isAspire && !orphaned && (isCompose || !allStopped) && (
+          <button className="btn ghost" disabled={busy} onClick={() => runAction(target, 'start', what)}>
+            Start
           </button>
-        </>
-      )}
-      {/* Per-panel Start is hidden for fully-stopped dapr run apps: a bare
-          half-restart is not discoverable — the header's whole-instance Start
-          is the affordance. Compose keeps per-container starts. */}
-      {status === 'stopped' && !app.isAspire && !orphaned && (isCompose || !allStopped) && (
-        <button className="btn ghost" disabled={busy} onClick={() => runAction(target, 'start', what)}>
-          Start
-        </button>
-      )}
-    </span>
-  )
+        )}
+      </span>
+    )
+  }
 
   return (
     <div className="page">
@@ -146,7 +152,7 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
           {hasContainerName && <div className="sub mono">{key}</div>}
         </div>
         <div style={{ display: 'flex', gap: 8 }}>
-          {anyRunning && (
+          {caps.lifecycle && anyRunning && (
             <>
               {!app.isAspire && !orphaned && (
                 <button
@@ -166,12 +172,12 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
               </button>
             </>
           )}
-          {removable && (
+          {caps.lifecycle && removable && (
             <button className="btn ghost" disabled={busy || forget.isPending} onClick={removeFromList}>
               Remove from list
             </button>
           )}
-          {allStopped && !app.isAspire && !orphaned && (
+          {caps.lifecycle && allStopped && !app.isAspire && !orphaned && (
             <button
               className="btn ghost"
               disabled={busy}

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -28,6 +28,7 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
 
   const key = appKey(app)
   const hasContainerName = key !== app.appId
+  const hasLabel = !hasContainerName && !!app.label && app.label !== app.appId
 
   const appPidDisplay = !app.metadataOk ? 'unknown' : app.appPid ? String(app.appPid) : '—'
   const isCompose = app.source === 'compose'
@@ -149,7 +150,11 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
               {app.runtime}
             </span>
           </div>
-          {hasContainerName && <div className="sub mono">{key}</div>}
+          {hasContainerName ? (
+            <div className="sub mono">{key}</div>
+          ) : (
+            hasLabel && <div className="sub mono">{app.label}</div>
+          )}
         </div>
         <div style={{ display: 'flex', gap: 8 }}>
           {caps.lifecycle && anyRunning && (

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -187,7 +187,9 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
             </button>
           )}
           <button className="tbtn" onClick={() => navigate('/')}>← Back</button>
-          <Link className="tbtn" to={`/logs?app=${key}&source=daprd`}>View logs</Link>
+          {caps.logs && (
+            <Link className="tbtn" to={`/logs?app=${key}&source=daprd`}>View logs</Link>
+          )}
         </div>
       </div>
 

--- a/web/src/pages/Applications.test.tsx
+++ b/web/src/pages/Applications.test.tsx
@@ -177,6 +177,26 @@ describe('Applications', () => {
     expect(link).toHaveAttribute('href', '/apps/order')
   })
 
+  it('shows the aspire label as muted secondary text when it differs from the app id', async () => {
+    mockApps([{ ...baseApp, appId: 'order', isAspire: true, label: 'Order Service' }])
+    renderAt()
+    const link = await screen.findByRole('link', { name: /order/ })
+    expect(link.textContent!.startsWith('order')).toBe(true)
+    expect(link.querySelector('.muted')).toHaveTextContent('Order Service')
+  })
+
+  it('does not duplicate the app id when the aspire label equals it or is absent', async () => {
+    mockApps([
+      { ...baseApp, appId: 'order', isAspire: true, label: 'order' },
+      { ...baseApp, appId: 'shipping', isAspire: true },
+    ])
+    renderAt()
+    const orderLink = await screen.findByRole('link', { name: 'order' })
+    expect(orderLink.querySelector('.muted')).toBeNull()
+    const shippingLink = screen.getByRole('link', { name: 'shipping' })
+    expect(shippingLink.querySelector('.muted')).toBeNull()
+  })
+
   it('renders stopped instances distinctly and excludes them from the running count', async () => {
     mockApps([
       { ...baseApp, appId: 'live', appStatus: 'running', daprdStatus: 'running' },

--- a/web/src/pages/Applications.tsx
+++ b/web/src/pages/Applications.tsx
@@ -118,6 +118,8 @@ function AppRow({ app, onOpen }: { app: AppSummary; onOpen: () => void }) {
   const unreachable = app.source === 'compose' && app.sidecarReachable === false && app.daprdStatus !== 'stopped'
   const key = appKey(app)
   const hasContainerName = key !== app.appId
+  const hasLabel = !hasContainerName && !!app.label && app.label !== app.appId
+  const secondary = hasContainerName ? key : hasLabel ? app.label : null
   return (
     <tr onClick={onOpen}>
       <td>
@@ -131,11 +133,11 @@ function AppRow({ app, onOpen }: { app: AppSummary; onOpen: () => void }) {
       </td>
       <td className="b">
         <Link className="celllink" to={`/apps/${key}`} onClick={(e) => e.stopPropagation()}>
-          {hasContainerName ? (
+          {secondary ? (
             <>
               {app.appId}
               <span className="muted" style={{ display: 'block', fontSize: 11, fontWeight: 400 }}>
-                {key}
+                {secondary}
               </span>
             </>
           ) : (

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -13,6 +13,33 @@ import { Resiliency } from './pages/Resiliency'
 import { ResiliencyBuilder } from './pages/resiliency-builder/ResiliencyBuilder'
 import { ControlPlane } from './pages/ControlPlane'
 import { RouteError } from './components/RouteError'
+import { getCapabilities } from './lib/capabilities'
+
+const caps = getCapabilities()
+
+const gatedChildren: RouteObject[] = [
+  { index: true, element: <Applications />, handle: { rumView: 'Applications' } },
+  { path: 'apps/:appId', element: <AppDetail />, handle: { rumView: 'AppDetail' } },
+  ...(caps.workflows
+    ? [
+        { path: 'workflows', element: <Workflows />, handle: { rumView: 'Workflows' } },
+        { path: 'workflows/:appId/:instanceId', element: <WorkflowDetail />, handle: { rumView: 'WorkflowDetail' } },
+      ]
+    : []),
+  { path: 'actors', element: <Actors />, handle: { rumView: 'Actors' } },
+  { path: 'subscriptions', element: <Subscriptions />, handle: { rumView: 'Subscriptions' } },
+  { path: 'components/new', element: <ComponentBuilder />, handle: { rumView: 'ComponentBuilder' } },
+  { path: 'components', element: <ResourceList kind="component" />, handle: { rumView: 'Components' } },
+  { path: 'components/:name', element: <ResourceList kind="component" />, handle: { rumView: 'Components' } },
+  { path: 'configurations', element: <ResourceList kind="configuration" />, handle: { rumView: 'Configurations' } },
+  { path: 'configurations/:name', element: <ResourceList kind="configuration" />, handle: { rumView: 'Configurations' } },
+  { path: 'resiliency', element: <Resiliency />, handle: { rumView: 'Resiliency' } },
+  { path: 'resiliency/new', element: <ResiliencyBuilder />, handle: { rumView: 'ResiliencyBuilder' } },
+  ...(caps.controlPlane
+    ? [{ path: 'control-plane', element: <ControlPlane />, handle: { rumView: 'ControlPlane' } }]
+    : []),
+  ...(caps.logs ? [{ path: 'logs', element: <Logs />, handle: { rumView: 'Logs' } }] : []),
+]
 
 export const routes: RouteObject[] = [
   {
@@ -25,23 +52,7 @@ export const routes: RouteObject[] = [
         // Pathless layout route: page render errors are caught here, so the
         // error renders inside the App shell (TopNav/sidebar stay usable).
         errorElement: <RouteError />,
-        children: [
-          { index: true, element: <Applications />, handle: { rumView: 'Applications' } },
-          { path: 'apps/:appId', element: <AppDetail />, handle: { rumView: 'AppDetail' } },
-          { path: 'workflows', element: <Workflows />, handle: { rumView: 'Workflows' } },
-          { path: 'workflows/:appId/:instanceId', element: <WorkflowDetail />, handle: { rumView: 'WorkflowDetail' } },
-          { path: 'actors', element: <Actors />, handle: { rumView: 'Actors' } },
-          { path: 'subscriptions', element: <Subscriptions />, handle: { rumView: 'Subscriptions' } },
-          { path: 'components/new', element: <ComponentBuilder />, handle: { rumView: 'ComponentBuilder' } },
-          { path: 'components', element: <ResourceList kind="component" />, handle: { rumView: 'Components' } },
-          { path: 'components/:name', element: <ResourceList kind="component" />, handle: { rumView: 'Components' } },
-          { path: 'configurations', element: <ResourceList kind="configuration" />, handle: { rumView: 'Configurations' } },
-          { path: 'configurations/:name', element: <ResourceList kind="configuration" />, handle: { rumView: 'Configurations' } },
-          { path: 'resiliency', element: <Resiliency />, handle: { rumView: 'Resiliency' } },
-          { path: 'resiliency/new', element: <ResiliencyBuilder />, handle: { rumView: 'ResiliencyBuilder' } },
-          { path: 'control-plane', element: <ControlPlane />, handle: { rumView: 'ControlPlane' } },
-          { path: 'logs', element: <Logs />, handle: { rumView: 'Logs' } },
-        ],
+        children: gatedChildren,
       },
     ],
   },

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -16,6 +16,10 @@ export interface AppSummary {
   runtime: string
   /** true when the app is .NET Aspire-managed (started by the Aspire host, not a run template) */
   isAspire?: boolean
+  /** display name from the Aspire AppHost; defaults to appId, so it may be identical (Aspire apps only) */
+  label?: string
+  /** per-app Dapr namespace assigned by the Aspire AppHost (Aspire apps only) */
+  namespace?: string
   /** discovery source: process table vs docker compose containers */
   source?: 'standalone' | 'compose'
   /** compose project name (source === 'compose' only) */


### PR DESCRIPTION
## Summary

Adds an **aspire mode** to the dashboard so it can run as a container resource inside a .NET Aspire AppHost, plus a published container image. Design spec and implementation plan are included in `docs/superpowers/`.

- **Mode switch** — `--mode` / `DEVDASHBOARD_MODE` (single value). Unset = today's complete host scan (`dapr run` + docker compose), now also merging an env-contract source when present (aspire entries win key collisions). `aspire` = discovery exclusively from injected env vars; `dapr`/`compose` reserved for future single-source filtering.
- **App discovery contract** — indexed `DEVDASHBOARD_APP_COUNT` / `DEVDASHBOARD_APP_<i>_{ID,DAPR_HTTP,NAMESPACE,LABEL}` env vars, fail-fast validation naming the exact variable; per-app daprd **base URLs** threaded through health, metadata, and workflow terminate/purge (replacing hardcoded `127.0.0.1:<port>`).
- **Container serving posture** (aspire mode) — binds `0.0.0.0:8080`, non-loopback Host allowed with same-origin CSRF, lifecycle/control-plane/log-tail/update-check routes not registered, capabilities injected into the SPA (`window.__DASH_CAPABILITIES__`) so the UI hides disabled features; workflows enabled via `DEVDASHBOARD_STATESTORE_FILE`.
- **Image** — multi-stage `Dockerfile` (distroless static, `DEVDASHBOARD_MODE=aspire` baked in) + goreleaser `dockers`/`docker_manifests` publishing multi-arch `ghcr.io/diagridio/dev-dashboard` on tag releases; CI builds the image on PRs.
- **Docs** — README section documenting the full contract (the rewritten `diagrid-labs/dashboard-aspire` hosting integration will be built against it).

Host-mode behavior with mode unset is unchanged (verified: existing suites pass untouched; unset-mode serving/scanning wiring reproduced byte-for-byte).

## Test plan

- [x] Unit suites: Go (all packages, `-race`) and web (688 tests, 83 files) green; `tsc -b` clean
- [x] Integration: new `TestAspireModeEndToEnd` — apps from env contract enriched via stub daprd, non-loopback Host accepted, gated routes 404
- [x] Docker smokes: image health-checks with `DEVDASHBOARD_APP_COUNT=0`; fails fast naming `DEVDASHBOARD_APP_COUNT` without a contract; goreleaser snapshot builds+smokes both arches
- [x] Per-task reviews (12 tasks) + final whole-branch review: ready to merge

Follow-ups (deliberately deferred): `DEVDASHBOARD_ALLOWED_HOSTS` allowlist for the container guard; in-contract duplicate app-id validation; wiring per-app `_NAMESPACE`/`_LABEL` beyond informational (documented as such).

🤖 Generated with [Claude Code](https://claude.com/claude-code)