### PR TITLE
feat: Testcontainers components in Components view + app detail completeness

### DIFF
--- a/cmd/derive.go
+++ b/cmd/derive.go
@@ -30,6 +30,14 @@ func derivePaths(apps []discovery.Instance, homeDir, stateStorePath string, extr
 				loaded[c.Name] = true
 			}
 		}
+		// Testcontainers apps' ResourcePaths are virtual (e.g.
+		// "crazy_lamport:/dapr-resources", a container name + in-container
+		// path, not a host path). They intentionally flow through here
+		// unchanged: every walker below (state-store detection, resource
+		// loading) treats a nonexistent host path as a no-op, so mixing
+		// virtual and real paths is harmless. See
+		// TestVirtualPathsDoNotFeedStoreDetection in cmd/serve_test.go, which
+		// pins that a virtual path yields zero detected components.
 		appPaths = append(appPaths, a.ResourcePaths...)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/diagridio/dev-dashboard/pkg/lifecycle"
 	"github.com/diagridio/dev-dashboard/pkg/logging"
 	"github.com/diagridio/dev-dashboard/pkg/metadata"
+	"github.com/diagridio/dev-dashboard/pkg/resources"
 	"github.com/diagridio/dev-dashboard/pkg/server"
 	"github.com/diagridio/dev-dashboard/pkg/statestore"
 	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
@@ -131,6 +132,7 @@ func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath s
 		updateCheck   updatecheck.Service
 		caps          *server.Capabilities
 		appNS         map[string]string
+		extraRes      func() []resources.Resource
 	)
 	switch mode {
 	case ModeAspire:
@@ -145,6 +147,7 @@ func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath s
 		_, crtRunner := containerruntime.Detect()
 		composeSrc := discovery.NewComposeSource(crtRunner)
 		tcSrc := discovery.NewTestcontainersSource(crtRunner)
+		extraRes = tcExtraResources(tcSrc)
 		scanners := []discovery.Scanner{discovery.StandaloneScanner(), composeSrc.Scanner(), tcSrc.Scanner()}
 		if discovery.AspireContractPresent(os.Getenv) {
 			as, err := discovery.NewAspireScanner(os.Getenv)
@@ -184,6 +187,7 @@ func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath s
 		ResourcesPaths:   settings.ResourcesPaths,
 		QuietRegistry:    mode == ModeAspire,
 		AppNamespaces:    appNS,
+		ExtraResources:   extraRes,
 	}, dist)
 	for _, close := range closers {
 		close := close

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -127,7 +127,7 @@ func assembleOptions(ctx context.Context, deps serveDeps, dist fs.FS) (server.Op
 		ContainerLogs:    deps.ContainerLogs,
 		Backend:          rc,
 		Stores:           rc,
-		Resources:        resources.New(rc.Paths),
+		Resources:        resources.New(rc.Paths, nil),
 		News:             newsSvc,
 		ControlPlane:     controlplane.New(),
 		TelemetryEnabled: deps.TelemetryEnabled,

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -67,6 +67,24 @@ type serveDeps struct {
 	// Workflow reads resolve per-app namespaces from it by map lookup, never
 	// via discovery enrichment (sidecar probes).
 	AppNamespaces map[string]string
+	// ExtraResources supplies resource entries that exist outside the host
+	// filesystem (testcontainers-extracted component YAML); nil when the
+	// testcontainers scanner is disabled (aspire mode, tests).
+	ExtraResources func() []resources.Resource
+}
+
+// tcExtraResources adapts the testcontainers scanner's extracted files into
+// resources entries with container-prefixed display paths. The entries feed
+// ONLY the resources service — never state-store detection or election (an
+// extracted in-memory actor store would otherwise win the election).
+func tcExtraResources(src *discovery.TestcontainersSource) func() []resources.Resource {
+	return func() []resources.Resource {
+		var out []resources.Resource
+		for _, f := range src.Files() {
+			out = append(out, resources.FromRaw(f.Container+":"+f.Path, f.Content)...)
+		}
+		return out
+	}
 }
 
 // containerLogStream adapts a runtime Runner into the log-stream dependency.
@@ -127,7 +145,7 @@ func assembleOptions(ctx context.Context, deps serveDeps, dist fs.FS) (server.Op
 		ContainerLogs:    deps.ContainerLogs,
 		Backend:          rc,
 		Stores:           rc,
-		Resources:        resources.New(rc.Paths, nil),
+		Resources:        resources.New(rc.Paths, deps.ExtraResources),
 		News:             newsSvc,
 		ControlPlane:     controlplane.New(),
 		TelemetryEnabled: deps.TelemetryEnabled,

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/diagridio/dev-dashboard/pkg/discovery"
+	"github.com/diagridio/dev-dashboard/pkg/resources"
+	"github.com/diagridio/dev-dashboard/pkg/statestore"
 	"github.com/diagridio/dev-dashboard/pkg/updatecheck"
 	"github.com/stretchr/testify/require"
 )
@@ -89,4 +91,37 @@ func TestAssembleOptionsPropagatesUpdateCheck(t *testing.T) {
 		defer func(c func() error) { _ = c() }(c)
 	}
 	require.Same(t, uc, opts.UpdateCheck)
+}
+
+// TestTCExtraResources_AdaptsExtractedFiles verifies the tcExtraResources
+// adapter: a source with no runner (thus no extracted files) yields no
+// extras, and the mapping contract it relies on — FromRaw producing a
+// Resource keyed by the container-prefixed display path — is pinned directly.
+func TestTCExtraResources_AdaptsExtractedFiles(t *testing.T) {
+	// A TestcontainersSource whose fake runner serves one daprd container
+	// with a resources tar — reuse the discovery test fixtures via a tiny
+	// local stand-in instead: tcExtraResources only needs Files(), so give
+	// it a source primed by a fake scan. Simplest honest setup: construct
+	// the source against a fake runner exactly as pkg/discovery tests do is
+	// not possible from cmd (fakeCRT is package-private), so this test uses
+	// a real TestcontainersSource with a nil runner (no files) plus a unit
+	// test of the adapter's mapping via FromRaw directly:
+	src := discovery.NewTestcontainersSource(nil)
+	extras := tcExtraResources(src)
+	require.Empty(t, extras()) // nil runner -> no files -> no extras
+
+	// Mapping contract is pinned at the resources level:
+	rs := resources.FromRaw("crazy_lamport:/dapr-resources/kvstore.yaml",
+		[]byte("kind: Component\nmetadata:\n  name: kvstore\nspec:\n  type: state.in-memory\n"))
+	require.Len(t, rs, 1)
+	require.Equal(t, "crazy_lamport:/dapr-resources/kvstore.yaml", rs[0].Path)
+}
+
+// TestVirtualPathsDoNotFeedStoreDetection guards the spec's isolation rule:
+// container-prefixed virtual resource paths must be harmless no-ops for
+// state-store detection (they are not host paths).
+func TestVirtualPathsDoNotFeedStoreDetection(t *testing.T) {
+	comps, err := statestore.Detect([]string{"crazy_lamport:/dapr-resources"})
+	require.NoError(t, err)
+	require.Empty(t, comps)
 }

--- a/docs/superpowers/plans/2026-07-13-testcontainers-components-appdetail.md
+++ b/docs/superpowers/plans/2026-07-13-testcontainers-components-appdetail.md
@@ -1,0 +1,1208 @@
+# Testcontainers Components View + App Detail Completeness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show testcontainers apps' component YAML (extracted from the daprd container via `docker cp`) in the Components view, and fill the empty App-detail fields (App protocol for all sources; App PID/uptime, Container/Session rows, and Paths for testcontainers apps).
+
+**Architecture:** `TestcontainersSource` extracts `--resources-path` YAML from each daprd container as a tar stream (`<runtime> cp <id>:<path> -`), cached per container ID; `pkg/resources` gains an extras provider so extracted entries appear beside file-scanned ones — never touching store detection/election. Metadata gains `appConnectionProperties.protocol`; the app-proc resolver gains a PID lookup; AppDetail renders per-source rows.
+
+**Tech Stack:** Go (`archive/tar`, gopsutil, chi), React/TypeScript (vitest).
+
+**Spec:** `docs/superpowers/specs/2026-07-12-testcontainers-components-appdetail-design.md`
+**Branch:** `feat/testcontainers-components` (stacked on `feat/testcontainers-discovery`, PR #60).
+
+## Global Constraints
+
+- Extracted YAML feeds ONLY the resources service — never `reconciler.Paths()` additions of real dirs, never `statestore.Detect`, never store election (a `state.in-memory` + `actorStateStore:true` component would win the election and break other apps' workflow views).
+- Extraction caps: 32 files, 1 MiB per file; only regular `.yaml`/`.yml` tar members.
+- Extract once per container ID; evict cache entries for containers gone from the scan; extraction failure logs once per container and yields no entries.
+- Display paths are container-prefixed: `<containerName>:<inContainerPath>` (e.g. `crazy_lamport:/dapr-resources/kvstore.yaml`).
+- Aspire rendering is explicitly untouched; CLI PID row stays for standalone; compose rows unchanged. Metrics port stays a placeholder.
+- Go test packages use `//go:build unit` tags where neighbors do — run `go test ./... -tags "unit integration"`.
+- Vitest does NOT typecheck: any `.ts`/`.tsx` change requires `cd web && npx tsc -b`.
+- Commit messages end with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+
+---
+
+### Task 1: Tar → YAML extraction helper
+
+**Files:**
+- Create: `pkg/discovery/tar_extract.go`
+- Test: `pkg/discovery/tar_extract_test.go`
+
+**Interfaces:**
+- Produces: `extractYAMLFromTar(tarBytes []byte) (map[string][]byte, error)` — keys are the tar member names cleaned to slash paths WITHOUT a leading `./` or the top-level directory prefix stripped? No: keys are `path.Clean("/" + name)` of each member (absolute-style container paths are NOT reconstructable from the tar alone, so keys are the member paths as recorded, cleaned; the caller joins them onto the container dir). Values are file contents. Caps: `maxExtractFiles = 32`, `maxExtractFileSize = 1 << 20`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `pkg/discovery/tar_extract_test.go`:
+
+```go
+//go:build unit
+
+package discovery
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// buildTar assembles an in-memory tar the way `docker cp <id>:/dir -` does:
+// a top-level directory entry followed by its files.
+func buildTar(t *testing.T, entries map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "dapr-resources/", Typeflag: tar.TypeDir, Mode: 0o755,
+	}))
+	for name, content := range entries {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: name, Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(content)),
+		}))
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	return buf.Bytes()
+}
+
+func TestExtractYAMLFromTar_KeepsOnlyYAMLFiles(t *testing.T) {
+	data := buildTar(t, map[string]string{
+		"dapr-resources/kvstore.yaml": "apiVersion: dapr.io/v1alpha1\nkind: Component\n",
+		"dapr-resources/notes.txt":    "not yaml",
+		"dapr-resources/cfg.yml":      "kind: Configuration\n",
+	})
+	files, err := extractYAMLFromTar(data)
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+	require.Contains(t, string(files["dapr-resources/kvstore.yaml"]), "kind: Component")
+	require.Contains(t, string(files["dapr-resources/cfg.yml"]), "kind: Configuration")
+}
+
+func TestExtractYAMLFromTar_Caps(t *testing.T) {
+	big := strings.Repeat("x", maxExtractFileSize+1)
+	data := buildTar(t, map[string]string{"dapr-resources/big.yaml": big})
+	files, err := extractYAMLFromTar(data)
+	require.NoError(t, err)
+	require.Empty(t, files) // oversized member skipped, not an error
+
+	many := map[string]string{}
+	for i := 0; i < maxExtractFiles+5; i++ {
+		many[fmt.Sprintf("dapr-resources/c%03d.yaml", i)] = "kind: Component\n"
+	}
+	data = buildTar(t, many)
+	files, err = extractYAMLFromTar(data)
+	require.NoError(t, err)
+	require.Len(t, files, maxExtractFiles)
+}
+
+func TestExtractYAMLFromTar_GarbageInput(t *testing.T) {
+	_, err := extractYAMLFromTar([]byte("this is not a tar archive"))
+	require.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/discovery/ -tags unit -run TestExtractYAMLFromTar -v`
+Expected: FAIL — `undefined: extractYAMLFromTar`.
+
+- [ ] **Step 3: Implement**
+
+Create `pkg/discovery/tar_extract.go`:
+
+```go
+package discovery
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"path"
+	"strings"
+)
+
+const (
+	// maxExtractFiles bounds how many YAML files are read from one
+	// container's resources dir; maxExtractFileSize bounds each file.
+	maxExtractFiles    = 32
+	maxExtractFileSize = 1 << 20 // 1 MiB
+)
+
+// extractYAMLFromTar reads a `docker cp <id>:<dir> -` tar stream and returns
+// its regular .yaml/.yml members (member path -> content). Oversized members
+// and non-YAML files are skipped silently; a corrupt archive errors.
+func extractYAMLFromTar(tarBytes []byte) (map[string][]byte, error) {
+	tr := tar.NewReader(bytes.NewReader(tarBytes))
+	out := map[string][]byte{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		name := path.Clean(hdr.Name)
+		ext := strings.ToLower(path.Ext(name))
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+		if hdr.Size > maxExtractFileSize {
+			continue
+		}
+		if len(out) >= maxExtractFiles {
+			break
+		}
+		data, err := io.ReadAll(io.LimitReader(tr, maxExtractFileSize+1))
+		if err != nil {
+			return nil, err
+		}
+		out[name] = data
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./pkg/discovery/ -tags unit -run TestExtractYAMLFromTar -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/discovery/tar_extract.go pkg/discovery/tar_extract_test.go
+git commit -m "feat(discovery): tar extraction helper for container resource YAML
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Container extraction in the scanner + virtual paths
+
+**Files:**
+- Modify: `pkg/discovery/scan_testcontainers.go`
+- Test: `pkg/discovery/scan_testcontainers_test.go` (add cases)
+
+**Interfaces:**
+- Consumes: `extractYAMLFromTar` (Task 1), `containerruntime.Runner.Run(ctx, "cp", "<id>:<dir>", "-")`, existing `TestcontainersSource` fields/cache.
+- Produces:
+  - `type ExtractedFile struct { Container string; Path string; Content []byte }` — `Container` is the container NAME (display identity), `Path` is the container-internal file path (e.g. `/dapr-resources/kvstore.yaml`).
+  - `(s *TestcontainersSource) Files() []ExtractedFile` — snapshot of all extracted files across live containers, stable order (by Container then Path).
+  - `ScanResult.ResourcePaths = ["<containerName>:<resourcesPath>"]` and `ScanResult.ConfigPath = "<containerName>:<configPath>"` (when the respective daprd flags are present) — virtual display paths.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `pkg/discovery/scan_testcontainers_test.go` (reuse the existing `fakeCRT` and `testcontainersInspectJSON` fixtures; the daprd container in the fixture has ID `28af628017d1`, name `crazy_lamport`, and `--resources-path /dapr-resources`):
+
+```go
+// resourcesTar returns a docker-cp-style tar of /dapr-resources with one
+// component file. Reuses buildTar from tar_extract_test.go (same package).
+func resourcesTar(t *testing.T) []byte {
+	t.Helper()
+	return buildTar(t, map[string]string{
+		"dapr-resources/kvstore.yaml": "apiVersion: dapr.io/v1alpha1\nkind: Component\nmetadata:\n  name: kvstore\nspec:\n  type: state.in-memory\n  version: v1\n",
+	})
+}
+
+func TestTestcontainersScanner_ExtractsResourceFiles(t *testing.T) {
+	crt := fakeTestcontainersRunner(t)
+	crt.responses["cp 28af628017d1:/dapr-resources"] = resourcesTar(t)
+	src := NewTestcontainersSource(crt)
+
+	results, err := src.Scanner()()
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, []string{"crazy_lamport:/dapr-resources"}, results[0].ResourcePaths)
+
+	files := src.Files()
+	require.Len(t, files, 1)
+	require.Equal(t, "crazy_lamport", files[0].Container)
+	require.Equal(t, "/dapr-resources/kvstore.yaml", files[0].Path)
+	require.Contains(t, string(files[0].Content), "state.in-memory")
+}
+
+func TestTestcontainersScanner_ExtractionCachedAndEvicted(t *testing.T) {
+	crt := fakeTestcontainersRunner(t)
+	crt.responses["cp 28af628017d1:/dapr-resources"] = resourcesTar(t)
+	src := NewTestcontainersSource(crt)
+	src.clock = func() time.Time { return time.Now() } // will be swapped below
+
+	// First scan extracts.
+	_, err := src.Scanner()()
+	require.NoError(t, err)
+	cpCalls := 0
+	for _, c := range crt.calls {
+		if strings.HasPrefix(c, "cp ") {
+			cpCalls++
+		}
+	}
+	require.Equal(t, 1, cpCalls)
+
+	// Second scan (cache TTL bypassed by advancing the clock) must NOT re-cp.
+	base := time.Now()
+	src.clock = func() time.Time { base = base.Add(3 * time.Second); return base }
+	_, err = src.Scanner()()
+	require.NoError(t, err)
+	cpCalls = 0
+	for _, c := range crt.calls {
+		if strings.HasPrefix(c, "cp ") {
+			cpCalls++
+		}
+	}
+	require.Equal(t, 1, cpCalls, "extraction must be cached per container ID")
+
+	// Container disappears -> cache evicted, Files() empty.
+	crt.responses["ps -aq"] = []byte("")
+	_, err = src.Scanner()()
+	require.NoError(t, err)
+	require.Empty(t, src.Files())
+}
+
+func TestTestcontainersScanner_ExtractionFailureDegrades(t *testing.T) {
+	crt := fakeTestcontainersRunner(t)
+	crt.errs = map[string]error{"cp 28af628017d1:/dapr-resources": errors.New("no such container")}
+	src := NewTestcontainersSource(crt)
+
+	results, err := src.Scanner()()
+	require.NoError(t, err) // scan itself still succeeds
+	require.Len(t, results, 1)
+	require.Empty(t, src.Files())
+}
+```
+
+Note `fakeCRT.key` joins the first two args, so `cp 28af628017d1:/dapr-resources -` keys as `"cp 28af628017d1:/dapr-resources"` — the map keys above match. Add `errors`, `strings`, `time` imports as needed; if `fakeCRT.errs` is nil-initialized in the existing helper, set the whole map as shown.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./pkg/discovery/ -tags unit -run TestTestcontainersScanner -v`
+Expected: new tests FAIL — `undefined: src.Files` / empty `ResourcePaths`.
+
+- [ ] **Step 3: Implement**
+
+In `pkg/discovery/scan_testcontainers.go`:
+
+1. Add the type and fields:
+
+```go
+// ExtractedFile is one YAML file copied out of a daprd container's
+// resources dir. Container is the container name (display identity), Path
+// the container-internal file path.
+type ExtractedFile struct {
+	Container string
+	Path      string
+	Content   []byte
+}
+```
+
+Add to the `TestcontainersSource` struct (inside the mutex-guarded section):
+
+```go
+	// extracted caches per-container-ID resource files (containerID ->
+	// files); extractFailed remembers IDs whose extraction already failed
+	// so the failure logs once and is not retried every scan.
+	extracted     map[string][]ExtractedFile
+	extractFailed map[string]bool
+```
+
+Initialize both maps in `NewTestcontainersSource`:
+
+```go
+func NewTestcontainersSource(run containerruntime.Runner) *TestcontainersSource {
+	return &TestcontainersSource{run: run, clock: time.Now,
+		extracted: map[string][]ExtractedFile{}, extractFailed: map[string]bool{}}
+}
+```
+
+2. Add the accessor:
+
+```go
+// Files returns the extracted resource files of all currently-scanned
+// containers, ordered by container name then path.
+func (s *TestcontainersSource) Files() []ExtractedFile {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []ExtractedFile
+	for _, files := range s.extracted {
+		out = append(out, files...)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Container != out[j].Container {
+			return out[i].Container < out[j].Container
+		}
+		return out[i].Path < out[j].Path
+	})
+	return out
+}
+```
+
+3. In `scanOnce`, inside the per-container loop after the `ScanResult` is built (before `results = append`), set the virtual paths and extract:
+
+```go
+		if args.ResourcesPath != "" {
+			r.ResourcePaths = []string{c.Name + ":" + args.ResourcesPath}
+			s.extractResources(ctx, c, args.ResourcesPath)
+		}
+		if args.ConfigPath != "" {
+			r.ConfigPath = c.Name + ":" + args.ConfigPath
+		}
+```
+
+`scanOnce` runs under `s.mu` (called from `scan`), so `extractResources` accesses the maps without extra locking — but `Files()` also takes `s.mu`; verify `scanOnce` is only ever invoked from `scan` while holding the lock (it is, in the current file) and note it in a comment.
+
+4. Add extraction + eviction:
+
+```go
+// extractResources copies the container's resources dir out as a tar stream
+// (`cp <id>:<dir> -`, no shell needed — works on distroless images) and
+// caches the YAML files per container ID. Runs once per container; a
+// failure logs once and is not retried. Caller holds s.mu.
+func (s *TestcontainersSource) extractResources(ctx context.Context, c composeContainer, dir string) {
+	if _, done := s.extracted[c.ID]; done || s.extractFailed[c.ID] {
+		return
+	}
+	raw, err := s.run.Run(ctx, "cp", c.ID+":"+dir, "-")
+	if err != nil {
+		logger().Warn("testcontainers resource extraction failed", "container", c.Name, "err", err)
+		s.extractFailed[c.ID] = true
+		return
+	}
+	files, err := extractYAMLFromTar(raw)
+	if err != nil {
+		logger().Warn("testcontainers resource tar parse failed", "container", c.Name, "err", err)
+		s.extractFailed[c.ID] = true
+		return
+	}
+	out := make([]ExtractedFile, 0, len(files))
+	base := path.Base(strings.TrimSuffix(dir, "/"))
+	for name, content := range files {
+		// Tar member names are relative to the copied dir's parent (e.g.
+		// "dapr-resources/kvstore.yaml"); rebase onto the container path.
+		rel := strings.TrimPrefix(name, base+"/")
+		out = append(out, ExtractedFile{Container: c.Name, Path: dir + "/" + rel, Content: content})
+	}
+	s.extracted[c.ID] = out
+}
+```
+
+At the end of `scanOnce` (after the loop), evict departed containers:
+
+```go
+	// Evict extraction cache entries for containers gone from this scan.
+	live := map[string]bool{}
+	for _, c := range containers {
+		live[c.ID] = true
+	}
+	for id := range s.extracted {
+		if !live[id] {
+			delete(s.extracted, id)
+		}
+	}
+	for id := range s.extractFailed {
+		if !live[id] {
+			delete(s.extractFailed, id)
+		}
+	}
+```
+
+Add imports: `path`, `sort` (and keep existing).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./pkg/discovery/ -tags unit`
+Expected: PASS (all, including pre-existing scanner tests — they set no `cp` response, so extraction fails once and degrades, which must not break them; if a pre-existing test asserts exact `crt.calls`, update its expectation to include the one `cp` call).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/discovery/scan_testcontainers.go pkg/discovery/scan_testcontainers_test.go
+git commit -m "feat(discovery): extract testcontainers resource YAML; virtual resource paths
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Resources extras provider
+
+**Files:**
+- Modify: `pkg/resources/resources.go`
+- Modify: `cmd/serve.go:130` (the `resources.New(rc.Paths)` call — add `nil` extras for now)
+- Test: `pkg/resources/resources_test.go` (add cases)
+
+**Interfaces:**
+- Consumes: nothing new (self-contained; Task 5 wires the real provider).
+- Produces:
+  - `New(paths func() []string, extras func() []Resource) Service` — `extras` may be nil; extras entries are merged after the file scan in both `List` and `Get`.
+  - `FromRaw(displayPath string, content []byte) []Resource` — parses multi-doc YAML into fully-populated Resources (ID from name|type|displayPath, `Path: displayPath`, `Raw: string(content)`); unparseable/unknown-kind docs are skipped.
+  - `List` strips `Raw` from extras entries (matching file entries); `Get` returns the extras entry with its stored `Raw` and must NOT try to `os.ReadFile` a display path.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `pkg/resources/resources_test.go` (match the file's build tags and helper style):
+
+```go
+func TestExtras_MergedListedAndFetched(t *testing.T) {
+	content := []byte("apiVersion: dapr.io/v1alpha1\nkind: Component\nmetadata:\n  name: kvstore\nspec:\n  type: state.in-memory\n  version: v1\n  metadata:\n  - name: actorStateStore\n    value: \"true\"\n")
+	extras := func() []Resource { return FromRaw("crazy_lamport:/dapr-resources/kvstore.yaml", content) }
+	svc := New(func() []string { return nil }, extras)
+
+	list, err := svc.List(context.Background(), KindComponent)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	require.Equal(t, "kvstore", list[0].Name)
+	require.Equal(t, "state.in-memory", list[0].Type)
+	require.Equal(t, "v1", list[0].Version)
+	require.Equal(t, "crazy_lamport:/dapr-resources/kvstore.yaml", list[0].Path)
+	require.Empty(t, list[0].Raw, "List strips Raw")
+
+	got, err := svc.Get(context.Background(), KindComponent, list[0].ID)
+	require.NoError(t, err)
+	require.Contains(t, got.Raw, "actorStateStore")
+
+	// Name-based lookup works too.
+	got, err = svc.Get(context.Background(), KindComponent, "kvstore")
+	require.NoError(t, err)
+	require.Equal(t, list[0].ID, got.ID)
+}
+
+func TestExtras_ConfigurationDocRoutedByKind(t *testing.T) {
+	content := []byte("kind: Component\nmetadata:\n  name: a\nspec:\n  type: state.in-memory\n---\nkind: Configuration\nmetadata:\n  name: cfg\n")
+	extras := func() []Resource { return FromRaw("c1:/res/multi.yaml", content) }
+	svc := New(func() []string { return nil }, extras)
+
+	comps, err := svc.List(context.Background(), KindComponent)
+	require.NoError(t, err)
+	require.Len(t, comps, 1)
+	cfgs, err := svc.List(context.Background(), KindConfiguration)
+	require.NoError(t, err)
+	require.Len(t, cfgs, 1)
+	require.Equal(t, "cfg", cfgs[0].Name)
+}
+
+func TestExtras_NilProviderKeepsFileBehavior(t *testing.T) {
+	svc := New(func() []string { return nil }, nil)
+	list, err := svc.List(context.Background(), KindComponent)
+	require.NoError(t, err)
+	require.Empty(t, list)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/resources/ -v -run TestExtras` (add `-tags unit` if the package's tests carry the tag)
+Expected: FAIL — `New` has wrong arity / `undefined: FromRaw`.
+
+- [ ] **Step 3: Implement**
+
+In `pkg/resources/resources.go`:
+
+1. Extend the service:
+
+```go
+type service struct {
+	paths  func() []string
+	extras func() []Resource
+}
+
+// New returns a Service that scans the paths returned by the provider for
+// Dapr resource YAMLs, merged with the extras provider's entries (resources
+// that exist outside the host filesystem, e.g. extracted from containers).
+// Either provider may be nil. Both are called on every List/Get so callers
+// can change sources at runtime.
+func New(paths func() []string, extras func() []Resource) Service {
+	if paths == nil {
+		paths = func() []string { return nil }
+	}
+	return &service{paths: paths, extras: extras}
+}
+```
+
+2. Add `FromRaw`:
+
+```go
+// FromRaw parses multi-document YAML content into fully-populated Resources
+// carrying Raw. displayPath is the entry's Path verbatim (for container
+// sources use "<containerName>:<inContainerPath>") and feeds the ID hash,
+// so same-named components from different containers stay distinct.
+// Unparseable documents and unknown kinds are skipped.
+func FromRaw(displayPath string, content []byte) []Resource {
+	var out []Resource
+	for _, doc := range splitYAMLDocs(content) {
+		var rr rawResource
+		if err := yaml.Unmarshal(doc, &rr); err != nil {
+			continue
+		}
+		k, ok := kindFromString(rr.Kind)
+		if !ok {
+			continue
+		}
+		out = append(out, Resource{
+			ID:      resourceID(rr.Metadata.Name, rr.Spec.Type, displayPath),
+			Name:    rr.Metadata.Name,
+			Kind:    k,
+			Type:    rr.Spec.Type,
+			Version: rr.Spec.Version,
+			Path:    displayPath,
+			Raw:     string(content),
+		})
+	}
+	return out
+}
+```
+
+3. Merge in `List` and `Get` (extras carry Raw; file entries read Raw from disk):
+
+```go
+// extraByKind returns the extras entries of the given kind.
+func (s *service) extraByKind(kind Kind) []Resource {
+	if s.extras == nil {
+		return nil
+	}
+	var out []Resource
+	for _, r := range s.extras() {
+		if r.Kind == kind {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// List returns all resources of the given kind, without Raw content.
+func (s *service) List(ctx context.Context, kind Kind) ([]Resource, error) {
+	out, err := s.scan(kind)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range s.extraByKind(kind) {
+		r.Raw = ""
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Path < out[j].Path
+	})
+	return out, nil
+}
+
+// Get returns the resource matching idOrName (ID first, then first name
+// match). File entries load Raw from disk; extras entries already carry it.
+func (s *service) Get(ctx context.Context, kind Kind, idOrName string) (Resource, error) {
+	scanned, err := s.scan(kind)
+	if err != nil {
+		return Resource{}, err
+	}
+	extras := s.extraByKind(kind)
+	withRaw := func(r Resource) (Resource, error) {
+		data, err := os.ReadFile(r.Path)
+		if err != nil {
+			return Resource{}, err
+		}
+		r.Raw = string(data)
+		return r, nil
+	}
+	for _, r := range scanned {
+		if r.ID == idOrName {
+			return withRaw(r)
+		}
+	}
+	for _, r := range extras {
+		if r.ID == idOrName {
+			return r, nil
+		}
+	}
+	for _, r := range scanned {
+		if r.Name == idOrName {
+			return withRaw(r)
+		}
+	}
+	for _, r := range extras {
+		if r.Name == idOrName {
+			return r, nil
+		}
+	}
+	return Resource{}, ErrNotFound
+}
+```
+
+(The old `List` sorted inside `scan`; keep `scan`'s sort — the re-sort in `List` after appending extras keeps the combined order stable. Do NOT remove `scan`'s sort: `Get`'s ID/name precedence relies on deterministic order.)
+
+4. Update the one caller in `cmd/serve.go` line ~130: `Resources: resources.New(rc.Paths)` → `Resources: resources.New(rc.Paths, deps.ExtraResources)`. Since `serveDeps.ExtraResources` doesn't exist until Task 5, for THIS task write `resources.New(rc.Paths, nil)` — Task 5 replaces the `nil`. Also update any `resources.New(` call sites in tests (`grep -rn "resources.New(" --include='*.go'`) to pass `nil`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./pkg/resources/ ./cmd/ ./pkg/server/ -tags "unit integration" && go build ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/resources/resources.go pkg/resources/resources_test.go cmd/serve.go
+git commit -m "feat(resources): extras provider for non-filesystem resource entries
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: App protocol — metadata + argv fallback
+
+**Files:**
+- Modify: `pkg/discovery/metadata.go` (Metadata struct, rawMetadata, FetchMetadata)
+- Modify: `pkg/discovery/compose_args.go` (`daprdArgs.AppProtocol`)
+- Modify: `pkg/discovery/service.go` (`ScanResult.AppProtocol`, enrich wiring)
+- Modify: `pkg/discovery/types.go` (`Instance.AppProtocol`)
+- Modify: `pkg/discovery/scan_compose.go` + `pkg/discovery/scan_testcontainers.go` (set `AppProtocol` from parsed args)
+- Test: `pkg/discovery/metadata_test.go`, `pkg/discovery/compose_args_test.go`, `pkg/discovery/service_test.go` (add cases)
+
+**Interfaces:**
+- Produces: `Metadata.AppProtocol string` (from JSON `appConnectionProperties.protocol`); `daprdArgs.AppProtocol` (from `--app-protocol`); `ScanResult.AppProtocol`; `Instance.AppProtocol` (JSON `appProtocol,omitempty`). Precedence in enrich: metadata value wins when non-empty; scan-result (argv) value is the initial/fallback value.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `pkg/discovery/metadata_test.go`, find the existing FetchMetadata test (it stubs the endpoint with `httptest`); add a case (mirror its style):
+
+```go
+func TestFetchMetadata_AppProtocol(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"a","appConnectionProperties":{"port":8080,"protocol":"http","channelAddress":"host.testcontainers.internal"}}`))
+	}))
+	defer srv.Close()
+	md, err := FetchMetadata(context.Background(), srv.Client(), srv.URL)
+	require.NoError(t, err)
+	require.Equal(t, "http", md.AppProtocol)
+}
+```
+
+In `pkg/discovery/compose_args_test.go`:
+
+```go
+func TestParseDaprdArgs_AppProtocol(t *testing.T) {
+	args, ok := parseDaprdArgs([]string{"./daprd", "--app-id", "a", "--app-protocol", "grpc"})
+	require.True(t, ok)
+	require.Equal(t, "grpc", args.AppProtocol)
+}
+```
+
+In `pkg/discovery/service_test.go` (extend the existing unreachable-sidecar testcontainers test pattern):
+
+```go
+func TestEnrich_AppProtocolFromScanResult(t *testing.T) {
+	scan := func() ([]ScanResult, error) {
+		return []ScanResult{{
+			AppID: "a", Source: SourceTestcontainers, AppProtocol: "http",
+			DaprdContainerName: "c1",
+		}}, nil
+	}
+	svc := &service{scan: scan}
+	out, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "http", out[0].AppProtocol)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./pkg/discovery/ -tags unit -run 'AppProtocol' -v`
+Expected: FAIL — unknown fields.
+
+- [ ] **Step 3: Implement**
+
+`pkg/discovery/metadata.go`:
+- `Metadata` struct: add `AppProtocol string` (after `CLIPID`).
+- `rawMetadata`: add
+
+```go
+	AppConnectionProperties struct {
+		Protocol string `json:"protocol"`
+	} `json:"appConnectionProperties"`
+```
+
+- `FetchMetadata` return literal: add `AppProtocol: raw.AppConnectionProperties.Protocol,`.
+
+`pkg/discovery/compose_args.go`:
+- `daprdArgs`: add `AppProtocol string`.
+- In `parseDaprdArgs`'s result literal: `AppProtocol: flags["app-protocol"],`.
+
+`pkg/discovery/service.go`:
+- `ScanResult`: add `AppProtocol string` (near `AppPort`).
+- In `enrich`'s `Instance` literal: add `AppProtocol: r.AppProtocol,`.
+- After `in.MetadataOK = true` block where other metadata fields are copied (next to `in.RuntimeVersion = md.RuntimeVersion`):
+
+```go
+	if md.AppProtocol != "" {
+		in.AppProtocol = md.AppProtocol
+	}
+```
+
+`pkg/discovery/types.go`:
+- `Instance`: add `AppProtocol string \`json:"appProtocol,omitempty"\`` (after `AppPort`).
+
+`pkg/discovery/scan_compose.go` (in the `ScanResult` literal): add `AppProtocol: args.AppProtocol,`.
+`pkg/discovery/scan_testcontainers.go` (in the `ScanResult` literal): add `AppProtocol: args.AppProtocol,`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./pkg/discovery/ -tags unit && go build ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/discovery/metadata.go pkg/discovery/compose_args.go pkg/discovery/service.go pkg/discovery/types.go pkg/discovery/scan_compose.go pkg/discovery/scan_testcontainers.go pkg/discovery/metadata_test.go pkg/discovery/compose_args_test.go pkg/discovery/service_test.go
+git commit -m "feat(discovery): app protocol from metadata with argv fallback
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: App PID + uptime via app-port listener
+
+**Files:**
+- Modify: `pkg/discovery/appproc.go` (resolver interface + gopsutil impl)
+- Modify: `pkg/discovery/service.go` (testcontainers post-metadata branch)
+- Test: `pkg/discovery/service_test.go` (add case; update fakes)
+
+**Interfaces:**
+- Consumes: existing `appProcResolver` interface, `service.procStartTime`.
+- Produces: `appProcResolver` gains `PIDForPort(port int) (int, bool)`; every in-repo fake implementing the interface gains the method. Testcontainers enrichment sets `Instance.AppPID` and `Instance.AppStartedAt` from the app-port listener when the app is running.
+
+- [ ] **Step 1: Write the failing test**
+
+In `pkg/discovery/service_test.go`, extend `fakeAppProc` (from the Task-4-of-PR-#60 work) with a PID:
+
+```go
+type fakeAppProc struct {
+	cmd string
+	pid int
+}
+
+func (f fakeAppProc) CommandForPort(int) (string, bool) { return f.cmd, f.cmd != "" }
+func (f fakeAppProc) PIDForPort(int) (int, bool)        { return f.pid, f.pid != 0 }
+```
+
+(Update the existing `fakeAppProc` literal uses accordingly — Go fills missing fields with zero values, so existing `fakeAppProc{cmd: ...}` literals keep compiling. Any OTHER type implementing `appProcResolver` in tests — e.g. `fakeAspireResolver` — needs the new method too; give it `func (f fakeAspireResolver) PIDForPort(int) (int, bool) { return 0, false }` adjusted to its receiver.)
+
+Add the test — the sidecar must be reachable so metadata runs, since PID resolution lives in the post-metadata branch (mirror the package's existing httptest metadata stub pattern; if none exists for enrich tests, stub health+metadata):
+
+```go
+func TestEnrich_TestcontainersAppPIDAndUptime(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/v1.0/metadata") {
+			_, _ = w.Write([]byte(`{"id":"workflow-patterns-app"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNoContent) // healthz
+	}))
+	defer srv.Close()
+	port := portOf(t, srv.URL) // helper: parse the httptest port; add if absent
+
+	scan := func() ([]ScanResult, error) {
+		return []ScanResult{{
+			AppID: "workflow-patterns-app", Source: SourceTestcontainers,
+			AppPort: 8080, HTTPPort: port, SidecarReachable: true,
+			DaprdContainerName: "crazy_lamport",
+		}}, nil
+	}
+	started := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	svc := &service{
+		scan:     scan,
+		client:   srv.Client(),
+		appProc:  fakeAppProc{cmd: "/usr/bin/java -jar app.jar", pid: 4242},
+		portOpen: func(int) bool { return true },
+		procStart: func(pid int) (time.Time, bool) {
+			if pid == 4242 {
+				return started, true
+			}
+			return time.Time{}, false
+		},
+	}
+	out, err := svc.List(context.Background())
+	require.NoError(t, err)
+	in := out[0]
+	require.Equal(t, 4242, in.AppPID)
+	require.Equal(t, started.Format(time.RFC3339), in.AppStartedAt)
+}
+```
+
+`portOf` helper if the file lacks one:
+
+```go
+func portOf(t *testing.T, rawURL string) int {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	p, err := strconv.Atoi(u.Port())
+	require.NoError(t, err)
+	return p
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/discovery/ -tags unit -run TestEnrich_TestcontainersAppPIDAndUptime -v`
+Expected: FAIL — `fakeAppProc` doesn't satisfy the (not-yet-extended) interface, then after interface change: AppPID stays 0.
+
+- [ ] **Step 3: Implement**
+
+`pkg/discovery/appproc.go`:
+
+```go
+// appProcResolver resolves the local process listening on a TCP port. It
+// isolates the OS-level lookup so it can be faked in tests.
+type appProcResolver interface {
+	CommandForPort(port int) (string, bool)
+	// PIDForPort returns the PID of the port's LISTEN process.
+	PIDForPort(port int) (int, bool)
+}
+```
+
+Add the gopsutil implementation (mirror `CommandForPort`'s loop):
+
+```go
+func (gopsutilResolver) PIDForPort(port int) (int, bool) {
+	conns, err := gnet.Connections("inet")
+	if err != nil {
+		return 0, false
+	}
+	for _, c := range conns {
+		if c.Status == "LISTEN" && int(c.Laddr.Port) == port && c.Pid != 0 {
+			return int(c.Pid), true
+		}
+	}
+	return 0, false
+}
+```
+
+`pkg/discovery/service.go` — in the existing testcontainers post-metadata branch (the one that sets `RunTemplate` and returns), before the return:
+
+```go
+	if in.Source == SourceTestcontainers {
+		// Container sidecar + host app: metadata Extended PIDs/log paths
+		// describe the container's own view; daprd logs stream from the
+		// container runtime, and the app's stdout belongs to the test process.
+		// The app PID comes from the host's app-port listener instead
+		// (metadata's appPID, if any, is container-scoped and was just
+		// copied over it — override).
+		in.AppPID = 0
+		if in.AppStatus == StatusRunning && s.appProc != nil && in.AppPort != 0 {
+			if pid, ok := s.appProc.PIDForPort(in.AppPort); ok {
+				in.AppPID = pid
+				if t, ok := s.procStartTime(pid); ok {
+					in.AppStartedAt = t.UTC().Format(time.RFC3339)
+				}
+			}
+		}
+		if md.RunTemplate != "" {
+			in.RunTemplate = md.RunTemplate
+		}
+		return in
+	}
+```
+
+Update every other `appProcResolver` implementation in test files to add `PIDForPort` (compile errors point at each; return `(0, false)` unless the test needs a PID).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./pkg/discovery/ -tags unit && go build ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/discovery/appproc.go pkg/discovery/service.go pkg/discovery/service_test.go
+git commit -m "feat(discovery): resolve testcontainers app PID and uptime from app-port listener
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: cmd wiring + store-isolation guard
+
+**Files:**
+- Modify: `cmd/serve.go` (`serveDeps.ExtraResources`; replace Task 3's `nil`)
+- Modify: `cmd/root.go` (build the adapter from `tcSrc`, pass through serveDeps)
+- Test: `cmd/serve_test.go` or `cmd/root_test.go` (adapter test), plus a store-isolation guard test
+
+**Interfaces:**
+- Consumes: `discovery.TestcontainersSource.Files() []discovery.ExtractedFile` (Task 2), `resources.FromRaw(displayPath, content) []resources.Resource` (Task 3).
+- Produces: `serveDeps.ExtraResources func() []resources.Resource`; `tcExtraResources(src *discovery.TestcontainersSource) func() []resources.Resource` in cmd.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `cmd/serve_test.go` (or a new focused test in `cmd/root_test.go` — follow whichever file already tests serve wiring helpers):
+
+```go
+func TestTCExtraResources_AdaptsExtractedFiles(t *testing.T) {
+	// A TestcontainersSource whose fake runner serves one daprd container
+	// with a resources tar — reuse the discovery test fixtures via a tiny
+	// local stand-in instead: tcExtraResources only needs Files(), so give
+	// it a source primed by a fake scan. Simplest honest setup: construct
+	// the source against a fake runner exactly as pkg/discovery tests do is
+	// not possible from cmd (fakeCRT is package-private), so this test uses
+	// a real TestcontainersSource with a nil runner (no files) plus a unit
+	// test of the adapter's mapping via FromRaw directly:
+	src := discovery.NewTestcontainersSource(nil)
+	extras := tcExtraResources(src)
+	require.Empty(t, extras()) // nil runner -> no files -> no extras
+
+	// Mapping contract is pinned at the resources level:
+	rs := resources.FromRaw("crazy_lamport:/dapr-resources/kvstore.yaml",
+		[]byte("kind: Component\nmetadata:\n  name: kvstore\nspec:\n  type: state.in-memory\n"))
+	require.Len(t, rs, 1)
+	require.Equal(t, "crazy_lamport:/dapr-resources/kvstore.yaml", rs[0].Path)
+}
+
+// TestVirtualPathsDoNotFeedStoreDetection guards the spec's isolation rule:
+// container-prefixed virtual resource paths must be harmless no-ops for
+// state-store detection (they are not host paths).
+func TestVirtualPathsDoNotFeedStoreDetection(t *testing.T) {
+	comps, err := statestore.Detect([]string{"crazy_lamport:/dapr-resources"})
+	require.NoError(t, err)
+	require.Empty(t, comps)
+}
+```
+
+Check `statestore.Detect`'s exact signature before writing (`grep -n "func Detect" pkg/statestore/*.go`) and adjust the call/returns to match.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/ -tags "unit integration" -run 'TCExtraResources|VirtualPaths' -v`
+Expected: FAIL — `undefined: tcExtraResources`.
+
+- [ ] **Step 3: Implement**
+
+`cmd/serve.go`:
+- Add to `serveDeps` (after `ResourcesPaths`):
+
+```go
+	// ExtraResources supplies resource entries that exist outside the host
+	// filesystem (testcontainers-extracted component YAML); nil when the
+	// testcontainers scanner is disabled (aspire mode, tests).
+	ExtraResources func() []resources.Resource
+```
+
+- In `assembleOptions`, replace Task 3's `resources.New(rc.Paths, nil)` with `resources.New(rc.Paths, deps.ExtraResources)`.
+
+`cmd/root.go`:
+- Add the adapter (near `containerLogStream` in serve.go, or in root.go next to its use — pick serve.go for cohesion with `serveDeps`):
+
+```go
+// tcExtraResources adapts the testcontainers scanner's extracted files into
+// resources entries with container-prefixed display paths. The entries feed
+// ONLY the resources service — never state-store detection or election (an
+// extracted in-memory actor store would otherwise win the election).
+func tcExtraResources(src *discovery.TestcontainersSource) func() []resources.Resource {
+	return func() []resources.Resource {
+		var out []resources.Resource
+		for _, f := range src.Files() {
+			out = append(out, resources.FromRaw(f.Container+":"+f.Path, f.Content)...)
+		}
+		return out
+	}
+}
+```
+
+- In `runServe`'s `default:` mode case, capture the source and add to the deps: after `tcSrc := discovery.NewTestcontainersSource(crtRunner)`, declare `extraRes = tcExtraResources(tcSrc)` (add `extraRes func() []resources.Resource` to the `var (...)` block at the top of `runServe`, import `pkg/resources`), and pass `ExtraResources: extraRes,` in the `serveDeps` literal.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/ -tags "unit integration" && go build ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/serve.go cmd/root.go cmd/serve_test.go
+git commit -m "feat(cmd): wire testcontainers extracted resources into the resources service
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Frontend — protocol, Container/Session rows
+
+**Files:**
+- Modify: `web/src/types/api.ts` (`appProtocol?: string` on `AppSummary`)
+- Modify: `web/src/pages/AppDetail.tsx` (protocol row; daprd-panel Container row for testcontainers; Session row replacing CLI PID for testcontainers)
+- Test: `web/src/pages/AppDetail.test.tsx` (add cases)
+
+**Interfaces:**
+- Consumes: backend now emits `appProtocol` and (from PR #60) `testcontainersSession`, `daprdContainerName`.
+- Produces: AppDetail renders — for every source: App protocol from `app.appProtocol`; for testcontainers only: daprd panel shows Container (name) instead of daprd PID; app panel shows App PID + Session (first 8 chars, full value in `title`); standalone/compose/aspire rendering unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `web/src/pages/AppDetail.test.tsx` (reuse the file's existing render helper and app fixture builder; names below follow the pattern established by the PR #60 testcontainers test in this file):
+
+```tsx
+it('renders app protocol when reported', () => {
+  renderDetail(makeApp({ appId: 'a', appProtocol: 'http' }))
+  expect(screen.getByText('http')).toBeInTheDocument()
+})
+
+it('renders Container and Session rows for testcontainers apps', () => {
+  renderDetail(makeApp({
+    appId: 'workflow-patterns-app',
+    source: 'testcontainers',
+    daprdContainerName: 'crazy_lamport',
+    testcontainersSession: 'efeba7ba-5fdd-4713-ae0c-38f4a462cf46',
+    appStatus: 'running',
+    daprdStatus: 'running',
+  }))
+  expect(screen.getByText('crazy_lamport')).toBeInTheDocument()
+  expect(screen.getByText('Session')).toBeInTheDocument()
+  expect(screen.getByText('efeba7ba')).toBeInTheDocument()
+  expect(screen.queryByText('daprd PID')).not.toBeInTheDocument()
+  expect(screen.queryByText('CLI PID')).not.toBeInTheDocument()
+})
+
+it('keeps CLI PID and daprd PID rows for standalone apps', () => {
+  renderDetail(makeApp({ appId: 'a', source: 'standalone' }))
+  expect(screen.getByText('CLI PID')).toBeInTheDocument()
+  expect(screen.getByText('daprd PID')).toBeInTheDocument()
+})
+```
+
+(Adapt `renderDetail`/`makeApp` to the file's actual helper names — they exist from prior testcontainers tests.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd web && npx vitest run src/pages/AppDetail.test.tsx`
+Expected: FAIL — protocol renders `—`; Session row absent; daprd PID row present for testcontainers. (TS may reject `appProtocol` until api.ts is edited.)
+
+- [ ] **Step 3: Implement**
+
+`web/src/types/api.ts` — on `AppSummary`, next to `appPort`:
+
+```ts
+  /** app channel protocol reported by daprd (http, grpc, https, ...) */
+  appProtocol?: string
+```
+
+`web/src/pages/AppDetail.tsx` (the `isTestcontainers` const exists from PR #60):
+
+1. Protocol row (currently a hardcoded dash):
+
+```tsx
+            <div className="kk">App protocol</div>
+            <div className="vv mono">{app.appProtocol || <span className="faint">—</span>}</div>
+```
+
+2. App panel PID block — the current `isCompose ? (container rows) : (App PID + CLI PID rows)` gains a testcontainers variant inside the else-branch: keep the App PID rows, then:
+
+```tsx
+                {isTestcontainers ? (
+                  <>
+                    <div className="kk">Session</div>
+                    <div className="vv mono" title={app.testcontainersSession}>
+                      {app.testcontainersSession ? app.testcontainersSession.slice(0, 8) : <span className="faint">—</span>}
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="kk">CLI PID</div>
+                    <div className="vv mono">{app.cliPid || <span className="faint">—</span>}</div>
+                  </>
+                )}
+```
+
+3. Daprd panel — widen the container-row condition from `isCompose ?` to `isCompose || isTestcontainers ?` (the row body already renders `app.daprdContainerName`).
+
+Aspire note: `isTestcontainers` is false for aspire apps, so aspire rendering is untouched — do not add any aspire-specific conditions.
+
+- [ ] **Step 4: Run tests + typecheck to verify they pass**
+
+Run: `cd web && npx vitest run && npx tsc -b`
+Expected: all PASS, tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/types/api.ts web/src/pages/AppDetail.tsx web/src/pages/AppDetail.test.tsx
+git commit -m "feat(web): app protocol row; container and session rows for testcontainers
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Full verification + live e2e
+
+**Files:** none created (verification only; commit fixes individually if something is broken).
+
+- [ ] **Step 1: Full build and suites**
+
+```bash
+go build ./... && go test ./... -tags "unit integration"
+cd web && npx vitest run && npx tsc -b && cd ..
+make build
+```
+
+Expected: everything passes.
+
+- [ ] **Step 2: Live e2e against the Java quickstart**
+
+Start the quickstart in the background (takes 1-3 min; poll `curl -s localhost:8080/actuator/health` for `{"status":"UP"}`):
+
+```bash
+cd /Users/marcduiker/dev/dapr/quickstarts/tutorials/workflow/java/child-workflows
+mvn spring-boot:test-run
+```
+
+Then run the dashboard (`go run . --no-open --port 9095`) and verify (confirm exact API paths against `pkg/server/resources.go` and `pkg/server/apps.go` first):
+
+```bash
+# 1. kvstore appears in the Components list with the container-prefixed path
+curl -s 'localhost:9095/api/resources?kind=component' | jq '.[] | {name, type, path, loadedBy}'
+# expect an entry: kvstore / state.in-memory / crazy_...:/dapr-resources/kvstore.yaml / ["<instanceKey>"]
+
+# 2. Detail carries the full YAML incl. actorStateStore
+ID=$(curl -s 'localhost:9095/api/resources?kind=component' | jq -r '.[] | select(.name=="kvstore") | .id')
+curl -s "localhost:9095/api/resources/component/$ID" | jq -r '.raw' | grep actorStateStore
+
+# 3. App detail: protocol, JVM PID, uptime, session, virtual paths
+curl -s localhost:9095/api/apps | jq '.[] | select(.source=="testcontainers") | {appProtocol, appPid, appStartedAt, testcontainersSession, resourcePaths}'
+# expect: http / non-zero PID (a java process) / RFC3339 timestamp / session uuid / ["<container>:/dapr-resources"]
+
+# 4. Workflows still work and the store election is untouched: no store banner
+#    change, and if a Redis store is elected it stays elected (check /api/statestores).
+curl -s localhost:9095/api/workflows | jq '.items | length'
+```
+
+Also verify in the UI if convenient: Components page shows kvstore (read-only, container path), AppDetail shows Uptime ticking, App PID, protocol `http`, Container `crazy_lamport`, Session prefix.
+
+Kill the mvn process and the dashboard afterward; confirm ryuk removed the org.testcontainers containers and no processes remain.
+
+- [ ] **Step 3: Confirm store-election isolation live**
+
+While the quickstart is up: `curl -s localhost:9095/api/statestores | jq` must NOT list kvstore/state.in-memory as a detected or active store entry.
+
+- [ ] **Step 4: Commit any fixes; hand off**
+
+If steps 1-3 surfaced fixes, commit each individually. Then hand off to superpowers:finishing-a-development-branch (PR should target `feat/testcontainers-discovery` if PR #60 is still open, else `main`).
+
+---
+
+## Deferred (documented, deliberately out of scope)
+
+- Extraction for compose containers with unmounted resource dirs.
+- Metrics port (placeholder for all sources today).
+- Aspire row rendering (dash-only CLI PID row remains).
+- Editing extracted (read-only) component entries.

--- a/docs/superpowers/specs/2026-07-12-testcontainers-components-appdetail-design.md
+++ b/docs/superpowers/specs/2026-07-12-testcontainers-components-appdetail-design.md
@@ -1,0 +1,145 @@
+# Testcontainers components in the Components view + App detail completeness
+
+Date: 2026-07-12
+Status: approved
+Builds on: `2026-07-12-testcontainers-discovery-sidecar-workflows-design.md` (PR #60);
+branch `feat/testcontainers-components` stacks on `feat/testcontainers-discovery`.
+
+## Goal
+
+1. Components declared in Testcontainers test config (e.g. the `kvstore`
+   `state.in-memory` component of the Java quickstart) appear in the
+   Components view with their full YAML, even though the file exists only
+   inside the daprd container.
+2. The Application detail page stops showing empty fields for testcontainers
+   apps: Uptime, App PID, App protocol, the daprd PID slot, and the Paths
+   section all carry real values — and App protocol is fixed for every
+   source, since it was a hardcoded placeholder.
+
+## Background (verified)
+
+- The Components view is backed by `pkg/resources`, which scans YAML files
+  on host disk from `reconciler.Paths()`. Testcontainers components are
+  written by `testcontainers-dapr` to `--resources-path /dapr-resources`
+  inside the daprd container — no host file, so no entry.
+- The server already learns each app's component names/types/versions from
+  sidecar metadata (the `LoadedBy` index in `pkg/server/resources.go`), so
+  badges work once an entry exists.
+- `AppDetail.tsx` renders "App protocol" and "Metrics port" as hardcoded
+  `—` for every source; PID rows render for testcontainers because only
+  `isCompose` swaps in container rows; `AppStartedAt` is never set for
+  testcontainers (enrichment probes the app port but never resolves the
+  listener's PID).
+
+## Part 1: Component YAML extraction from the daprd container
+
+**Mechanism.** For each testcontainers daprd container, run
+`<runtime> cp <containerID>:<resourcesPath> -` through the existing
+`containerruntime.Runner` (docker and podman both stream a tar archive to
+stdout; no shell needed in the container, so distroless daprd images work).
+Parse with `archive/tar`, keeping only regular `.yaml`/`.yml` files, capped
+at 32 files and 1 MiB per file.
+
+**Caching.** Extract once per container ID (the files are written at
+container creation and never change). Evict cache entries for container IDs
+no longer present in the scan. Extraction failure logs once per container
+and degrades to no extracted files.
+
+**Store-election isolation (load-bearing).** Extracted YAML feeds ONLY the
+resources service (Components/Configurations pages). It is never added to
+`reconciler.Paths()`, never passed to `statestore.Detect`, and never
+participates in active-store election. Rationale: a testcontainers
+component like `kvstore` is `state.in-memory` with `actorStateStore: true`;
+the election precedence ranks app-provided actor stores first, so feeding
+it in would evict a real (e.g. Redis) store and break other apps' workflow
+views. Workflow routing stays exactly as shipped in PR #60.
+
+**Wiring.**
+- `TestcontainersSource` exposes the extracted files (container name,
+  in-container path, raw content), populated during its cached scan.
+- `resources.New` gains an optional extras provider (`func() []Resource`)
+  merged after the file scan. Extracted content parses through the same
+  multi-doc YAML parser as scanned files, so a `Configuration` document in
+  the resources dir lands on the Configurations page for free.
+- Extracted entries carry `Raw` (full spec, including fields like
+  `actorStateStore: true`) and a container-prefixed display path, e.g.
+  `crazy_lamport:/dapr-resources/kvstore.yaml`. IDs derive from the same
+  name|type|path hash as file entries; the container name in the path keeps
+  concurrent sessions with identical component names distinct.
+- `LoadedBy` badges work unchanged (computed from metadata by name).
+- Entries are read-only, like any scanned file.
+
+## Part 2: App detail completeness
+
+**App protocol — all sources.** `FetchMetadata` additionally reads
+`appConnectionProperties.protocol` from `/v1.0/metadata` (Dapr 1.11+);
+`Instance.AppProtocol` carries it; the hardcoded `—` in `AppDetail.tsx`
+becomes the real value for standalone, compose, aspire, and testcontainers.
+Fallback for container sources when metadata is unavailable:
+`--app-protocol` from the parsed daprd argv. Metrics port stays a
+placeholder (out of scope).
+
+**App PID and app Uptime (testcontainers).** The `appProcResolver` gains a
+PID-returning lookup for the app-port listener (same gopsutil connection
+data that already yields the command). The testcontainers enrich branch
+sets `AppPID` from it (overriding the container-scoped metadata appPID,
+which is meaningless on the host) and `AppStartedAt` via the existing
+`procStartTime` — giving the JVM's real PID and a ticking uptime. Daprd
+uptime already flows from the container's `StartedAt`.
+
+**Row selection (testcontainers only; aspire untouched).**
+- Daprd panel: render the compose-style **Container** row
+  (daprd container name) instead of the "daprd PID" row — an in-container
+  PID is not a host PID and would mislead (especially on macOS).
+- App panel: keep **App PID** (now filled — the app genuinely is a host
+  process); replace the **CLI PID** row with a **Session** row showing the
+  `org.testcontainers.sessionId` (first 8 characters, full value as the
+  element's title attribute). CLI PID remains for
+  standalone (it is real and drives orphan detection), compose keeps its
+  container rows, and aspire's rendering is explicitly unchanged (its
+  dash-only CLI PID row is a pre-existing cosmetic gap, out of scope).
+
+**Paths.** `ResourcePaths` for testcontainers instances gets the
+container-prefixed virtual path (e.g. `crazy_lamport:/dapr-resources`),
+matching Part 1's display convention; `ConfigPath` likewise when `--config`
+is present in the argv. Known caveat: these are display paths — the copy
+button yields a string that is not a host path, and the reconciler's path
+walkers no-op harmlessly on nonexistent paths (verified; and per the
+isolation rule above, extracted YAML never reaches store election anyway).
+
+## Error handling
+
+- `cp` failure / tar parse failure: log once per container, no entries;
+  page behaves as today.
+- Oversized/odd tar members skipped silently (caps above).
+- Missing `appConnectionProperties` in metadata (older daprd): protocol
+  falls back to argv for container sources, else stays `—`.
+- App-port listener PID lookup failure: PID/uptime stay empty (as today);
+  never blocks other enrichment.
+
+## Testing
+
+- Extractor: tar-fixture tests (fixture captured from a real
+  `docker cp` of the live quickstart container), including cap and
+  malformed-member cases.
+- Scanner: fake-runner tests for extract-once caching and eviction of
+  departed containers.
+- Resources service: merge tests (file + extras, ID stability, kind
+  routing of a Configuration doc).
+- Guard test: extracted components never appear in store detection paths.
+- Metadata: `appConnectionProperties.protocol` parse test; argv fallback
+  test.
+- Enrich: App PID/StartedAt from listener-PID resolver (faked).
+- Web: row-selection tests (Session/Container rows for testcontainers,
+  standalone/compose/aspire unchanged), App protocol rendering; `tsc -b`.
+- Manual e2e against the child-workflows quickstart: kvstore visible in
+  Components with full YAML and LoadedBy badge; AppDetail shows uptime,
+  JVM PID, protocol http, container row, session, and paths.
+
+## Out of scope
+
+- Extending extraction to compose containers with unmounted resource dirs
+  (documented follow-up).
+- Metrics port (placeholder for all sources today).
+- Aspire row rendering changes.
+- Editing extracted (read-only) component entries.

--- a/pkg/discovery/appproc.go
+++ b/pkg/discovery/appproc.go
@@ -10,10 +10,12 @@ import (
 	gproc "github.com/shirou/gopsutil/process"
 )
 
-// appProcResolver resolves the full command line of the local process listening
-// on a TCP port. It isolates the OS-level lookup so it can be faked in tests.
+// appProcResolver resolves the local process listening on a TCP port. It
+// isolates the OS-level lookup so it can be faked in tests.
 type appProcResolver interface {
 	CommandForPort(port int) (string, bool)
+	// PIDForPort returns the PID of the port's LISTEN process.
+	PIDForPort(port int) (int, bool)
 }
 
 // isAspireProxy reports whether cmd is the .NET Aspire Developer Control Plane
@@ -76,6 +78,19 @@ func (gopsutilResolver) CommandForPort(port int) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func (gopsutilResolver) PIDForPort(port int) (int, bool) {
+	conns, err := gnet.Connections("inet")
+	if err != nil {
+		return 0, false
+	}
+	for _, c := range conns {
+		if c.Status == "LISTEN" && int(c.Laddr.Port) == port && c.Pid != 0 {
+			return int(c.Pid), true
+		}
+	}
+	return 0, false
 }
 
 // gopsutilProcStart resolves a process's start time from its PID.

--- a/pkg/discovery/appproc_test.go
+++ b/pkg/discovery/appproc_test.go
@@ -14,6 +14,7 @@ type fakeResolver struct {
 }
 
 func (f fakeResolver) CommandForPort(int) (string, bool) { return f.cmd, f.ok }
+func (f fakeResolver) PIDForPort(int) (int, bool)        { return 0, false }
 
 func TestAppRuntime(t *testing.T) {
 	t.Run("known primary command — no fallback needed", func(t *testing.T) {

--- a/pkg/discovery/compose_args.go
+++ b/pkg/discovery/compose_args.go
@@ -12,6 +12,7 @@ type daprdArgs struct {
 	AppChannelAddress string
 	ResourcesPath     string
 	ConfigPath        string
+	AppProtocol       string
 	AppPort           int
 	HTTPPort          int // container-internal; defaults to 3500 like daprd itself
 	GRPCPort          int // container-internal; defaults to 50001 like daprd itself
@@ -54,6 +55,7 @@ func parseDaprdArgs(argv []string) (daprdArgs, bool) {
 		AppChannelAddress: flags["app-channel-address"],
 		ResourcesPath:     flags["resources-path"],
 		ConfigPath:        flags["config"],
+		AppProtocol:       flags["app-protocol"],
 		AppPort:           atoi(flags["app-port"]),
 		HTTPPort:          atoi(flags["dapr-http-port"]),
 		GRPCPort:          atoi(flags["dapr-grpc-port"]),

--- a/pkg/discovery/compose_args_test.go
+++ b/pkg/discovery/compose_args_test.go
@@ -5,6 +5,8 @@ package discovery
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseDaprdArgs(t *testing.T) {
@@ -60,4 +62,10 @@ func TestParseDaprdArgs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseDaprdArgs_AppProtocol(t *testing.T) {
+	args, ok := parseDaprdArgs([]string{"./daprd", "--app-id", "a", "--app-protocol", "grpc"})
+	require.True(t, ok)
+	require.Equal(t, "grpc", args.AppProtocol)
 }

--- a/pkg/discovery/metadata.go
+++ b/pkg/discovery/metadata.go
@@ -42,6 +42,7 @@ type Metadata struct {
 	AppLogPath      string
 	DaprdLogPath    string
 	RunTemplate     string
+	AppProtocol     string
 	Actors          []ActorType
 	Subscriptions   []Subscription
 	Components      []Component
@@ -68,6 +69,9 @@ type rawMetadata struct {
 	ActorRuntime    struct {
 		Placement string `json:"placement"`
 	} `json:"actorRuntime"`
+	AppConnectionProperties struct {
+		Protocol string `json:"protocol"`
+	} `json:"appConnectionProperties"`
 }
 
 // runTemplateFromExtended returns the run template's display name. The
@@ -125,6 +129,7 @@ func FetchMetadata(ctx context.Context, client *http.Client, baseURL string) (Me
 		AppLogPath:      raw.Extended["appLogPath"],
 		DaprdLogPath:    raw.Extended["daprdLogPath"],
 		RunTemplate:     runTemplateFromExtended(raw.Extended),
+		AppProtocol:     raw.AppConnectionProperties.Protocol,
 		Actors:          raw.Actors,
 		Components:      raw.Components,
 		Subscriptions:   subs,

--- a/pkg/discovery/metadata_test.go
+++ b/pkg/discovery/metadata_test.go
@@ -79,3 +79,14 @@ func TestFetchMetadataRunTemplateEmptyWhenNeitherFieldSet(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", md.RunTemplate)
 }
+
+func TestFetchMetadata_AppProtocol(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"a","appConnectionProperties":{"port":8080,"protocol":"http","channelAddress":"host.testcontainers.internal"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	md, err := FetchMetadata(context.Background(), &http.Client{Timeout: 2 * time.Second}, srv.URL)
+	require.NoError(t, err)
+	require.Equal(t, "http", md.AppProtocol)
+}

--- a/pkg/discovery/scan_compose.go
+++ b/pkg/discovery/scan_compose.go
@@ -154,6 +154,7 @@ func (s *ComposeSource) scanOnce() ([]ScanResult, ComposeEnv, error) {
 			AppPort:            args.AppPort,
 			Created:            c.StartedAt,
 			Command:            strings.Join(c.Argv, " "),
+			AppProtocol:        args.AppProtocol,
 			Source:             SourceCompose,
 			ComposeProject:     c.Project,
 			ComposeService:     c.Service,

--- a/pkg/discovery/scan_testcontainers.go
+++ b/pkg/discovery/scan_testcontainers.go
@@ -174,10 +174,11 @@ func (s *TestcontainersSource) scanOnce() ([]ScanResult, error) {
 
 // extractResources copies the container's resources dir out as a tar stream
 // (`cp <id>:<dir> -`, no shell needed — works on distroless images) and
-// caches the YAML files per container ID. Runs once per container; a
-// failure logs once and is not retried. Caller holds s.mu (extractResources
-// is only ever called from scanOnce, which is only ever called from scan
-// while s.mu is held).
+// caches the YAML files per container ID. Runs once per container; genuine
+// failures are pinned and not retried, while context-expiry failures are
+// retried on the next scan. Caller holds s.mu (extractResources is only ever
+// called from scanOnce, which is only ever called from scan while s.mu is
+// held).
 func (s *TestcontainersSource) extractResources(ctx context.Context, c composeContainer, dir string) {
 	if _, done := s.extracted[c.ID]; done || s.extractFailed[c.ID] {
 		return

--- a/pkg/discovery/scan_testcontainers.go
+++ b/pkg/discovery/scan_testcontainers.go
@@ -131,6 +131,7 @@ func (s *TestcontainersSource) scanOnce() ([]ScanResult, error) {
 			AppPort:               args.AppPort,
 			Created:               c.StartedAt,
 			Command:               strings.Join(c.Argv, " "),
+			AppProtocol:           args.AppProtocol,
 			Source:                SourceTestcontainers,
 			TestcontainersSession: c.Labels[labelTestcontainersSessionID],
 			DaprdContainerID:      c.ID,

--- a/pkg/discovery/scan_testcontainers.go
+++ b/pkg/discovery/scan_testcontainers.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"sort"
@@ -183,6 +184,14 @@ func (s *TestcontainersSource) extractResources(ctx context.Context, c composeCo
 	}
 	raw, err := s.run.Run(ctx, "cp", c.ID+":"+dir, "-")
 	if err != nil {
+		if extractionRetryable(ctx, err) {
+			// The cp call shares scanOnce's single scan-wide context with ps
+			// and inspect; a slow docker round-trip can expire the deadline
+			// mid-cp. That's transient, not a genuine extraction failure —
+			// leave extractFailed unset so the next scan retries.
+			logger().Warn("testcontainers resource extraction timed out, will retry", "container", c.Name, "err", err)
+			return
+		}
 		logger().Warn("testcontainers resource extraction failed", "container", c.Name, "err", err)
 		s.extractFailed[c.ID] = true
 		return
@@ -202,4 +211,17 @@ func (s *TestcontainersSource) extractResources(ctx context.Context, c composeCo
 		out = append(out, ExtractedFile{Container: c.Name, Path: dir + "/" + rel, Content: content})
 	}
 	s.extracted[c.ID] = out
+}
+
+// extractionRetryable classifies a failed extraction call as transient
+// (caused by the scan's shared context expiring or being cancelled, rather
+// than a genuine failure like a missing container or corrupt tar). scanCtx
+// is the context passed to the runner for this scan; it is checked directly
+// because a container runtime may return its own error type instead of (or
+// in addition to) propagating ctx.Err() verbatim.
+func extractionRetryable(scanCtx context.Context, err error) bool {
+	if scanCtx.Err() != nil {
+		return true
+	}
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
 }

--- a/pkg/discovery/scan_testcontainers.go
+++ b/pkg/discovery/scan_testcontainers.go
@@ -3,6 +3,8 @@ package discovery
 import (
 	"context"
 	"fmt"
+	"path"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -34,10 +36,44 @@ type TestcontainersSource struct {
 	last    time.Time
 	results []ScanResult
 	lastErr error
+
+	// extracted caches per-container-ID resource files (containerID ->
+	// files); extractFailed remembers IDs whose extraction already failed
+	// so the failure logs once and is not retried every scan.
+	extracted     map[string][]ExtractedFile
+	extractFailed map[string]bool
+}
+
+// ExtractedFile is one YAML file copied out of a daprd container's
+// resources dir. Container is the container name (display identity), Path
+// the container-internal file path.
+type ExtractedFile struct {
+	Container string
+	Path      string
+	Content   []byte
 }
 
 func NewTestcontainersSource(run containerruntime.Runner) *TestcontainersSource {
-	return &TestcontainersSource{run: run, clock: time.Now}
+	return &TestcontainersSource{run: run, clock: time.Now,
+		extracted: map[string][]ExtractedFile{}, extractFailed: map[string]bool{}}
+}
+
+// Files returns the extracted resource files of all currently-scanned
+// containers, ordered by container name then path.
+func (s *TestcontainersSource) Files() []ExtractedFile {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []ExtractedFile
+	for _, files := range s.extracted {
+		out = append(out, files...)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Container != out[j].Container {
+			return out[i].Container < out[j].Container
+		}
+		return out[i].Path < out[j].Path
+	})
+	return out
 }
 
 // Scanner returns the testcontainers scan as a discovery.Scanner.
@@ -68,6 +104,9 @@ func (s *TestcontainersSource) scanOnce() ([]ScanResult, error) {
 	}
 	ids := strings.Fields(string(out))
 	if len(ids) == 0 {
+		// No testcontainers-labeled containers left: evict all extraction cache.
+		s.extracted = map[string][]ExtractedFile{}
+		s.extractFailed = map[string]bool{}
 		return nil, nil
 	}
 	raw, err := s.run.Run(ctx, append([]string{"inspect"}, ids...)...)
@@ -102,7 +141,64 @@ func (s *TestcontainersSource) scanOnce() ([]ScanResult, error) {
 			r.DaprdStartedAt = c.StartedAt
 		}
 		r.SidecarReachable = r.HTTPPort != 0
+		if args.ResourcesPath != "" {
+			r.ResourcePaths = []string{c.Name + ":" + args.ResourcesPath}
+			s.extractResources(ctx, c, args.ResourcesPath)
+		}
+		if args.ConfigPath != "" {
+			r.ConfigPath = c.Name + ":" + args.ConfigPath
+		}
 		results = append(results, r)
 	}
+
+	// Evict extraction cache entries for containers gone from this scan.
+	live := map[string]bool{}
+	for _, c := range containers {
+		live[c.ID] = true
+	}
+	for id := range s.extracted {
+		if !live[id] {
+			delete(s.extracted, id)
+		}
+	}
+	for id := range s.extractFailed {
+		if !live[id] {
+			delete(s.extractFailed, id)
+		}
+	}
+
 	return results, nil
+}
+
+// extractResources copies the container's resources dir out as a tar stream
+// (`cp <id>:<dir> -`, no shell needed — works on distroless images) and
+// caches the YAML files per container ID. Runs once per container; a
+// failure logs once and is not retried. Caller holds s.mu (extractResources
+// is only ever called from scanOnce, which is only ever called from scan
+// while s.mu is held).
+func (s *TestcontainersSource) extractResources(ctx context.Context, c composeContainer, dir string) {
+	if _, done := s.extracted[c.ID]; done || s.extractFailed[c.ID] {
+		return
+	}
+	raw, err := s.run.Run(ctx, "cp", c.ID+":"+dir, "-")
+	if err != nil {
+		logger().Warn("testcontainers resource extraction failed", "container", c.Name, "err", err)
+		s.extractFailed[c.ID] = true
+		return
+	}
+	files, err := extractYAMLFromTar(raw)
+	if err != nil {
+		logger().Warn("testcontainers resource tar parse failed", "container", c.Name, "err", err)
+		s.extractFailed[c.ID] = true
+		return
+	}
+	out := make([]ExtractedFile, 0, len(files))
+	base := path.Base(strings.TrimSuffix(dir, "/"))
+	for name, content := range files {
+		// Tar member names are relative to the copied dir's parent (e.g.
+		// "dapr-resources/kvstore.yaml"); rebase onto the container path.
+		rel := strings.TrimPrefix(name, base+"/")
+		out = append(out, ExtractedFile{Container: c.Name, Path: dir + "/" + rel, Content: content})
+	}
+	s.extracted[c.ID] = out
 }

--- a/pkg/discovery/scan_testcontainers_test.go
+++ b/pkg/discovery/scan_testcontainers_test.go
@@ -3,7 +3,10 @@
 package discovery
 
 import (
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -84,4 +87,78 @@ func TestTestcontainersScanner_NilRunnerIsEmptyAndErrorFree(t *testing.T) {
 	results, err := src.Scanner()()
 	require.NoError(t, err)
 	require.Empty(t, results)
+}
+
+// resourcesTar returns a docker-cp-style tar of /dapr-resources with one
+// component file. Reuses buildTar from tar_extract_test.go (same package).
+func resourcesTar(t *testing.T) []byte {
+	t.Helper()
+	return buildTar(t, map[string]string{
+		"dapr-resources/kvstore.yaml": "apiVersion: dapr.io/v1alpha1\nkind: Component\nmetadata:\n  name: kvstore\nspec:\n  type: state.in-memory\n  version: v1\n",
+	})
+}
+
+func TestTestcontainersScanner_ExtractsResourceFiles(t *testing.T) {
+	crt := fakeTestcontainersRunner(t)
+	crt.responses["cp 28af628017d1:/dapr-resources"] = resourcesTar(t)
+	src := NewTestcontainersSource(crt)
+
+	results, err := src.Scanner()()
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, []string{"crazy_lamport:/dapr-resources"}, results[0].ResourcePaths)
+
+	files := src.Files()
+	require.Len(t, files, 1)
+	require.Equal(t, "crazy_lamport", files[0].Container)
+	require.Equal(t, "/dapr-resources/kvstore.yaml", files[0].Path)
+	require.Contains(t, string(files[0].Content), "state.in-memory")
+}
+
+func TestTestcontainersScanner_ExtractionCachedAndEvicted(t *testing.T) {
+	crt := fakeTestcontainersRunner(t)
+	crt.responses["cp 28af628017d1:/dapr-resources"] = resourcesTar(t)
+	src := NewTestcontainersSource(crt)
+	src.clock = func() time.Time { return time.Now() } // will be swapped below
+
+	// First scan extracts.
+	_, err := src.Scanner()()
+	require.NoError(t, err)
+	cpCalls := 0
+	for _, c := range crt.calls {
+		if strings.HasPrefix(c, "cp ") {
+			cpCalls++
+		}
+	}
+	require.Equal(t, 1, cpCalls)
+
+	// Second scan (cache TTL bypassed by advancing the clock) must NOT re-cp.
+	base := time.Now()
+	src.clock = func() time.Time { base = base.Add(3 * time.Second); return base }
+	_, err = src.Scanner()()
+	require.NoError(t, err)
+	cpCalls = 0
+	for _, c := range crt.calls {
+		if strings.HasPrefix(c, "cp ") {
+			cpCalls++
+		}
+	}
+	require.Equal(t, 1, cpCalls, "extraction must be cached per container ID")
+
+	// Container disappears -> cache evicted, Files() empty.
+	crt.responses["ps -aq"] = []byte("")
+	_, err = src.Scanner()()
+	require.NoError(t, err)
+	require.Empty(t, src.Files())
+}
+
+func TestTestcontainersScanner_ExtractionFailureDegrades(t *testing.T) {
+	crt := fakeTestcontainersRunner(t)
+	crt.errs = map[string]error{"cp 28af628017d1:/dapr-resources": errors.New("no such container")}
+	src := NewTestcontainersSource(crt)
+
+	results, err := src.Scanner()()
+	require.NoError(t, err) // scan itself still succeeds
+	require.Len(t, results, 1)
+	require.Empty(t, src.Files())
 }

--- a/pkg/discovery/scan_testcontainers_test.go
+++ b/pkg/discovery/scan_testcontainers_test.go
@@ -3,7 +3,9 @@
 package discovery
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -161,4 +163,89 @@ func TestTestcontainersScanner_ExtractionFailureDegrades(t *testing.T) {
 	require.NoError(t, err) // scan itself still succeeds
 	require.Len(t, results, 1)
 	require.Empty(t, src.Files())
+
+	// A genuine failure (bad container, garbage tar) is pinned: a second scan
+	// (cache TTL bypassed) must NOT retry the cp.
+	base := time.Now()
+	src.clock = func() time.Time { base = base.Add(3 * time.Second); return base }
+	_, err = src.Scanner()()
+	require.NoError(t, err)
+	cpCalls := 0
+	for _, c := range crt.calls {
+		if strings.HasPrefix(c, "cp ") {
+			cpCalls++
+		}
+	}
+	require.Equal(t, 1, cpCalls, "genuine extraction failure must not be retried")
+}
+
+// TestTestcontainersScanner_ExtractionRetriesAfterContextExpiry pins the fix
+// for a transient cp failure caused by the shared scan context expiring
+// mid-extraction (all cp calls share scanOnce's single 3s context with ps and
+// inspect; a slow docker round-trip can expire the deadline mid-cp). Such a
+// failure must NOT be pinned in extractFailed — the next scan must retry.
+// The fake runtime models this by returning an error wrapping
+// context.DeadlineExceeded on the first cp call (a runner reporting the
+// scan context's expiry), then succeeding on retry.
+func TestTestcontainersScanner_ExtractionRetriesAfterContextExpiry(t *testing.T) {
+	crt := fakeTestcontainersRunner(t)
+	crt.responses["cp 28af628017d1:/dapr-resources"] = resourcesTar(t)
+	crt.errs = map[string]error{
+		"cp 28af628017d1:/dapr-resources": fmt.Errorf("cp: %w", context.DeadlineExceeded),
+	}
+	src := NewTestcontainersSource(crt)
+
+	// First scan: cp fails with a context-expiry error. Scan itself still
+	// succeeds, and the container's resources are just not yet extracted.
+	results, err := src.Scanner()()
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Empty(t, src.Files(), "extraction not yet retried")
+
+	// Second scan (cache TTL bypassed, and the transient error cleared, as a
+	// real retry would find the docker daemon responsive again): the cp call
+	// must be re-attempted and succeed this time.
+	delete(crt.errs, "cp 28af628017d1:/dapr-resources")
+	base := time.Now()
+	src.clock = func() time.Time { base = base.Add(3 * time.Second); return base }
+	_, err = src.Scanner()()
+	require.NoError(t, err)
+
+	cpCalls := 0
+	for _, c := range crt.calls {
+		if strings.HasPrefix(c, "cp ") {
+			cpCalls++
+		}
+	}
+	require.Equal(t, 2, cpCalls, "transient context-expiry failure must be retried, not pinned")
+
+	files := src.Files()
+	require.Len(t, files, 1)
+	require.Equal(t, "/dapr-resources/kvstore.yaml", files[0].Path)
+}
+
+func TestExtractionRetryable(t *testing.T) {
+	t.Run("live context, generic error -> not retryable", func(t *testing.T) {
+		require.False(t, extractionRetryable(context.Background(), errors.New("no such container")))
+	})
+	t.Run("live context, no error -> not retryable", func(t *testing.T) {
+		require.False(t, extractionRetryable(context.Background(), nil))
+	})
+	t.Run("cancelled scan context -> retryable regardless of error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		require.True(t, extractionRetryable(ctx, errors.New("no such container")))
+	})
+	t.Run("expired scan context -> retryable", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 0)
+		defer cancel()
+		<-ctx.Done()
+		require.True(t, extractionRetryable(ctx, errors.New("client is closed")))
+	})
+	t.Run("live context, error wraps DeadlineExceeded -> retryable", func(t *testing.T) {
+		require.True(t, extractionRetryable(context.Background(), fmt.Errorf("wrap: %w", context.DeadlineExceeded)))
+	})
+	t.Run("live context, error wraps Canceled -> retryable", func(t *testing.T) {
+		require.True(t, extractionRetryable(context.Background(), fmt.Errorf("wrap: %w", context.Canceled)))
+	})
 }

--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -40,6 +40,7 @@ type ScanResult struct {
 	ResourcePaths []string
 	ConfigPath    string
 	Command       string
+	AppProtocol   string
 
 	// Source is SourceStandalone (process table) or SourceCompose (containers).
 	Source             string
@@ -194,8 +195,9 @@ func (s *service) enrich(ctx context.Context, r ScanResult) Instance {
 		AppID: r.AppID, InstanceKey: r.Key(), HTTPPort: r.HTTPPort, GRPCPort: r.GRPCPort, AppPort: r.AppPort,
 		DaprdPID: r.DaprdPID, CLIPID: r.CLIPID, RunTemplate: r.RunTemplate,
 		ResourcePaths: r.ResourcePaths, ConfigPath: r.ConfigPath, Command: r.Command,
-		Age:     humanAge(r.Created),
-		Runtime: InferRuntime(r.Command), Health: HealthUnknown,
+		AppProtocol: r.AppProtocol,
+		Age:         humanAge(r.Created),
+		Runtime:     InferRuntime(r.Command), Health: HealthUnknown,
 		Source: r.Source, ComposeProject: r.ComposeProject, ComposeService: r.ComposeService,
 		DaprdContainerID: r.DaprdContainerID, DaprdContainerName: r.DaprdContainerName,
 		AppContainerID: r.AppContainerID, AppContainerName: r.AppContainerName,
@@ -281,6 +283,9 @@ func (s *service) enrich(ctx context.Context, r ScanResult) Instance {
 	in.Components = md.Components
 	in.EnabledFeatures = md.EnabledFeatures
 	in.Placement = md.Placement
+	if md.AppProtocol != "" {
+		in.AppProtocol = md.AppProtocol
+	}
 	if in.Source == SourceStandalone {
 		switch {
 		case in.AppPID != 0:

--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -329,6 +329,18 @@ func (s *service) enrich(ctx context.Context, r ScanResult) Instance {
 		// Container sidecar + host app: metadata Extended PIDs/log paths
 		// describe the container's own view; daprd logs stream from the
 		// container runtime, and the app's stdout belongs to the test process.
+		// The app PID comes from the host's app-port listener instead
+		// (metadata's appPID, if any, is container-scoped and was just
+		// copied over it — override).
+		in.AppPID = 0
+		if in.AppStatus == StatusRunning && s.appProc != nil && in.AppPort != 0 {
+			if pid, ok := s.appProc.PIDForPort(in.AppPort); ok {
+				in.AppPID = pid
+				if t, ok := s.procStartTime(pid); ok {
+					in.AppStartedAt = t.UTC().Format(time.RFC3339)
+				}
+			}
+		}
 		if md.RunTemplate != "" {
 			in.RunTemplate = md.RunTemplate
 		}

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -583,6 +583,8 @@ func (fakeAspireResolver) CommandForPort(port int) (string, bool) {
 	return "/path/to/dcp run-controllers", true
 }
 
+func (fakeAspireResolver) PIDForPort(int) (int, bool) { return 0, false }
+
 func TestSidecarOrphanedDetection(t *testing.T) {
 	newSvc := func(cliPID int) *service {
 		port := stubSidecar(t, "") // no appPID, no cliPID in metadata
@@ -647,9 +649,23 @@ func TestEnrichZeroCreatedShowsNoTimestamp(t *testing.T) {
 	require.Equal(t, "", items[0].Age)
 }
 
-type fakeAppProc struct{ cmd string }
+type fakeAppProc struct {
+	cmd string
+	pid int
+}
 
 func (f fakeAppProc) CommandForPort(int) (string, bool) { return f.cmd, f.cmd != "" }
+func (f fakeAppProc) PIDForPort(int) (int, bool)        { return f.pid, f.pid != 0 }
+
+// portOf parses the port out of an httptest server URL.
+func portOf(t *testing.T, rawURL string) int {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	p, err := strconv.Atoi(u.Port())
+	require.NoError(t, err)
+	return p
+}
 
 func TestEnrich_TestcontainersHostAppPairing(t *testing.T) {
 	scan := func() ([]ScanResult, error) {
@@ -688,6 +704,44 @@ func TestEnrich_TestcontainersStoppedApp(t *testing.T) {
 	out, err := svc.List(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, StatusStopped, out[0].AppStatus)
+}
+
+func TestEnrich_TestcontainersAppPIDAndUptime(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/v1.0/metadata") {
+			_, _ = w.Write([]byte(`{"id":"workflow-patterns-app"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNoContent) // healthz
+	}))
+	defer srv.Close()
+	port := portOf(t, srv.URL)
+
+	scan := func() ([]ScanResult, error) {
+		return []ScanResult{{
+			AppID: "workflow-patterns-app", Source: SourceTestcontainers,
+			AppPort: 8080, HTTPPort: port, SidecarReachable: true,
+			DaprdContainerName: "crazy_lamport",
+		}}, nil
+	}
+	started := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	svc := &service{
+		scan:     scan,
+		client:   srv.Client(),
+		appProc:  fakeAppProc{cmd: "/usr/bin/java -jar app.jar", pid: 4242},
+		portOpen: func(int) bool { return true },
+		procStart: func(pid int) (time.Time, bool) {
+			if pid == 4242 {
+				return started, true
+			}
+			return time.Time{}, false
+		},
+	}
+	out, err := svc.List(context.Background())
+	require.NoError(t, err)
+	in := out[0]
+	require.Equal(t, 4242, in.AppPID)
+	require.Equal(t, started.Format(time.RFC3339), in.AppStartedAt)
 }
 
 func TestEnrich_AppProtocolFromScanResult(t *testing.T) {

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -689,3 +689,16 @@ func TestEnrich_TestcontainersStoppedApp(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, StatusStopped, out[0].AppStatus)
 }
+
+func TestEnrich_AppProtocolFromScanResult(t *testing.T) {
+	scan := func() ([]ScanResult, error) {
+		return []ScanResult{{
+			AppID: "a", Source: SourceTestcontainers, AppProtocol: "http",
+			DaprdContainerName: "c1",
+		}}, nil
+	}
+	svc := &service{scan: scan}
+	out, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "http", out[0].AppProtocol)
+}

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -752,6 +752,48 @@ func TestEnrich_TestcontainersAppPIDAndUptime(t *testing.T) {
 	require.Equal(t, started.Format(time.RFC3339), in.AppStartedAt)
 }
 
+func TestEnrich_TestcontainersAppPIDLeakGuardOnFailedResolution(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/v1.0/metadata") {
+			// metadata provides container-scoped appPID (99999), but PID
+			// resolution will fail, so the leak-guard `in.AppPID = 0` in
+			// service.go's testcontainers branch ensures 99999 does not leak
+			// through.
+			_, _ = w.Write([]byte(`{"id":"workflow-patterns-app","extended":{"appPID":"99999"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNoContent) // healthz
+	}))
+	defer srv.Close()
+	port := portOf(t, srv.URL)
+
+	scan := func() ([]ScanResult, error) {
+		return []ScanResult{{
+			AppID: "workflow-patterns-app", Source: SourceTestcontainers,
+			AppPort: 8080, HTTPPort: port, SidecarReachable: true,
+			DaprdContainerName: "crazy_lamport",
+		}}, nil
+	}
+	svc := &service{
+		scan:     scan,
+		client:   srv.Client(),
+		appProc:  fakeAppProc{cmd: "", pid: 0}, // PID resolution fails
+		portOpen: func(int) bool { return true },
+		procStart: func(pid int) (time.Time, bool) {
+			// No live process found
+			return time.Time{}, false
+		},
+	}
+	out, err := svc.List(context.Background())
+	require.NoError(t, err)
+	in := out[0]
+	// When PID resolution fails, AppPID must be 0, not the metadata's
+	// container-scoped 99999 — proves the testcontainers branch's override
+	// guards against leaking container-local PIDs.
+	require.Equal(t, 0, in.AppPID)
+	require.Equal(t, "", in.AppStartedAt)
+}
+
 func TestEnrich_AppProtocolFromScanResult(t *testing.T) {
 	scan := func() ([]ScanResult, error) {
 		return []ScanResult{{

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -709,7 +709,12 @@ func TestEnrich_TestcontainersStoppedApp(t *testing.T) {
 func TestEnrich_TestcontainersAppPIDAndUptime(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/v1.0/metadata") {
-			_, _ = w.Write([]byte(`{"id":"workflow-patterns-app"}`))
+			// extended.appPID is container-scoped (daprd's own view inside the
+			// sidecar container) and must be discarded in favor of the host
+			// app-port listener's PID (4242 below) — service.go's
+			// testcontainers branch does `in.AppPID = 0` before resolving the
+			// PID from appProc.PIDForPort.
+			_, _ = w.Write([]byte(`{"id":"workflow-patterns-app","extended":{"appPID":"99999"}}`))
 			return
 		}
 		w.WriteHeader(http.StatusNoContent) // healthz
@@ -740,6 +745,9 @@ func TestEnrich_TestcontainersAppPIDAndUptime(t *testing.T) {
 	out, err := svc.List(context.Background())
 	require.NoError(t, err)
 	in := out[0]
+	// 4242 (the host app-port listener) must win over metadata's
+	// container-scoped appPID (99999) — proves the testcontainers branch's
+	// override discards the sidecar-local PID.
 	require.Equal(t, 4242, in.AppPID)
 	require.Equal(t, started.Format(time.RFC3339), in.AppStartedAt)
 }

--- a/pkg/discovery/tar_extract.go
+++ b/pkg/discovery/tar_extract.go
@@ -1,0 +1,53 @@
+package discovery
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"path"
+	"strings"
+)
+
+const (
+	// maxExtractFiles bounds how many YAML files are read from one
+	// container's resources dir; maxExtractFileSize bounds each file.
+	maxExtractFiles    = 32
+	maxExtractFileSize = 1 << 20 // 1 MiB
+)
+
+// extractYAMLFromTar reads a `docker cp <id>:<dir> -` tar stream and returns
+// its regular .yaml/.yml members (member path -> content). Oversized members
+// and non-YAML files are skipped silently; a corrupt archive errors.
+func extractYAMLFromTar(tarBytes []byte) (map[string][]byte, error) {
+	tr := tar.NewReader(bytes.NewReader(tarBytes))
+	out := map[string][]byte{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		name := path.Clean(hdr.Name)
+		ext := strings.ToLower(path.Ext(name))
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+		if hdr.Size > maxExtractFileSize {
+			continue
+		}
+		if len(out) >= maxExtractFiles {
+			break
+		}
+		data, err := io.ReadAll(io.LimitReader(tr, maxExtractFileSize+1))
+		if err != nil {
+			return nil, err
+		}
+		out[name] = data
+	}
+	return out, nil
+}

--- a/pkg/discovery/tar_extract_test.go
+++ b/pkg/discovery/tar_extract_test.go
@@ -1,0 +1,68 @@
+//go:build unit
+
+package discovery
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// buildTar assembles an in-memory tar the way `docker cp <id>:/dir -` does:
+// a top-level directory entry followed by its files.
+func buildTar(t *testing.T, entries map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "dapr-resources/", Typeflag: tar.TypeDir, Mode: 0o755,
+	}))
+	for name, content := range entries {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: name, Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(content)),
+		}))
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	return buf.Bytes()
+}
+
+func TestExtractYAMLFromTar_KeepsOnlyYAMLFiles(t *testing.T) {
+	data := buildTar(t, map[string]string{
+		"dapr-resources/kvstore.yaml": "apiVersion: dapr.io/v1alpha1\nkind: Component\n",
+		"dapr-resources/notes.txt":    "not yaml",
+		"dapr-resources/cfg.yml":      "kind: Configuration\n",
+	})
+	files, err := extractYAMLFromTar(data)
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+	require.Contains(t, string(files["dapr-resources/kvstore.yaml"]), "kind: Component")
+	require.Contains(t, string(files["dapr-resources/cfg.yml"]), "kind: Configuration")
+}
+
+func TestExtractYAMLFromTar_Caps(t *testing.T) {
+	big := strings.Repeat("x", maxExtractFileSize+1)
+	data := buildTar(t, map[string]string{"dapr-resources/big.yaml": big})
+	files, err := extractYAMLFromTar(data)
+	require.NoError(t, err)
+	require.Empty(t, files) // oversized member skipped, not an error
+
+	many := map[string]string{}
+	for i := 0; i < maxExtractFiles+5; i++ {
+		many[fmt.Sprintf("dapr-resources/c%03d.yaml", i)] = "kind: Component\n"
+	}
+	data = buildTar(t, many)
+	files, err = extractYAMLFromTar(data)
+	require.NoError(t, err)
+	require.Len(t, files, maxExtractFiles)
+}
+
+func TestExtractYAMLFromTar_GarbageInput(t *testing.T) {
+	_, err := extractYAMLFromTar([]byte("this is not a tar archive"))
+	require.Error(t, err)
+}

--- a/pkg/discovery/testdata/golden/metadata_parsed.golden.json
+++ b/pkg/discovery/testdata/golden/metadata_parsed.golden.json
@@ -7,6 +7,7 @@
   "AppLogPath": "/home/dev/.dapr/logs/order_app.log",
   "DaprdLogPath": "/home/dev/.dapr/logs/order_daprd.log",
   "RunTemplate": "dapr.yaml",
+  "AppProtocol": "",
   "Actors": [
     {
       "type": "dapr.internal.default.order.workflow",

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -47,6 +47,7 @@ type Instance struct {
 	HTTPPort       int    `json:"httpPort"`
 	GRPCPort       int    `json:"grpcPort"`
 	AppPort        int    `json:"appPort"`
+	AppProtocol    string `json:"appProtocol,omitempty"`
 	DaprdPID       int    `json:"daprdPid"`
 	AppPID         int    `json:"appPid"` // 0 = unknown
 	CLIPID         int    `json:"cliPid"`

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -82,14 +82,20 @@ type rawResource struct {
 }
 
 type service struct {
-	paths func() []string
+	paths  func() []string
+	extras func() []Resource
 }
 
-// New returns a Service that scans the paths returned by the provider for Dapr
-// resource YAMLs. The provider is called on every List/Get so callers can change
-// the scan locations at runtime.
-func New(paths func() []string) Service {
-	return &service{paths: paths}
+// New returns a Service that scans the paths returned by the provider for
+// Dapr resource YAMLs, merged with the extras provider's entries (resources
+// that exist outside the host filesystem, e.g. extracted from containers).
+// Either provider may be nil. Both are called on every List/Get so callers
+// can change sources at runtime.
+func New(paths func() []string, extras func() []Resource) Service {
+	if paths == nil {
+		paths = func() []string { return nil }
+	}
+	return &service{paths: paths, extras: extras}
 }
 
 // kindFromString maps a YAML kind string to a Kind constant.
@@ -102,6 +108,35 @@ func kindFromString(s string) (Kind, bool) {
 	default:
 		return "", false
 	}
+}
+
+// FromRaw parses multi-document YAML content into fully-populated Resources
+// carrying Raw. displayPath is the entry's Path verbatim (for container
+// sources use "<containerName>:<inContainerPath>") and feeds the ID hash,
+// so same-named components from different containers stay distinct.
+// Unparseable documents and unknown kinds are skipped.
+func FromRaw(displayPath string, content []byte) []Resource {
+	var out []Resource
+	for _, doc := range splitYAMLDocs(content) {
+		var rr rawResource
+		if err := yaml.Unmarshal(doc, &rr); err != nil {
+			continue
+		}
+		k, ok := kindFromString(rr.Kind)
+		if !ok {
+			continue
+		}
+		out = append(out, Resource{
+			ID:      resourceID(rr.Metadata.Name, rr.Spec.Type, displayPath),
+			Name:    rr.Metadata.Name,
+			Kind:    k,
+			Type:    rr.Spec.Type,
+			Version: rr.Spec.Version,
+			Path:    displayPath,
+			Raw:     string(content),
+		})
+	}
+	return out
 }
 
 // scan walks all configured paths and returns resources matching the requested kind.
@@ -162,18 +197,48 @@ func (s *service) scan(kind Kind) ([]Resource, error) {
 	return out, nil
 }
 
+// extraByKind returns the extras entries of the given kind.
+func (s *service) extraByKind(kind Kind) []Resource {
+	if s.extras == nil {
+		return nil
+	}
+	var out []Resource
+	for _, r := range s.extras() {
+		if r.Kind == kind {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
 // List returns all resources of the given kind, without Raw content.
 func (s *service) List(ctx context.Context, kind Kind) ([]Resource, error) {
-	return s.scan(kind)
+	out, err := s.scan(kind)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range s.extraByKind(kind) {
+		r.Raw = ""
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Path < out[j].Path
+	})
+	return out, nil
 }
 
 // Get returns the resource matching idOrName (ID first, then first name
-// match), with Raw populated from the file. Returns ErrNotFound if none match.
+// match). File entries load Raw from disk; extras entries already carry it.
+// Returns ErrNotFound if none match.
 func (s *service) Get(ctx context.Context, kind Kind, idOrName string) (Resource, error) {
-	resources, err := s.scan(kind)
+	scanned, err := s.scan(kind)
 	if err != nil {
 		return Resource{}, err
 	}
+	extras := s.extraByKind(kind)
 	withRaw := func(r Resource) (Resource, error) {
 		data, err := os.ReadFile(r.Path)
 		if err != nil {
@@ -182,14 +247,24 @@ func (s *service) Get(ctx context.Context, kind Kind, idOrName string) (Resource
 		r.Raw = string(data)
 		return r, nil
 	}
-	for _, r := range resources {
+	for _, r := range scanned {
 		if r.ID == idOrName {
 			return withRaw(r)
 		}
 	}
-	for _, r := range resources {
+	for _, r := range extras {
+		if r.ID == idOrName {
+			return r, nil
+		}
+	}
+	for _, r := range scanned {
 		if r.Name == idOrName {
 			return withRaw(r)
+		}
+	}
+	for _, r := range extras {
+		if r.Name == idOrName {
+			return r, nil
 		}
 	}
 	return Resource{}, ErrNotFound

--- a/pkg/resources/resources_test.go
+++ b/pkg/resources/resources_test.go
@@ -20,7 +20,7 @@ func TestResourcesListAndGet(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "statestore.yaml"), []byte(compYAML), 0o600))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "appconfig.yaml"), []byte(cfgYAML), 0o600))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "orders-sub.yaml"), []byte(subYAML), 0o600))
-	svc := New(func() []string { return []string{dir} })
+	svc := New(func() []string { return []string{dir} }, nil)
 
 	comps, err := svc.List(context.Background(), KindComponent)
 	require.NoError(t, err)
@@ -48,7 +48,7 @@ func TestResourcesMultiDocFile(t *testing.T) {
 	dir := t.TempDir()
 	multi := comp2YAML + "---\n" + cfgYAML + "---\n" + compYAML
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "resources.yaml"), []byte(multi), 0o600))
-	svc := New(func() []string { return []string{dir} })
+	svc := New(func() []string { return []string{dir} }, nil)
 
 	comps, err := svc.List(context.Background(), KindComponent)
 	require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestResourcesStableIDsAndDuplicateNames(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dirA, "statestore.yaml"), []byte(compYAML), 0o600))
 	dupYAML := "apiVersion: dapr.io/v1alpha1\nkind: Component\nmetadata:\n  name: statestore\nspec:\n  type: state.sqlite\n  version: v1\n"
 	require.NoError(t, os.WriteFile(filepath.Join(dirB, "statestore.yaml"), []byte(dupYAML), 0o600))
-	svc := New(func() []string { return []string{dirA, dirB} })
+	svc := New(func() []string { return []string{dirA, dirB} }, nil)
 
 	comps, err := svc.List(context.Background(), KindComponent)
 	require.NoError(t, err)
@@ -105,4 +105,49 @@ func TestResourcesStableIDsAndDuplicateNames(t *testing.T) {
 	// Unknown id-or-name -> ErrNotFound.
 	_, err = svc.Get(context.Background(), KindComponent, "nosuchthing")
 	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestExtras_MergedListedAndFetched(t *testing.T) {
+	content := []byte("apiVersion: dapr.io/v1alpha1\nkind: Component\nmetadata:\n  name: kvstore\nspec:\n  type: state.in-memory\n  version: v1\n  metadata:\n  - name: actorStateStore\n    value: \"true\"\n")
+	extras := func() []Resource { return FromRaw("crazy_lamport:/dapr-resources/kvstore.yaml", content) }
+	svc := New(func() []string { return nil }, extras)
+
+	list, err := svc.List(context.Background(), KindComponent)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	require.Equal(t, "kvstore", list[0].Name)
+	require.Equal(t, "state.in-memory", list[0].Type)
+	require.Equal(t, "v1", list[0].Version)
+	require.Equal(t, "crazy_lamport:/dapr-resources/kvstore.yaml", list[0].Path)
+	require.Empty(t, list[0].Raw, "List strips Raw")
+
+	got, err := svc.Get(context.Background(), KindComponent, list[0].ID)
+	require.NoError(t, err)
+	require.Contains(t, got.Raw, "actorStateStore")
+
+	// Name-based lookup works too.
+	got, err = svc.Get(context.Background(), KindComponent, "kvstore")
+	require.NoError(t, err)
+	require.Equal(t, list[0].ID, got.ID)
+}
+
+func TestExtras_ConfigurationDocRoutedByKind(t *testing.T) {
+	content := []byte("kind: Component\nmetadata:\n  name: a\nspec:\n  type: state.in-memory\n---\nkind: Configuration\nmetadata:\n  name: cfg\n")
+	extras := func() []Resource { return FromRaw("c1:/res/multi.yaml", content) }
+	svc := New(func() []string { return nil }, extras)
+
+	comps, err := svc.List(context.Background(), KindComponent)
+	require.NoError(t, err)
+	require.Len(t, comps, 1)
+	cfgs, err := svc.List(context.Background(), KindConfiguration)
+	require.NoError(t, err)
+	require.Len(t, cfgs, 1)
+	require.Equal(t, "cfg", cfgs[0].Name)
+}
+
+func TestExtras_NilProviderKeepsFileBehavior(t *testing.T) {
+	svc := New(func() []string { return nil }, nil)
+	list, err := svc.List(context.Background(), KindComponent)
+	require.NoError(t, err)
+	require.Empty(t, list)
 }

--- a/web/src/pages/AppDetail.test.tsx
+++ b/web/src/pages/AppDetail.test.tsx
@@ -405,6 +405,43 @@ describe('AppDetail', () => {
     confirmSpy.mockRestore()
   })
 
+  it('renders app protocol when reported', async () => {
+    server.use(
+      http.get('/api/apps/order', () => HttpResponse.json({ ...runningApp, appProtocol: 'http' })),
+    )
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    expect(screen.getByText('http')).toBeInTheDocument()
+  })
+
+  it('renders Container and Session rows for testcontainers apps', async () => {
+    server.use(
+      http.get('/api/apps/order', () =>
+        HttpResponse.json({
+          ...runningApp,
+          source: 'testcontainers',
+          daprdContainerName: 'crazy_lamport',
+          testcontainersSession: 'efeba7ba-5fdd-4713-ae0c-38f4a462cf46',
+        }),
+      ),
+    )
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    expect(screen.getByText('crazy_lamport')).toBeInTheDocument()
+    expect(screen.getByText('Session')).toBeInTheDocument()
+    expect(screen.getByText('efeba7ba')).toBeInTheDocument()
+    expect(screen.queryByText('daprd PID')).not.toBeInTheDocument()
+    expect(screen.queryByText('CLI PID')).not.toBeInTheDocument()
+  })
+
+  it('keeps CLI PID and daprd PID rows for standalone apps', async () => {
+    server.use(http.get('/api/apps/order', () => HttpResponse.json(runningApp)))
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    expect(screen.getByText('CLI PID')).toBeInTheDocument()
+    expect(screen.getByText('daprd PID')).toBeInTheDocument()
+  })
+
   it('hides all lifecycle controls for testcontainers apps', async () => {
     server.use(
       http.get('/api/apps/order', () =>

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -240,7 +240,7 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
             <div className="vv mono">{app.appPort || <span className="faint">—</span>}</div>
 
             <div className="kk">App protocol</div>
-            <div className="vv mono"><span className="faint">—</span></div>
+            <div className="vv mono">{app.appProtocol || <span className="faint">—</span>}</div>
 
             {isCompose ? (
               <>
@@ -258,8 +258,19 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
                 <div className="kk">App PID</div>
                 <div className="vv mono">{appPidDisplay}</div>
 
-                <div className="kk">CLI PID</div>
-                <div className="vv mono">{app.cliPid || <span className="faint">—</span>}</div>
+                {isTestcontainers ? (
+                  <>
+                    <div className="kk">Session</div>
+                    <div className="vv mono" title={app.testcontainersSession}>
+                      {app.testcontainersSession ? app.testcontainersSession.slice(0, 8) : <span className="faint">—</span>}
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="kk">CLI PID</div>
+                    <div className="vv mono">{app.cliPid || <span className="faint">—</span>}</div>
+                  </>
+                )}
               </>
             )}
 
@@ -294,7 +305,7 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
             <div className="kk">Metrics port</div>
             <div className="vv mono"><span className="faint">—</span></div>
 
-            {isCompose ? (
+            {isCompose || isTestcontainers ? (
               <>
                 <div className="kk">Container</div>
                 <div className="vv mono">{app.daprdContainerName || <span className="faint">—</span>}</div>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -31,6 +31,8 @@ export interface AppSummary {
   httpPort: number
   grpcPort: number
   appPort: number
+  /** app channel protocol reported by daprd (http, grpc, https, ...) */
+  appProtocol?: string
   daprdPid: number
   appPid: number
   cliPid: number


### PR DESCRIPTION
## Summary

Follow-up to #60. Components declared in Testcontainers test config (e.g. the Java quickstart's `kvstore` `state.in-memory` component) now appear in the Components view with their full YAML, and the App detail page fills its previously-empty fields for testcontainers apps.

- **Component extraction** (`pkg/discovery` + `pkg/resources`): each testcontainers daprd container's `--resources-path` dir is copied out as a tar stream (`<runtime> cp <id>:<dir> -` — no shell needed, distroless-safe), parsed with 32-file/1 MiB caps, cached per container ID (evicted when containers leave; transient context-expiry failures retried, genuine failures pinned once). A new resources extras provider merges these entries into the Components/Configurations pages with container-prefixed display paths (`crazy_lamport:/dapr-resources/kvstore.yaml`), inline read-only YAML, and working `LoadedBy` badges.
- **Store-election isolation (load-bearing)**: extracted YAML feeds ONLY the resources service — never `statestore.Detect`, reconciler paths, or store election. An extracted `state.in-memory` + `actorStateStore: true` component would otherwise win the election and break other apps' workflow views. Guarded by a dedicated test.
- **App detail completeness**: App protocol now wired from daprd metadata `appConnectionProperties.protocol` for **all** sources (was a hardcoded dash) with `--app-protocol` argv fallback for container sources; testcontainers apps get their real host JVM PID + ticking uptime via a new `PIDForPort` listener lookup (container-scoped metadata PIDs are explicitly discarded); the daprd panel shows the Container row and the app panel a Session row (`org.testcontainers.sessionId`, first 8 chars) instead of dash-only PID rows. Standalone/compose/aspire rendering unchanged.

Spec: `docs/superpowers/specs/2026-07-12-testcontainers-components-appdetail-design.md`
Plan: `docs/superpowers/plans/2026-07-13-testcontainers-components-appdetail.md`

## Testing

- TDD throughout: tar fixtures built with `archive/tar`, extraction cache/eviction/retry tests with call counting, resources merge/precedence tests, AppPID leak-guard pins, row-selection tests.
- Full `go test ./... -tags "unit integration"`, `go build ./...`, 700 web tests + `tsc -b`, `make build` — all green.
- Live e2e against the `child-workflows` Java quickstart: `kvstore` listed with container path + full YAML incl. `actorStateStore`; app shows protocol `http`, verified java PID, uptime, session; `/api/statestores` confirmed free of the extracted in-memory store; workflows unaffected; clean ryuk teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)