### PR TITLE
Exclusive --mode discovery filters (dapr-run, compose, test-containers, aspire)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -120,7 +120,9 @@ threads through everything.
 
 | Flag | Default | Controls |
 |------|---------|----------|
-| `--port` | `9090` | HTTP listen port (always bound to `127.0.0.1`) |
+| `--port` | `9090` | HTTP listen port (`8080` default in aspire container posture) |
+| `--bind` | `127.0.0.1` | Listen address (`0.0.0.0` default in aspire container posture) |
+| `--mode` | unset | Exclusive discovery filter: `dapr-run`, `compose`, `test-containers`, `aspire`; unset = complete scan (env: `DEVDASHBOARD_MODE`, flag wins) |
 | `--base-path` | `""` | Sub-path mount, e.g. `/dashboard` (must match the SPA's `DASH_BASE_PATH` build var) |
 | `--no-open` | `false` | Skip auto-opening the browser |
 | `--statestore` | `""` | Explicit state-store component YAML; disables auto-detection |
@@ -133,19 +135,31 @@ reconciler.)
 
 ### `serve` boot sequence (`cmd/root.go` `runServe` → `cmd/serve.go` `assembleOptions`)
 
-1. `logging.New(verbose)` → set as the default `slog.Logger`.
-2. Load the embedded SPA (`web.DistFS()`) and the component catalog (`metadata.Init()`).
-3. Resolve the bind address (`127.0.0.1:<port>`) and the browser URL (base-path aware).
-4. Resolve `~` (`os.UserHomeDir()`); if unavailable, warn and run with registry
+1. Resolve the mode and posture (`cmd/mode.go`): `resolveMode` validates
+   `--mode`/`DEVDASHBOARD_MODE`; **container posture** = aspire mode *with* the
+   `DEVDASHBOARD_APP_*` env contract present, and drives the port/bind defaults
+   (`resolveServeSettings`, flag > env > posture default), Host-guard relaxation,
+   registry persistence, and browser auto-open. Aspire *without* the contract is a
+   host-posture run filtered to Aspire-managed apps.
+2. `logging.New(verbose)` → set as the default `slog.Logger`.
+3. Load the embedded SPA (`web.DistFS()`) and the component catalog (`metadata.Init()`).
+4. Resolve the bind address and the browser URL (base-path aware).
+5. Select discovery sources by mode (`cmd/sources.go` `sourcesFor`): mode-unset runs
+   every scanner; a filter mode runs exactly one (aspire host mode additionally wraps
+   the service in `discovery.FilterAspire`). `compose` and `test-containers` **fail
+   startup here** when no container runtime is found. The control-plane manager gets
+   the matching family filter (`cpSourcesFor` → `controlplane.Sources`), and the mode
+   is echoed to the SPA via the capabilities flags.
+6. Resolve `~` (`os.UserHomeDir()`); if unavailable, warn and run with registry
    persistence disabled (features degrade to in-memory no-ops rather than writing a
    CWD-relative `.dapr/`).
-5. `assembleOptions`: load the connection registry (`LoadRegistry`), build the lazy
+7. `assembleOptions`: load the connection registry (`LoadRegistry`), build the lazy
    connection pool (`newConnPool`), build the reconciler, and **synchronously seed** it
    with one reconcile against the boot apps snapshot (so the active store is elected and
    pre-warmed before the first request). The discovery service is wrapped in a
    `reconcilingApps` decorator (see §4).
-6. `server.New(addr, opts)` builds the chi router; start it in a goroutine.
-7. Open the browser (unless `--no-open`), then block on `select`:
+8. `server.New(addr, opts)` builds the chi router; start it in a goroutine.
+9. Open the browser (unless `--no-open` or container posture), then block on `select`:
    server error → log + exit non-zero; signal → 5-second graceful `Shutdown`.
 
 ---
@@ -311,6 +325,8 @@ A second scanner, `ComposeSource` (`scan_compose.go`), discovers Dapr apps runni
 
 A third scanner, `TestcontainersSource` (`scan_testcontainers.go`), discovers **Dapr Testcontainers** sessions (e.g. Spring Boot apps run with `mvn spring-boot:test-run` and `dapr-spring-boot-starter-test`): it lists `org.testcontainers=true`-labelled containers and keeps those whose argv invokes `daprd` (which naturally excludes ryuk/placement/scheduler helpers). The daprd container publishes its HTTP/gRPC ports to **random host ports on every run**, so port mappings are re-read each poll. Unlike compose, the paired app is a **host process** (reached via `host.testcontainers.internal`): enrichment probes the app port for liveness and resolves the listener's command and PID (`appproc.go`) for runtime inference, App PID, and uptime. The scanner also extracts the container's `--resources-path` YAML as a tar stream (`cp <id>:<dir> -`, `tar_extract.go` — no shell needed, distroless-safe; cached per container ID, evicted on departure, transient failures retried) and exposes it via `Files()` for the resources extras provider (see Resources below). Lifecycle actions are refused for these apps — ryuk owns the containers, the test process owns the app. All scanners are combined with `Merge` (one failing source never hides the others).
 
+Which scanners run is decided by `--mode` (`cmd/sources.go` `sourcesFor`): unset merges all of the above (plus the Aspire env-contract scanner when `DEVDASHBOARD_APP_COUNT` is set); `dapr-run`, `compose`, and `test-containers` run exactly one scanner each. `--mode aspire` without the env contract runs the standalone scan and wraps the **outermost** service (after the lifecycle overlay) in `FilterAspire` (`filter.go`), which keeps only instances flagged `IsAspire` by enrichment — the flag comes from the DCP-proxy heuristic (`appproc.go`), so it cannot be filtered at scan time.
+
 Derived fields include a human-friendly `Age` and an inferred runtime language.
 **To add a per-app field:** add it to `Instance` (`types.go`), populate it in `enrich`
 (`service.go`) from either the scan result or the parsed metadata, and it serializes
@@ -354,14 +370,20 @@ components-contrib `state.Store` (+ `KeysLiker`) interface.
 
 ### Control plane (`pkg/controlplane`)
 
-`New()` resolves a container runtime — `DASH_CONTAINER_RUNTIME` override, else `docker`,
-else `podman`, else none. `List()` probes reachability, then `docker inspect` +
-`docker stats` each known container: `dapr_scheduler` and `dapr_placement` are the
-**actionable** self-hosted containers (`LiveServiceNames`). It returns status,
-health, port bindings, memory, and log path per service. `List()` additionally detects
-compose containers whose command is `placement`/`scheduler`, surfaces them with a
-`composeProject`, and `Do`/`LogStream` accept the compose names discovered by the most
-recent `List` (still never arbitrary names). `Do(name, action)` runs a
+`New(src Sources)` resolves a container runtime — `DASH_CONTAINER_RUNTIME` override, else
+`docker`, else `podman`, else none. The `Sources` selector (`Init`, `Compose` — derived
+from `--mode` via `cpSourcesFor`) gates both which families `List` reports and which
+names `Do`/`LogStream` accept: `dapr-run`/`aspire` show only the `dapr init` containers,
+`compose` only the compose-run ones, `test-containers` the zero value (no control-plane
+detection yet — honest empty list), and mode-unset both. `List()` probes reachability,
+then `docker inspect` + `docker stats` each enabled container (the stats sampling is
+skipped entirely when no names are enabled — a bare `docker stats` would sample every
+container on the host): `dapr_scheduler` and `dapr_placement` are the **actionable**
+self-hosted containers (`LiveServiceNames`). It returns status, health, port bindings,
+memory, and log path per service. `List()` additionally detects compose containers whose
+command is `placement`/`scheduler`, surfaces them with a `composeProject`, and
+`Do`/`LogStream` accept the compose names discovered by the most recent `List` (still
+never arbitrary names). `Do(name, action)` runs a
 lifecycle verb **allowlisted** to `start`/`stop`/`restart` on the actionable names only
 (`ValidAction` + `IsLiveName`). `LogStream` runs `docker logs -f --tail 200` and demuxes
 stdout+stderr onto one channel for the SSE handler. **To add an action:** extend

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ docker run --rm -p 8080:8080 \
 
 | Source | Values | Default |
 |---|---|---|
-| `--mode` flag / `DEVDASHBOARD_MODE` env | `aspire` (reserved for future work: `dapr`, `compose`) | unset |
+| `--mode` flag / `DEVDASHBOARD_MODE` env | `dapr-run`, `compose`, `test-containers`, `aspire` | unset (complete scan) |
 
 **App discovery** — one set of `_<i>_*` vars per app, for `i = 0..DEVDASHBOARD_APP_COUNT-1`:
 
@@ -164,11 +164,20 @@ dashboard finds the Testcontainers-managed daprd container, pairs it with your h
 process, and even reads workflows from an in-memory state store via the sidecar itself.
 
 With `--mode`/`DEVDASHBOARD_MODE` unset (the default for host use), the dashboard performs the
-complete scan across all discovery sources described above. `--mode=aspire` restricts
-discovery to the container env contract and switches to container serving posture — see
-[Run as a container](#run-as-a-container-net-aspire) above. `dapr` and `compose` are reserved
-mode values for future single-source filtering and are not implemented yet. `--bind` (default
-`127.0.0.1`, `0.0.0.0` in aspire mode) controls the listen address alongside `--port`.
+complete scan across all discovery sources described above. Setting a mode restricts every
+dashboard surface — applications, workflows, state stores, the Control Plane view, and log
+targets — to a single source; filters are exclusive and never combined:
+
+- `--mode dapr-run` — host `dapr run` processes only (Control Plane shows the `dapr init` containers).
+- `--mode compose` — Docker Compose containers only (Control Plane shows compose-run placement/scheduler).
+- `--mode test-containers` — Testcontainers discovery only (no control-plane detection yet).
+- `--mode aspire` — Aspire resources only. Inside an AppHost-managed container (the
+  `DEVDASHBOARD_APP_*` contract is present) this is the container serving posture described
+  below; on a plain host it filters the process scan to Aspire-managed apps.
+
+`compose` and `test-containers` require a container runtime (docker or podman) and fail at
+startup without one. `--bind` (default `127.0.0.1`, `0.0.0.0` in aspire container posture)
+controls the listen address alongside `--port`.
 
 ## Updating the dashboard
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ development tool — never expose it publicly.
 | `DEVDASHBOARD_ALLOWED_HOSTS` | unset (any host) | optional, aspire mode only; comma-separated hostnames the `Host` header is restricted to (loopback always allowed). Empty means any host. Set it to close the DNS-rebinding hole described above |
 | `DEVDASHBOARD_MODE` | `aspire` (baked into the image) | see mode switch above |
 
-Precedence everywhere is **flag > env > mode default**.
+Precedence everywhere is **flag > env > posture default**.
 
 ## Run the dashboard
 

--- a/cmd/mode.go
+++ b/cmd/mode.go
@@ -10,14 +10,28 @@ import (
 
 // Mode selects the dashboard's discovery and serving posture. ModeDefault
 // (the zero value, mode unset) is the complete scan across all discovery
-// sources with today's host behavior; ModeAspire restricts discovery to the
-// DEVDASHBOARD_APP_* env contract and switches to container posture.
-// "dapr" and "compose" are reserved for future single-source filter modes.
+// sources with today's host behavior. Every other value is an exclusive
+// single-source filter — they are never combined:
+//
+//   - ModeDaprRun: host `dapr run` process scan only.
+//   - ModeCompose: Docker Compose container discovery only.
+//   - ModeTestcontainers: Testcontainers container discovery only.
+//   - ModeAspire: Aspire resources only. With the DEVDASHBOARD_APP_* env
+//     contract present the dashboard is the AppHost-managed container
+//     (container posture); without it the dashboard runs on the host and
+//     filters the process scan to Aspire-managed instances.
+//
+// CLI values ("dapr-run", "test-containers") are user-facing names and
+// intentionally differ from the discovery Source wire values ("standalone",
+// "testcontainers") — do not unify them.
 type Mode string
 
 const (
-	ModeDefault Mode = ""
-	ModeAspire  Mode = "aspire"
+	ModeDefault        Mode = ""
+	ModeAspire         Mode = "aspire"
+	ModeDaprRun        Mode = "dapr-run"
+	ModeCompose        Mode = "compose"
+	ModeTestcontainers Mode = "test-containers"
 )
 
 // resolveMode picks the mode from the --mode flag value and the
@@ -28,10 +42,10 @@ func resolveMode(flagValue string, getenv func(string) string) (Mode, error) {
 		v = getenv("DEVDASHBOARD_MODE")
 	}
 	switch Mode(v) {
-	case ModeDefault, ModeAspire:
+	case ModeDefault, ModeAspire, ModeDaprRun, ModeCompose, ModeTestcontainers:
 		return Mode(v), nil
 	}
-	return ModeDefault, fmt.Errorf("unknown mode %q: supported values are \"aspire\" (or unset for the complete scan)", v)
+	return ModeDefault, fmt.Errorf("unknown mode %q: supported values are \"dapr-run\", \"compose\", \"test-containers\", \"aspire\" (or unset for the complete scan)", v)
 }
 
 // serveSettings is the fully resolved serve configuration: flag > env > mode

--- a/cmd/mode.go
+++ b/cmd/mode.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/diagridio/dev-dashboard/pkg/discovery"
 )
 
 // Mode selects the dashboard's discovery and serving posture. ModeDefault
@@ -48,6 +50,14 @@ func resolveMode(flagValue string, getenv func(string) string) (Mode, error) {
 	return ModeDefault, fmt.Errorf("unknown mode %q: supported values are \"dapr-run\", \"compose\", \"test-containers\", \"aspire\" (or unset for the complete scan)", v)
 }
 
+// containerPosture reports whether the dashboard serves as the
+// AppHost-managed container: aspire mode with the DEVDASHBOARD_APP_* env
+// contract present. Aspire mode without the contract is a host-run dashboard
+// filtered to Aspire resources and keeps host serving defaults.
+func containerPosture(mode Mode, getenv func(string) string) bool {
+	return mode == ModeAspire && discovery.AspireContractPresent(getenv)
+}
+
 // serveSettings is the fully resolved serve configuration: flag > env > mode
 // default, per the spec's precedence rule.
 type serveSettings struct {
@@ -61,11 +71,11 @@ type serveSettings struct {
 	AllowedHosts []string
 }
 
-// resolveServeSettings applies the flag > env > mode-default precedence.
+// resolveServeSettings applies the flag > env > posture-default precedence.
 // flagChanged reports whether the named cobra flag was set explicitly; port,
 // bind, stateStore, namespace carry the flag values (which hold cobra
 // defaults when unchanged).
-func resolveServeSettings(mode Mode, flagChanged func(string) bool, port int, bind, stateStore, namespace string, getenv func(string) string) (serveSettings, error) {
+func resolveServeSettings(containerPosture bool, flagChanged func(string) bool, port int, bind, stateStore, namespace string, getenv func(string) string) (serveSettings, error) {
 	s := serveSettings{Port: port, Bind: bind, StateStore: stateStore, Namespace: namespace}
 
 	if !flagChanged("port") {
@@ -75,14 +85,14 @@ func resolveServeSettings(mode Mode, flagChanged func(string) bool, port int, bi
 				return s, fmt.Errorf("DEVDASHBOARD_PORT: expected a port number, got %q", v)
 			}
 			s.Port = p
-		} else if mode == ModeAspire {
+		} else if containerPosture {
 			s.Port = 8080
 		}
 	}
 	if !flagChanged("bind") {
 		if v := getenv("DEVDASHBOARD_BIND"); v != "" {
 			s.Bind = v
-		} else if mode == ModeAspire {
+		} else if containerPosture {
 			s.Bind = "0.0.0.0"
 		}
 	}
@@ -100,7 +110,7 @@ func resolveServeSettings(mode Mode, flagChanged func(string) bool, port int, bi
 				s.ResourcesPaths = append(s.ResourcesPaths, p)
 			}
 		}
-	} else if mode == ModeAspire && s.StateStore != "" {
+	} else if containerPosture && s.StateStore != "" {
 		s.ResourcesPaths = []string{filepath.Dir(s.StateStore)}
 	}
 	if v := getenv("DEVDASHBOARD_ALLOWED_HOSTS"); v != "" {

--- a/cmd/mode.go
+++ b/cmd/mode.go
@@ -58,8 +58,8 @@ func containerPosture(mode Mode, getenv func(string) string) bool {
 	return mode == ModeAspire && discovery.AspireContractPresent(getenv)
 }
 
-// serveSettings is the fully resolved serve configuration: flag > env > mode
-// default, per the spec's precedence rule.
+// serveSettings is the fully resolved serve configuration: flag > env >
+// posture default, per the spec's precedence rule.
 type serveSettings struct {
 	Port           int
 	Bind           string

--- a/cmd/mode_test.go
+++ b/cmd/mode_test.go
@@ -22,10 +22,14 @@ func TestResolveMode(t *testing.T) {
 	}{
 		{name: "unset everywhere is default", flag: "", env: nil, want: ModeDefault},
 		{name: "flag aspire", flag: "aspire", env: nil, want: ModeAspire},
+		{name: "flag dapr-run", flag: "dapr-run", env: nil, want: ModeDaprRun},
+		{name: "flag compose", flag: "compose", env: nil, want: ModeCompose},
+		{name: "flag test-containers", flag: "test-containers", env: nil, want: ModeTestcontainers},
 		{name: "env aspire", flag: "", env: map[string]string{"DEVDASHBOARD_MODE": "aspire"}, want: ModeAspire},
+		{name: "env compose", flag: "", env: map[string]string{"DEVDASHBOARD_MODE": "compose"}, want: ModeCompose},
 		{name: "flag wins over env", flag: "aspire", env: map[string]string{"DEVDASHBOARD_MODE": "bogus"}, want: ModeAspire},
-		{name: "unknown flag value errors", flag: "compose", wantErr: true},
-		{name: "unknown env value errors", env: map[string]string{"DEVDASHBOARD_MODE": "dapr"}, wantErr: true},
+		{name: "unknown flag value errors", flag: "dapr", wantErr: true},
+		{name: "unknown env value errors", env: map[string]string{"DEVDASHBOARD_MODE": "docker"}, wantErr: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/mode_test.go
+++ b/cmd/mode_test.go
@@ -50,6 +50,28 @@ func TestResolveMode(t *testing.T) {
 	}
 }
 
+func TestContainerPosture(t *testing.T) {
+	withContract := func(k string) string {
+		if k == "DEVDASHBOARD_APP_COUNT" {
+			return "2"
+		}
+		return ""
+	}
+	none := func(string) string { return "" }
+	if !containerPosture(ModeAspire, withContract) {
+		t.Fatal("aspire + contract must be container posture")
+	}
+	if containerPosture(ModeAspire, none) {
+		t.Fatal("aspire without the contract must stay host posture")
+	}
+	if containerPosture(ModeCompose, withContract) {
+		t.Fatal("non-aspire modes are never container posture")
+	}
+	if containerPosture(ModeDefault, withContract) {
+		t.Fatal("mode-unset is never container posture")
+	}
+}
+
 func TestListenAddr(t *testing.T) {
 	tests := []struct {
 		bind string
@@ -71,7 +93,7 @@ func TestResolveServeSettings(t *testing.T) {
 	noneChanged := func(string) bool { return false }
 	tests := []struct {
 		name       string
-		mode       Mode
+		container  bool
 		changed    func(string) bool
 		port       int
 		bind       string
@@ -81,18 +103,18 @@ func TestResolveServeSettings(t *testing.T) {
 		want       serveSettings
 	}{
 		{
-			name: "default mode keeps host defaults",
-			mode: ModeDefault, changed: noneChanged, port: 9090, bind: "127.0.0.1",
+			name:    "default mode keeps host defaults",
+			changed: noneChanged, port: 9090, bind: "127.0.0.1",
 			want: serveSettings{Port: 9090, Bind: "127.0.0.1", Namespace: "default"},
 		},
 		{
-			name: "aspire mode defaults to 8080 on 0.0.0.0",
-			mode: ModeAspire, changed: noneChanged, port: 9090, bind: "127.0.0.1",
+			name:      "aspire mode defaults to 8080 on 0.0.0.0",
+			container: true, changed: noneChanged, port: 9090, bind: "127.0.0.1",
 			want: serveSettings{Port: 8080, Bind: "0.0.0.0", Namespace: "default"},
 		},
 		{
-			name: "env overrides aspire defaults",
-			mode: ModeAspire, changed: noneChanged, port: 9090, bind: "127.0.0.1",
+			name:      "env overrides aspire defaults",
+			container: true, changed: noneChanged, port: 9090, bind: "127.0.0.1",
 			env: map[string]string{
 				"DEVDASHBOARD_PORT":            "9999",
 				"DEVDASHBOARD_BIND":            "127.0.0.1",
@@ -103,14 +125,14 @@ func TestResolveServeSettings(t *testing.T) {
 				Namespace: "team-a", ResourcesPaths: []string{"/app/components"}},
 		},
 		{
-			name: "changed flag beats env",
-			mode: ModeAspire, changed: func(f string) bool { return f == "port" }, port: 7000, bind: "127.0.0.1",
+			name:      "changed flag beats env",
+			container: true, changed: func(f string) bool { return f == "port" }, port: 7000, bind: "127.0.0.1",
 			env:  map[string]string{"DEVDASHBOARD_PORT": "9999"},
 			want: serveSettings{Port: 7000, Bind: "0.0.0.0", Namespace: "default"},
 		},
 		{
-			name: "explicit resources path splits on list separator",
-			mode: ModeAspire, changed: noneChanged, port: 9090, bind: "127.0.0.1",
+			name:      "explicit resources path splits on list separator",
+			container: true, changed: noneChanged, port: 9090, bind: "127.0.0.1",
 			env: map[string]string{
 				"DEVDASHBOARD_RESOURCES_PATH": "/mnt/a" + string(os.PathListSeparator) + "/mnt/b",
 			},
@@ -118,8 +140,8 @@ func TestResolveServeSettings(t *testing.T) {
 				ResourcesPaths: []string{"/mnt/a", "/mnt/b"}},
 		},
 		{
-			name: "allowed hosts split on comma, trimmed",
-			mode: ModeAspire, changed: noneChanged, port: 9090, bind: "127.0.0.1",
+			name:      "allowed hosts split on comma, trimmed",
+			container: true, changed: noneChanged, port: 9090, bind: "127.0.0.1",
 			env: map[string]string{
 				"DEVDASHBOARD_ALLOWED_HOSTS": "a.example, b.example",
 			},
@@ -127,23 +149,23 @@ func TestResolveServeSettings(t *testing.T) {
 				AllowedHosts: []string{"a.example", "b.example"}},
 		},
 		{
-			name: "changed bind flag beats env",
-			mode: ModeDefault, changed: func(f string) bool { return f == "bind" },
-			port: 9090, bind: "10.0.0.5",
+			name:    "changed bind flag beats env",
+			changed: func(f string) bool { return f == "bind" },
+			port:    9090, bind: "10.0.0.5",
 			env:  map[string]string{"DEVDASHBOARD_BIND": "192.168.1.1"},
 			want: serveSettings{Port: 9090, Bind: "10.0.0.5", Namespace: "default"},
 		},
 		{
-			name: "changed namespace flag beats env",
-			mode: ModeDefault, changed: func(f string) bool { return f == "namespace" },
-			port: 9090, bind: "127.0.0.1", namespace: "team-x",
+			name:    "changed namespace flag beats env",
+			changed: func(f string) bool { return f == "namespace" },
+			port:    9090, bind: "127.0.0.1", namespace: "team-x",
 			env:  map[string]string{"DEVDASHBOARD_NAMESPACE": "env-ns"},
 			want: serveSettings{Port: 9090, Bind: "127.0.0.1", Namespace: "team-x"},
 		},
 		{
-			name: "non-empty statestore flag beats env",
-			mode: ModeDefault, changed: noneChanged,
-			port: 9090, bind: "127.0.0.1", stateStore: "/flag/state.yaml",
+			name:    "non-empty statestore flag beats env",
+			changed: noneChanged,
+			port:    9090, bind: "127.0.0.1", stateStore: "/flag/state.yaml",
 			env:  map[string]string{"DEVDASHBOARD_STATESTORE_FILE": "/env/state.yaml"},
 			want: serveSettings{Port: 9090, Bind: "127.0.0.1", StateStore: "/flag/state.yaml", Namespace: "default"},
 		},
@@ -155,7 +177,7 @@ func TestResolveServeSettings(t *testing.T) {
 			if ns == "" {
 				ns = "default"
 			}
-			got, err := resolveServeSettings(tc.mode, tc.changed, tc.port, tc.bind, tc.stateStore, ns, getenv)
+			got, err := resolveServeSettings(tc.container, tc.changed, tc.port, tc.bind, tc.stateStore, ns, getenv)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -165,7 +187,7 @@ func TestResolveServeSettings(t *testing.T) {
 		})
 	}
 	t.Run("bad DEVDASHBOARD_PORT errors", func(t *testing.T) {
-		_, err := resolveServeSettings(ModeAspire, noneChanged, 9090, "127.0.0.1", "", "default",
+		_, err := resolveServeSettings(true, noneChanged, 9090, "127.0.0.1", "", "default",
 			func(k string) string {
 				if k == "DEVDASHBOARD_PORT" {
 					return "not-a-port"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,11 +55,12 @@ func NewRootCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			settings, err := resolveServeSettings(mode, cmd.Flags().Changed, port, bind, stateStore, namespace, os.Getenv)
+			posture := containerPosture(mode, os.Getenv)
+			settings, err := resolveServeSettings(posture, cmd.Flags().Changed, port, bind, stateStore, namespace, os.Getenv)
 			if err != nil {
 				return err
 			}
-			return runServe(cmd.Context(), mode, settings, basePath, noOpen, verbose)
+			return runServe(cmd.Context(), mode, posture, settings, basePath, noOpen, verbose)
 		},
 	}
 	c.SetVersionTemplate(fmt.Sprintf("dev-dashboard {{.Version}} (commit %s, built %s)\n", info.Commit, info.Date))
@@ -82,7 +83,7 @@ func Execute() error {
 	return NewRootCmd().ExecuteContext(ctx)
 }
 
-func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath string, noOpen, verbose bool) error {
+func runServe(ctx context.Context, mode Mode, containerPosture bool, settings serveSettings, basePath string, noOpen, verbose bool) error {
 	logger := logging.New(verbose)
 	slog.SetDefault(logger)
 	statestore.SetVerbose(verbose)
@@ -97,8 +98,8 @@ func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath s
 		return fmt.Errorf("init component metadata: %w", err)
 	}
 	addr := listenAddr(settings.Bind, settings.Port)
-	if mode == ModeDefault && !isLoopbackBind(settings.Bind) {
-		logger.Warn("binding a non-loopback address without aspire mode; the loopback Host guard will reject remote clients (set --mode aspire for container serving posture)", "bind", settings.Bind)
+	if !containerPosture && !isLoopbackBind(settings.Bind) {
+		logger.Warn("binding a non-loopback address without container posture; the loopback Host guard will reject remote clients (set --mode aspire for container serving posture)", "bind", settings.Bind)
 	}
 	urlPath := ""
 	if trimmed := trimSlash(basePath); trimmed != "" {
@@ -113,7 +114,7 @@ func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath s
 	// Aspire/container mode disables registry persistence entirely (no home
 	// directory), so the "no home" warning is suppressed via QuietRegistry.
 	home := ""
-	if mode != ModeAspire {
+	if !containerPosture {
 		home, err = os.UserHomeDir()
 		if err != nil {
 			// An empty home disables registry persistence in assembleOptions rather
@@ -134,8 +135,8 @@ func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath s
 		appNS         map[string]string
 		extraRes      func() []resources.Resource
 	)
-	switch mode {
-	case ModeAspire:
+	switch {
+	case containerPosture:
 		scan, err := discovery.NewAspireScanner(os.Getenv)
 		if err != nil {
 			return err
@@ -180,12 +181,12 @@ func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath s
 		ContainerLogs:    containerLogs,
 		TelemetryEnabled: telemetry,
 		UpdateCheck:      updateCheck,
-		AllowNonLoopback: mode == ModeAspire,
+		AllowNonLoopback: containerPosture,
 		AllowedHosts:     settings.AllowedHosts,
 		ListenPort:       settings.Port,
 		Capabilities:     caps,
 		ResourcesPaths:   settings.ResourcesPaths,
-		QuietRegistry:    mode == ModeAspire,
+		QuietRegistry:    containerPosture,
 		AppNamespaces:    appNS,
 		ExtraResources:   extraRes,
 	}, dist)
@@ -207,7 +208,7 @@ func runServe(ctx context.Context, mode Mode, settings serveSettings, basePath s
 	} else {
 		fmt.Println("Anonymous usage telemetry is disabled (DEVDASHBOARD_TELEMETRY_OPTOUT=true).")
 	}
-	if !noOpen && mode != ModeAspire {
+	if !noOpen && !containerPosture {
 		go func() { time.Sleep(400 * time.Millisecond); _ = openBrowser(url) }()
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,7 @@ func NewRootCmd() *cobra.Command {
 	}
 	c.SetVersionTemplate(fmt.Sprintf("dev-dashboard {{.Version}} (commit %s, built %s)\n", info.Commit, info.Date))
 	c.Flags().IntVar(&port, "port", 9090, "port to serve the dashboard on")
-	c.Flags().StringVar(&bind, "bind", "127.0.0.1", "address to bind (aspire mode defaults to 0.0.0.0); binding a non-loopback address without aspire mode leaves the loopback Host guard in place, which rejects remote clients")
+	c.Flags().StringVar(&bind, "bind", "127.0.0.1", "address to bind (aspire container posture defaults to 0.0.0.0); binding a non-loopback address outside container posture leaves the loopback Host guard in place, which rejects remote clients")
 	c.Flags().StringVar(&modeFlag, "mode", "", `discovery filter: "dapr-run", "compose", "test-containers", or "aspire" show only that source's resources ("aspire" also switches to container posture when the DEVDASHBOARD_APP_* contract is present); unset scans every source`)
 	c.Flags().StringVar(&basePath, "base-path", "", "optional base path (e.g. /dashboard)")
 	c.Flags().BoolVar(&noOpen, "no-open", false, "do not open the browser on start")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/diagridio/dev-dashboard/pkg/containerruntime"
+	"github.com/diagridio/dev-dashboard/pkg/controlplane"
 	"github.com/diagridio/dev-dashboard/pkg/discovery"
 	"github.com/diagridio/dev-dashboard/pkg/lifecycle"
 	"github.com/diagridio/dev-dashboard/pkg/logging"
@@ -66,7 +67,7 @@ func NewRootCmd() *cobra.Command {
 	c.SetVersionTemplate(fmt.Sprintf("dev-dashboard {{.Version}} (commit %s, built %s)\n", info.Commit, info.Date))
 	c.Flags().IntVar(&port, "port", 9090, "port to serve the dashboard on")
 	c.Flags().StringVar(&bind, "bind", "127.0.0.1", "address to bind (aspire mode defaults to 0.0.0.0); binding a non-loopback address without aspire mode leaves the loopback Host guard in place, which rejects remote clients")
-	c.Flags().StringVar(&modeFlag, "mode", "", `serving/discovery mode: "aspire", or unset for the complete scan`)
+	c.Flags().StringVar(&modeFlag, "mode", "", `discovery filter: "dapr-run", "compose", "test-containers", or "aspire" show only that source's resources ("aspire" also switches to container posture when the DEVDASHBOARD_APP_* contract is present); unset scans every source`)
 	c.Flags().StringVar(&basePath, "base-path", "", "optional base path (e.g. /dashboard)")
 	c.Flags().BoolVar(&noOpen, "no-open", false, "do not open the browser on start")
 	c.Flags().StringVar(&stateStore, "statestore", "", "path to a state-store component YAML (overrides auto-detect)")
@@ -143,14 +144,28 @@ func runServe(ctx context.Context, mode Mode, containerPosture bool, settings se
 		}
 		appNS = contractNamespaces(scan)
 		appsSvc = discovery.New(scan, client)
-		caps = &server.Capabilities{Workflows: settings.StateStore != ""}
+		caps = &server.Capabilities{Workflows: settings.StateStore != "", Mode: string(ModeAspire)}
 	default:
+		src := sourcesFor(mode, discovery.AspireContractPresent(os.Getenv))
 		_, crtRunner := containerruntime.Detect()
-		composeSrc := discovery.NewComposeSource(crtRunner)
-		tcSrc := discovery.NewTestcontainersSource(crtRunner)
-		extraRes = tcExtraResources(tcSrc)
-		scanners := []discovery.Scanner{discovery.StandaloneScanner(), composeSrc.Scanner(), tcSrc.Scanner()}
-		if discovery.AspireContractPresent(os.Getenv) {
+		if src.NeedsRuntime && crtRunner == nil {
+			return fmt.Errorf("--mode %s requires a container runtime: install docker or podman (or set DASH_CONTAINER_RUNTIME)", mode)
+		}
+		var scanners []discovery.Scanner
+		if src.Standalone {
+			scanners = append(scanners, discovery.StandaloneScanner())
+		}
+		if src.Compose {
+			composeSrc := discovery.NewComposeSource(crtRunner)
+			scanners = append(scanners, composeSrc.Scanner())
+			composeEnv = composeSrc.Env
+		}
+		if src.Testcontainers {
+			tcSrc := discovery.NewTestcontainersSource(crtRunner)
+			scanners = append(scanners, tcSrc.Scanner())
+			extraRes = tcExtraResources(tcSrc)
+		}
+		if src.AspireContract {
 			as, err := discovery.NewAspireScanner(os.Getenv)
 			if err != nil {
 				return err
@@ -162,10 +177,17 @@ func runServe(ctx context.Context, mode Mode, containerPosture bool, settings se
 		lifeProc := lifecycle.NewProcController()
 		appsSvc = lifecycle.Overlay(
 			discovery.New(discovery.Merge(scanners...), client), lifeReg, lifeProc)
+		if src.AspireFilter {
+			appsSvc = discovery.FilterAspire(appsSvc)
+		}
 		lifeMgr = lifecycle.New(appsSvc, lifeReg, crtRunner, lifeProc, lifecycle.NewStarter())
-		composeEnv = composeSrc.Env
-		containerLogs = containerLogStream(crtRunner)
+		if src.Compose || src.Testcontainers {
+			containerLogs = containerLogStream(crtRunner)
+		}
 		updateCheck = updatecheck.New(&http.Client{Timeout: 5 * time.Second}, "https://api.github.com", "diagridio/dev-dashboard", version.Get().Version, time.Hour)
+		c := server.FullCapabilities()
+		c.Mode = string(mode)
+		caps = &c
 	}
 
 	telemetry := telemetryEnabled(os.Getenv)
@@ -175,6 +197,7 @@ func runServe(ctx context.Context, mode Mode, containerPosture bool, settings se
 		Namespace:        settings.Namespace,
 		Apps:             appsSvc,
 		Lifecycle:        lifeMgr,
+		ControlPlane:     controlplane.New(cpSourcesFor(mode)),
 		HomeDir:          home,
 		HTTPClient:       &http.Client{Timeout: 10 * time.Second},
 		ComposeEnv:       composeEnv,

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -28,9 +28,12 @@ type serveDeps struct {
 	Apps           discovery.Service
 	// Lifecycle starts/stops/restarts discovered apps; nil disables the actions
 	// API (routes return 503).
-	Lifecycle  lifecycle.Manager
-	HomeDir    string
-	HTTPClient *http.Client // workflow HTTP client (remover/purge)
+	Lifecycle lifecycle.Manager
+	// ControlPlane lists/controls the placement+scheduler services, already
+	// filtered to the mode's families (cpSourcesFor).
+	ControlPlane controlplane.Manager
+	HomeDir      string
+	HTTPClient   *http.Client // workflow HTTP client (remover/purge)
 	// ComposeEnv returns the compose endpoint/mount context from the last
 	// compose scan; nil when compose discovery is disabled (tests, no runtime).
 	ComposeEnv func() discovery.ComposeEnv
@@ -147,7 +150,7 @@ func assembleOptions(ctx context.Context, deps serveDeps, dist fs.FS) (server.Op
 		Stores:           rc,
 		Resources:        resources.New(rc.Paths, deps.ExtraResources),
 		News:             newsSvc,
-		ControlPlane:     controlplane.New(controlplane.AllSources()),
+		ControlPlane:     deps.ControlPlane,
 		TelemetryEnabled: deps.TelemetryEnabled,
 		UpdateCheck:      deps.UpdateCheck,
 		AllowNonLoopback: deps.AllowNonLoopback,

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -147,7 +147,7 @@ func assembleOptions(ctx context.Context, deps serveDeps, dist fs.FS) (server.Op
 		Stores:           rc,
 		Resources:        resources.New(rc.Paths, deps.ExtraResources),
 		News:             newsSvc,
-		ControlPlane:     controlplane.New(),
+		ControlPlane:     controlplane.New(controlplane.AllSources()),
 		TelemetryEnabled: deps.TelemetryEnabled,
 		UpdateCheck:      deps.UpdateCheck,
 		AllowNonLoopback: deps.AllowNonLoopback,

--- a/cmd/sources.go
+++ b/cmd/sources.go
@@ -1,0 +1,49 @@
+package cmd
+
+import "github.com/diagridio/dev-dashboard/pkg/controlplane"
+
+// sourceSet describes which discovery sources a host-posture mode enables.
+// Filter modes set exactly one source; ModeDefault sets everything.
+type sourceSet struct {
+	Standalone     bool // host `dapr run` process scan
+	Compose        bool // Docker Compose container discovery
+	Testcontainers bool // Testcontainers container discovery
+	AspireContract bool // env-contract scanner joins the merge (mode unset only)
+	AspireFilter   bool // post-enrichment IsAspire filter (aspire host mode)
+	NeedsRuntime   bool // startup fails when no container runtime is found
+}
+
+// sourcesFor maps a host-posture mode to its discovery sources. Container
+// posture (aspire + env contract) never reaches this function — runServe
+// branches to the env-contract scanner before consulting it.
+func sourcesFor(mode Mode, contractPresent bool) sourceSet {
+	switch mode {
+	case ModeDaprRun:
+		return sourceSet{Standalone: true}
+	case ModeCompose:
+		return sourceSet{Compose: true, NeedsRuntime: true}
+	case ModeTestcontainers:
+		return sourceSet{Testcontainers: true, NeedsRuntime: true}
+	case ModeAspire:
+		return sourceSet{Standalone: true, AspireFilter: true}
+	default:
+		return sourceSet{Standalone: true, Compose: true, Testcontainers: true, AspireContract: contractPresent}
+	}
+}
+
+// cpSourcesFor maps a mode to the control-plane families the dashboard shows
+// and manages. dapr-run and aspire sidecars use the `dapr init` containers;
+// test-containers has no control-plane detection yet (deferred), so it gets
+// the zero value — an honest empty list.
+func cpSourcesFor(mode Mode) controlplane.Sources {
+	switch mode {
+	case ModeDaprRun, ModeAspire:
+		return controlplane.Sources{Init: true}
+	case ModeCompose:
+		return controlplane.Sources{Compose: true}
+	case ModeTestcontainers:
+		return controlplane.Sources{}
+	default:
+		return controlplane.AllSources()
+	}
+}

--- a/cmd/sources_test.go
+++ b/cmd/sources_test.go
@@ -1,0 +1,56 @@
+//go:build unit
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/diagridio/dev-dashboard/pkg/controlplane"
+)
+
+func TestSourcesFor(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     Mode
+		contract bool
+		want     sourceSet
+	}{
+		{name: "default scans everything", mode: ModeDefault,
+			want: sourceSet{Standalone: true, Compose: true, Testcontainers: true}},
+		{name: "default joins the env contract when present", mode: ModeDefault, contract: true,
+			want: sourceSet{Standalone: true, Compose: true, Testcontainers: true, AspireContract: true}},
+		{name: "dapr-run is standalone only", mode: ModeDaprRun,
+			want: sourceSet{Standalone: true}},
+		{name: "compose is compose only and needs a runtime", mode: ModeCompose,
+			want: sourceSet{Compose: true, NeedsRuntime: true}},
+		{name: "test-containers is tc only and needs a runtime", mode: ModeTestcontainers,
+			want: sourceSet{Testcontainers: true, NeedsRuntime: true}},
+		{name: "aspire host filters the standalone scan", mode: ModeAspire,
+			want: sourceSet{Standalone: true, AspireFilter: true}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sourcesFor(tc.mode, tc.contract); got != tc.want {
+				t.Fatalf("sourcesFor(%q,%v)=%+v want %+v", tc.mode, tc.contract, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCPSourcesFor(t *testing.T) {
+	tests := []struct {
+		mode Mode
+		want controlplane.Sources
+	}{
+		{ModeDefault, controlplane.AllSources()},
+		{ModeDaprRun, controlplane.Sources{Init: true}},
+		{ModeAspire, controlplane.Sources{Init: true}},
+		{ModeCompose, controlplane.Sources{Compose: true}},
+		{ModeTestcontainers, controlplane.Sources{}},
+	}
+	for _, tc := range tests {
+		if got := cpSourcesFor(tc.mode); got != tc.want {
+			t.Fatalf("cpSourcesFor(%q)=%+v want %+v", tc.mode, got, tc.want)
+		}
+	}
+}

--- a/docs/aspire-discovery.md
+++ b/docs/aspire-discovery.md
@@ -35,6 +35,14 @@ and **the Aspire entry wins** (it carries the reachable base URL) —
 
 The rest of this document describes **Aspire mode** specifically.
 
+**Note on `--mode aspire` without the env contract:** `--mode aspire` without the
+`DEVDASHBOARD_APP_*` contract runs the dashboard on the host with normal host
+defaults and filters the standalone process scan to instances flagged
+`IsAspire` (DCP-proxy heuristic); the env-contract container flow described
+above is unchanged. Heuristic limitations (apps without an app port are
+missed; stopped apps drop out) are listed in
+[2026-07-13-mode-filter-design.md](superpowers/specs/2026-07-13-mode-filter-design.md).
+
 ---
 
 ## 2. The contract — the single source of truth

--- a/docs/aspire-discovery.md
+++ b/docs/aspire-discovery.md
@@ -20,7 +20,7 @@ There are two entry paths, both centered on the same env contract:
 
 | Path | Trigger | Discovery sources | Serving posture |
 |---|---|---|---|
-| **Aspire mode** | `--mode aspire` / `DEVDASHBOARD_MODE=aspire` | **Only** the `DEVDASHBOARD_APP_*` env contract | Container posture (bind `0.0.0.0:8080`, non-loopback Host allowed, host features off) |
+| **Aspire mode** | `--mode aspire` / `DEVDASHBOARD_MODE=aspire` | **Only** the `DEVDASHBOARD_APP_*` env contract | Container posture (bind `0.0.0.0:8080`, non-loopback Host allowed, host features off) — with the env contract; host posture without it |
 | **Mode unset (default)** | no mode flag | Full merge: standalone process scan + compose + testcontainers + Aspire contract (if present) | Host posture (loopback `127.0.0.1:9090`, all features on) |
 
 Mode is resolved once at startup in [`cmd/mode.go`](../cmd/mode.go) (`resolveMode`,

--- a/docs/superpowers/plans/2026-07-13-mode-filter.md
+++ b/docs/superpowers/plans/2026-07-13-mode-filter.md
@@ -1,0 +1,1082 @@
+# Exclusive `--mode` Discovery Filters Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `--mode` to four exclusive discovery filters — `dapr-run`, `compose`, `test-containers`, `aspire` — that restrict every dashboard surface (apps, control plane, logs) to one source, with `aspire` gaining a standalone host posture, and relabel the UI's "Run template" column to "Mode".
+
+**Architecture:** Mode drives a scanner-selection helper in `cmd`; the aspire host filter is a post-enrichment `discovery.Service` wrapper (the `IsAspire` flag only exists after enrichment); the Control Plane manager gains a `Sources` family selector; the SPA learns the mode via the existing `window.__DASH_CAPABILITIES__` injection so the Logs page can gate its static `dapr_*` fallback.
+
+**Tech Stack:** Go (cobra CLI, chi server), React + TypeScript (vitest), existing test conventions (`//go:build unit`, fakeRunner, Testing Library).
+
+**Spec:** `docs/superpowers/specs/2026-07-13-mode-filter-design.md`
+
+## Global Constraints
+
+- CLI mode values are exactly `dapr-run`, `compose`, `test-containers`, `aspire`; unset means complete scan. Filters are exclusive, never combined.
+- Pretty UI labels are exactly `Dapr run`, `Compose`, `TestContainers`, `Aspire`.
+- `compose`/`test-containers` mode with no container runtime must FAIL at startup, not degrade to empty.
+- Testcontainers control-plane detection is DEFERRED — the Control Plane view shows an honest empty list in `test-containers` mode.
+- Container posture (8080/0.0.0.0/no registry/no browser) applies ONLY to `aspire` + `DEVDASHBOARD_APP_*` contract present; every other mode keeps host posture.
+- Go tests run with `go test -tags unit -race ./<pkg>/...`; any `.ts(x)` change requires `make build` (vitest does not typecheck).
+- Run `gofmt -w` on every touched Go file before committing.
+
+---
+
+### Task 1: Mode constants and validation
+
+**Files:**
+- Modify: `cmd/mode.go:11-35`
+- Test: `cmd/mode_test.go:12-47`
+
+**Interfaces:**
+- Produces: `ModeDaprRun Mode = "dapr-run"`, `ModeCompose Mode = "compose"`, `ModeTestcontainers Mode = "test-containers"` (used by every later task); `resolveMode` unchanged signature, now accepting the new values.
+
+- [ ] **Step 1: Update the tests to accept the new values**
+
+In `cmd/mode_test.go`, replace the two "unknown" cases (lines 27-28) and extend the table inside `TestResolveMode`:
+
+```go
+		{name: "unset everywhere is default", flag: "", env: nil, want: ModeDefault},
+		{name: "flag aspire", flag: "aspire", env: nil, want: ModeAspire},
+		{name: "flag dapr-run", flag: "dapr-run", env: nil, want: ModeDaprRun},
+		{name: "flag compose", flag: "compose", env: nil, want: ModeCompose},
+		{name: "flag test-containers", flag: "test-containers", env: nil, want: ModeTestcontainers},
+		{name: "env aspire", flag: "", env: map[string]string{"DEVDASHBOARD_MODE": "aspire"}, want: ModeAspire},
+		{name: "env compose", flag: "", env: map[string]string{"DEVDASHBOARD_MODE": "compose"}, want: ModeCompose},
+		{name: "flag wins over env", flag: "aspire", env: map[string]string{"DEVDASHBOARD_MODE": "bogus"}, want: ModeAspire},
+		{name: "unknown flag value errors", flag: "dapr", wantErr: true},
+		{name: "unknown env value errors", env: map[string]string{"DEVDASHBOARD_MODE": "docker"}, wantErr: true},
+```
+
+- [ ] **Step 2: Run tests to verify the new cases fail**
+
+Run: `go test -tags unit -race ./cmd/ -run TestResolveMode -v`
+Expected: FAIL — "flag dapr-run", "flag compose", "flag test-containers", "env compose" error with `unknown mode`.
+
+- [ ] **Step 3: Add the constants and accept them in resolveMode**
+
+In `cmd/mode.go`, replace the type comment + const block (lines 11-21):
+
+```go
+// Mode selects the dashboard's discovery and serving posture. ModeDefault
+// (the zero value, mode unset) is the complete scan across all discovery
+// sources with today's host behavior. Every other value is an exclusive
+// single-source filter — they are never combined:
+//
+//   - ModeDaprRun: host `dapr run` process scan only.
+//   - ModeCompose: Docker Compose container discovery only.
+//   - ModeTestcontainers: Testcontainers container discovery only.
+//   - ModeAspire: Aspire resources only. With the DEVDASHBOARD_APP_* env
+//     contract present the dashboard is the AppHost-managed container
+//     (container posture); without it the dashboard runs on the host and
+//     filters the process scan to Aspire-managed instances.
+//
+// CLI values ("dapr-run", "test-containers") are user-facing names and
+// intentionally differ from the discovery Source wire values ("standalone",
+// "testcontainers") — do not unify them.
+type Mode string
+
+const (
+	ModeDefault        Mode = ""
+	ModeAspire         Mode = "aspire"
+	ModeDaprRun        Mode = "dapr-run"
+	ModeCompose        Mode = "compose"
+	ModeTestcontainers Mode = "test-containers"
+)
+```
+
+And in `resolveMode`, replace the switch + error (lines 30-34):
+
+```go
+	switch Mode(v) {
+	case ModeDefault, ModeAspire, ModeDaprRun, ModeCompose, ModeTestcontainers:
+		return Mode(v), nil
+	}
+	return ModeDefault, fmt.Errorf("unknown mode %q: supported values are \"dapr-run\", \"compose\", \"test-containers\", \"aspire\" (or unset for the complete scan)", v)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -tags unit -race ./cmd/ -run TestResolveMode -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/mode.go cmd/mode_test.go
+git commit -m "feat(mode): accept dapr-run, compose, test-containers mode values"
+```
+
+---
+
+### Task 2: Container posture split (aspire dual semantics)
+
+**Files:**
+- Modify: `cmd/mode.go:50-100` (`resolveServeSettings`), add `containerPosture` helper
+- Modify: `cmd/root.go:53-62` (RunE), `cmd/root.go:85` (runServe signature), `cmd/root.go:100,116,137,183,188,210` (posture checks)
+- Test: `cmd/mode_test.go` (`TestResolveServeSettings`, new `TestContainerPosture`)
+
+**Interfaces:**
+- Consumes: `discovery.AspireContractPresent(getenv func(string) string) bool` (existing, `pkg/discovery/scan_aspire.go:18`).
+- Produces: `containerPosture(mode Mode, getenv func(string) string) bool`; `resolveServeSettings(containerPosture bool, flagChanged func(string) bool, port int, bind, stateStore, namespace string, getenv func(string) string) (serveSettings, error)`; `runServe(ctx context.Context, mode Mode, containerPosture bool, settings serveSettings, basePath string, noOpen, verbose bool) error`. Task 6 relies on `runServe` receiving both `mode` and `containerPosture`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `cmd/mode_test.go`, add after `TestResolveMode`:
+
+```go
+func TestContainerPosture(t *testing.T) {
+	withContract := func(k string) string {
+		if k == "DEVDASHBOARD_APP_COUNT" {
+			return "2"
+		}
+		return ""
+	}
+	none := func(string) string { return "" }
+	if !containerPosture(ModeAspire, withContract) {
+		t.Fatal("aspire + contract must be container posture")
+	}
+	if containerPosture(ModeAspire, none) {
+		t.Fatal("aspire without the contract must stay host posture")
+	}
+	if containerPosture(ModeCompose, withContract) {
+		t.Fatal("non-aspire modes are never container posture")
+	}
+	if containerPosture(ModeDefault, withContract) {
+		t.Fatal("mode-unset is never container posture")
+	}
+}
+```
+
+In `TestResolveServeSettings`, change the table field `mode Mode` to `container bool`, set `container: true` on the five cases currently using `mode: ModeAspire`, drop `mode: ModeDefault` from the rest (zero value false), and update the two call sites:
+
+```go
+			got, err := resolveServeSettings(tc.container, tc.changed, tc.port, tc.bind, tc.stateStore, ns, getenv)
+```
+
+and in the "bad DEVDASHBOARD_PORT errors" subtest:
+
+```go
+		_, err := resolveServeSettings(true, noneChanged, 9090, "127.0.0.1", "", "default",
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit -race ./cmd/ -run 'TestContainerPosture|TestResolveServeSettings' -v`
+Expected: FAIL to compile — `undefined: containerPosture`, wrong argument type for `resolveServeSettings`.
+
+- [ ] **Step 3: Implement the posture split**
+
+In `cmd/mode.go`, add the import `"github.com/diagridio/dev-dashboard/pkg/discovery"` and, below `resolveMode`:
+
+```go
+// containerPosture reports whether the dashboard serves as the
+// AppHost-managed container: aspire mode with the DEVDASHBOARD_APP_* env
+// contract present. Aspire mode without the contract is a host-run dashboard
+// filtered to Aspire resources and keeps host serving defaults.
+func containerPosture(mode Mode, getenv func(string) string) bool {
+	return mode == ModeAspire && discovery.AspireContractPresent(getenv)
+}
+```
+
+Change `resolveServeSettings`'s first parameter from `mode Mode` to `containerPosture bool` and replace its three `mode == ModeAspire` checks (lines 64, 71, 89) with `containerPosture`. Update its doc comment's "mode default" wording to "posture default".
+
+In `cmd/root.go` RunE (lines 53-62):
+
+```go
+			mode, err := resolveMode(modeFlag, os.Getenv)
+			if err != nil {
+				return err
+			}
+			posture := containerPosture(mode, os.Getenv)
+			settings, err := resolveServeSettings(posture, cmd.Flags().Changed, port, bind, stateStore, namespace, os.Getenv)
+			if err != nil {
+				return err
+			}
+			return runServe(cmd.Context(), mode, posture, settings, basePath, noOpen, verbose)
+```
+
+In `runServe`, change the signature to `func runServe(ctx context.Context, mode Mode, containerPosture bool, settings serveSettings, basePath string, noOpen, verbose bool) error` and replace every aspire-keyed posture check:
+
+- line 100: `if !containerPosture && !isLoopbackBind(settings.Bind) {` (warning text: change "without aspire mode" to "without container posture" and keep the `--mode aspire` hint)
+- line 116: `if !containerPosture {` (home dir)
+- lines 137-138: replace `switch mode { case ModeAspire:` with `switch { case containerPosture:` and `default:` stays (aspire host mode intentionally falls to the default branch here; Task 6 adds its filter)
+- line 183: `AllowNonLoopback: containerPosture,`
+- line 188: `QuietRegistry:    containerPosture,`
+- line 210: `if !noOpen && !containerPosture {`
+
+- [ ] **Step 4: Run the package tests**
+
+Run: `go test -tags unit -race ./cmd/...`
+Expected: PASS (including the untouched workflow/serve tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/mode.go cmd/mode_test.go cmd/root.go
+git commit -m "feat(mode): key container posture on aspire env contract, not mode alone"
+```
+
+---
+
+### Task 3: Aspire post-enrichment service filter
+
+**Files:**
+- Create: `pkg/discovery/filter.go`
+- Test: `pkg/discovery/filter_test.go`
+
+**Interfaces:**
+- Consumes: `discovery.Service` (List/Get, `pkg/discovery/service.go:100-104`), `Instance.IsAspire`, `ErrNotFound`.
+- Produces: `discovery.FilterAspire(inner Service) Service` — Task 6 wraps the lifecycle-overlaid service with it in aspire host mode.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `pkg/discovery/filter_test.go`:
+
+```go
+//go:build unit
+
+package discovery
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fakeFilterInner struct{ instances []Instance }
+
+func (f fakeFilterInner) List(context.Context) ([]Instance, error) { return f.instances, nil }
+
+func (f fakeFilterInner) Get(_ context.Context, key string) (Instance, error) {
+	for _, in := range f.instances {
+		if in.AppID == key {
+			return in, nil
+		}
+	}
+	return Instance{}, ErrNotFound
+}
+
+func newAspireFiltered() Service {
+	return FilterAspire(fakeFilterInner{instances: []Instance{
+		{AppID: "checkout", IsAspire: true},
+		{AppID: "plain-daprd", IsAspire: false},
+	}})
+}
+
+func TestFilterAspireListKeepsOnlyAspire(t *testing.T) {
+	got, err := newAspireFiltered().List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].AppID != "checkout" {
+		t.Fatalf("want only the aspire instance, got %+v", got)
+	}
+}
+
+func TestFilterAspireGet(t *testing.T) {
+	svc := newAspireFiltered()
+	if _, err := svc.Get(context.Background(), "checkout"); err != nil {
+		t.Fatalf("aspire instance must resolve: %v", err)
+	}
+	if _, err := svc.Get(context.Background(), "plain-daprd"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("non-aspire instance must be ErrNotFound, got %v", err)
+	}
+	if _, err := svc.Get(context.Background(), "missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unknown key must stay ErrNotFound, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit -race ./pkg/discovery/ -run TestFilterAspire -v`
+Expected: FAIL to compile — `undefined: FilterAspire`.
+
+- [ ] **Step 3: Implement the wrapper**
+
+Create `pkg/discovery/filter.go`:
+
+```go
+package discovery
+
+import "context"
+
+// FilterAspire restricts a Service to Aspire-managed instances. Aspire host
+// mode (dashboard on the host, no env contract) scans the full process table
+// — IsAspire is only known after enrichment (the DCP-proxy heuristic in
+// appproc.go), so the filter must wrap the Service rather than the Scanner.
+// Wrap the outermost Service (after the lifecycle overlay) so every consumer
+// — apps API, workflows, state-store election — sees the filtered view.
+func FilterAspire(inner Service) Service { return aspireOnly{inner: inner} }
+
+type aspireOnly struct{ inner Service }
+
+func (a aspireOnly) List(ctx context.Context) ([]Instance, error) {
+	all, err := a.inner.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Instance, 0, len(all))
+	for _, in := range all {
+		if in.IsAspire {
+			out = append(out, in)
+		}
+	}
+	return out, nil
+}
+
+func (a aspireOnly) Get(ctx context.Context, key string) (Instance, error) {
+	in, err := a.inner.Get(ctx, key)
+	if err != nil {
+		return Instance{}, err
+	}
+	if !in.IsAspire {
+		return Instance{}, ErrNotFound
+	}
+	return in, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -tags unit -race ./pkg/discovery/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/discovery/filter.go pkg/discovery/filter_test.go
+git commit -m "feat(discovery): FilterAspire service wrapper for aspire host mode"
+```
+
+---
+
+### Task 4: Control-plane family filtering
+
+**Files:**
+- Modify: `pkg/controlplane/types.go` (add `Sources`), `pkg/controlplane/service.go:34-101,162-184`
+- Modify: `cmd/serve.go:150` (compile fix: `controlplane.New(controlplane.AllSources())`)
+- Test: `pkg/controlplane/service_test.go`
+
+**Interfaces:**
+- Consumes: existing `newManager(kind, run)` test seam, `fakeRunner` (outputs keyed on `args[0]+" "+args[1]`).
+- Produces: `type Sources struct { Init, Compose bool }`, `func AllSources() Sources`, `func New(src Sources) Manager`, `newManager(kind RuntimeKind, run containerruntime.Runner, src Sources) *manager`. Task 5's `cpSourcesFor` returns `controlplane.Sources`; Task 6 calls `controlplane.New(cpSourcesFor(mode))`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `pkg/controlplane/service_test.go`, add `AllSources()` as the third argument to every existing `newManager(...)` call, then append:
+
+```go
+func TestListInitOnlyExcludesCompose(t *testing.T) {
+	f := &fakeRunner{outputs: map[string][]byte{
+		"info":                []byte("ok"),
+		"inspect dapr_scheduler": []byte("[]"),
+		"inspect dapr_placement": []byte("[]"),
+	}}
+	m := newManager(RuntimeDocker, f, Sources{Init: true})
+	res, err := m.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, s := range res.Services {
+		if s.ComposeProject != "" {
+			t.Fatalf("init-only sources must not list compose services, got %+v", s)
+		}
+	}
+	if len(res.Services) != len(LiveServiceNames) {
+		t.Fatalf("want the %d init services, got %d", len(LiveServiceNames), len(res.Services))
+	}
+}
+
+func TestListComposeOnlyExcludesInit(t *testing.T) {
+	f := &fakeRunner{outputs: map[string][]byte{
+		"info":  []byte("ok"),
+		"ps -aq": []byte(""), // no compose containers running
+	}}
+	m := newManager(RuntimeDocker, f, Sources{Compose: true})
+	res, err := m.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Services) != 0 {
+		t.Fatalf("compose-only sources must not list the dapr_* init services, got %+v", res.Services)
+	}
+}
+
+func TestListEmptySourcesIsHonestEmpty(t *testing.T) {
+	f := &fakeRunner{outputs: map[string][]byte{"info": []byte("ok")}}
+	m := newManager(RuntimeDocker, f, Sources{})
+	res, err := m.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Available || !res.Reachable || len(res.Services) != 0 {
+		t.Fatalf("want available+reachable with zero services, got %+v", res)
+	}
+}
+
+func TestDoAndLogStreamRespectSources(t *testing.T) {
+	m := newManager(RuntimeDocker, &fakeRunner{outputs: map[string][]byte{}}, Sources{Compose: true})
+	if err := m.Do(context.Background(), "restart", "dapr_placement"); !errors.Is(err, ErrUnknownService) {
+		t.Fatalf("Do must reject a filtered-out init service, got %v", err)
+	}
+	if _, err := m.LogStream(context.Background(), "dapr_scheduler"); !errors.Is(err, ErrUnknownService) {
+		t.Fatalf("LogStream must reject a filtered-out init service, got %v", err)
+	}
+}
+```
+
+(Adapt the `fakeRunner` output keys to the file's existing conventions — the fixtures at the top of the file show the exact key format; if inspect output must be valid JSON for `parseInspect`, reuse the file's existing inspect fixture instead of `[]`. Add `"errors"` to the test imports if missing.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit -race ./pkg/controlplane/ -v`
+Expected: FAIL to compile — `undefined: Sources`, wrong arg count for `newManager`.
+
+- [ ] **Step 3: Implement Sources**
+
+In `pkg/controlplane/types.go`, add below `LiveServiceNames`:
+
+```go
+// Sources selects which control-plane families List reports and Do/LogStream
+// accept. The zero value shows nothing — e.g. test-containers mode, which has
+// no control-plane detection yet (deferred to a future iteration).
+type Sources struct {
+	Init    bool // fixed dapr_* containers created by `dapr init`
+	Compose bool // compose-labeled placement/scheduler containers
+}
+
+// AllSources is the mode-unset default: every family.
+func AllSources() Sources { return Sources{Init: true, Compose: true} }
+```
+
+In `pkg/controlplane/service.go`:
+
+```go
+type manager struct {
+	runtime RuntimeKind
+	run     containerruntime.Runner
+	src     Sources
+
+	mu           sync.Mutex
+	composeNames map[string]bool // compose CP containers found by the last List
+}
+
+// New resolves the container runtime from the environment and PATH.
+func New(src Sources) Manager {
+	kind, run := containerruntime.Detect()
+	return newManager(kind, run, src)
+}
+
+func newManager(kind RuntimeKind, run containerruntime.Runner, src Sources) *manager {
+	return &manager{runtime: kind, run: run, src: src}
+}
+```
+
+In `List`, gate the families (replacing lines 60-65's setup and the fixed-name loop's range):
+
+```go
+	var composeSvcs []Service
+	if m.src.Compose {
+		composeSvcs = m.composeControlPlane(ctx)
+	}
+	var liveNames []string
+	if m.src.Init {
+		liveNames = LiveServiceNames
+	}
+	statNames := append(append([]string{}, liveNames...), serviceNames(composeSvcs)...)
+	mem := m.memory(ctx, statNames)
+	services := make([]Service, 0, len(liveNames)+len(composeSvcs))
+	present := false
+	for _, name := range liveNames {
+```
+
+Add an allowlist helper and use it in `Do` (line 166) and `LogStream` (line 177):
+
+```go
+// allowed reports whether name belongs to a family this manager serves.
+func (m *manager) allowed(name string) bool {
+	return (m.src.Init && IsLiveName(name)) || (m.src.Compose && m.isComposeName(name))
+}
+```
+
+replacing both `if !IsLiveName(name) && !m.isComposeName(name) {` with `if !m.allowed(name) {`.
+
+In `cmd/serve.go` line 150, fix the call: `ControlPlane: controlplane.New(controlplane.AllSources()),` (Task 6 threads the real mode).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -tags unit -race ./pkg/controlplane/ ./cmd/...`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/controlplane/types.go pkg/controlplane/service.go pkg/controlplane/service_test.go cmd/serve.go
+git commit -m "feat(controlplane): filter listed/actionable families by Sources"
+```
+
+---
+
+### Task 5: Mode → source-selection helpers
+
+**Files:**
+- Create: `cmd/sources.go`
+- Test: `cmd/sources_test.go`
+
+**Interfaces:**
+- Consumes: `Mode` constants (Task 1), `controlplane.Sources`/`AllSources` (Task 4).
+- Produces: `sourceSet{Standalone, Compose, Testcontainers, AspireContract, AspireFilter, NeedsRuntime bool}`, `sourcesFor(mode Mode, contractPresent bool) sourceSet`, `cpSourcesFor(mode Mode) controlplane.Sources`. Task 6 wires `runServe` from both.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `cmd/sources_test.go`:
+
+```go
+//go:build unit
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/diagridio/dev-dashboard/pkg/controlplane"
+)
+
+func TestSourcesFor(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     Mode
+		contract bool
+		want     sourceSet
+	}{
+		{name: "default scans everything", mode: ModeDefault,
+			want: sourceSet{Standalone: true, Compose: true, Testcontainers: true}},
+		{name: "default joins the env contract when present", mode: ModeDefault, contract: true,
+			want: sourceSet{Standalone: true, Compose: true, Testcontainers: true, AspireContract: true}},
+		{name: "dapr-run is standalone only", mode: ModeDaprRun,
+			want: sourceSet{Standalone: true}},
+		{name: "compose is compose only and needs a runtime", mode: ModeCompose,
+			want: sourceSet{Compose: true, NeedsRuntime: true}},
+		{name: "test-containers is tc only and needs a runtime", mode: ModeTestcontainers,
+			want: sourceSet{Testcontainers: true, NeedsRuntime: true}},
+		{name: "aspire host filters the standalone scan", mode: ModeAspire,
+			want: sourceSet{Standalone: true, AspireFilter: true}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sourcesFor(tc.mode, tc.contract); got != tc.want {
+				t.Fatalf("sourcesFor(%q,%v)=%+v want %+v", tc.mode, tc.contract, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCPSourcesFor(t *testing.T) {
+	tests := []struct {
+		mode Mode
+		want controlplane.Sources
+	}{
+		{ModeDefault, controlplane.AllSources()},
+		{ModeDaprRun, controlplane.Sources{Init: true}},
+		{ModeAspire, controlplane.Sources{Init: true}},
+		{ModeCompose, controlplane.Sources{Compose: true}},
+		{ModeTestcontainers, controlplane.Sources{}},
+	}
+	for _, tc := range tests {
+		if got := cpSourcesFor(tc.mode); got != tc.want {
+			t.Fatalf("cpSourcesFor(%q)=%+v want %+v", tc.mode, got, tc.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit -race ./cmd/ -run 'TestSourcesFor|TestCPSourcesFor' -v`
+Expected: FAIL to compile — `undefined: sourceSet`, `sourcesFor`, `cpSourcesFor`.
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `cmd/sources.go`:
+
+```go
+package cmd
+
+import "github.com/diagridio/dev-dashboard/pkg/controlplane"
+
+// sourceSet describes which discovery sources a host-posture mode enables.
+// Filter modes set exactly one source; ModeDefault sets everything.
+type sourceSet struct {
+	Standalone     bool // host `dapr run` process scan
+	Compose        bool // Docker Compose container discovery
+	Testcontainers bool // Testcontainers container discovery
+	AspireContract bool // env-contract scanner joins the merge (mode unset only)
+	AspireFilter   bool // post-enrichment IsAspire filter (aspire host mode)
+	NeedsRuntime   bool // startup fails when no container runtime is found
+}
+
+// sourcesFor maps a host-posture mode to its discovery sources. Container
+// posture (aspire + env contract) never reaches this function — runServe
+// branches to the env-contract scanner before consulting it.
+func sourcesFor(mode Mode, contractPresent bool) sourceSet {
+	switch mode {
+	case ModeDaprRun:
+		return sourceSet{Standalone: true}
+	case ModeCompose:
+		return sourceSet{Compose: true, NeedsRuntime: true}
+	case ModeTestcontainers:
+		return sourceSet{Testcontainers: true, NeedsRuntime: true}
+	case ModeAspire:
+		return sourceSet{Standalone: true, AspireFilter: true}
+	default:
+		return sourceSet{Standalone: true, Compose: true, Testcontainers: true, AspireContract: contractPresent}
+	}
+}
+
+// cpSourcesFor maps a mode to the control-plane families the dashboard shows
+// and manages. dapr-run and aspire sidecars use the `dapr init` containers;
+// test-containers has no control-plane detection yet (deferred), so it gets
+// the zero value — an honest empty list.
+func cpSourcesFor(mode Mode) controlplane.Sources {
+	switch mode {
+	case ModeDaprRun, ModeAspire:
+		return controlplane.Sources{Init: true}
+	case ModeCompose:
+		return controlplane.Sources{Compose: true}
+	case ModeTestcontainers:
+		return controlplane.Sources{}
+	default:
+		return controlplane.AllSources()
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -tags unit -race ./cmd/...`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/sources.go cmd/sources_test.go
+git commit -m "feat(mode): source-selection helpers for discovery and control plane"
+```
+
+---
+
+### Task 6: Wire runServe — filtered scanners, fail-fast, capabilities mode
+
+**Files:**
+- Modify: `cmd/root.go:66-68` (flag help), `cmd/root.go:137-191` (runServe branch + deps)
+- Modify: `cmd/serve.go` (serveDeps gains `ControlPlane`; assembleOptions uses it)
+- Modify: `pkg/server/server.go:62-72` (Capabilities gains `Mode`), `pkg/server/spa.go:64` (comment)
+- Test: `cmd/sources_test.go` (compile-level), existing suites
+
+**Interfaces:**
+- Consumes: `sourcesFor`/`cpSourcesFor` (Task 5), `discovery.FilterAspire` (Task 3), `controlplane.New(Sources)` (Task 4), `containerPosture` bool param on `runServe` (Task 2).
+- Produces: `server.Capabilities.Mode string` (json `mode`) — Task 7's frontend reads it from `window.__DASH_CAPABILITIES__`.
+
+- [ ] **Step 1: Add Mode to server.Capabilities**
+
+In `pkg/server/server.go`, extend the struct (keep FullCapabilities as-is — `Mode` zero value `""` is the complete scan):
+
+```go
+type Capabilities struct {
+	Lifecycle    bool `json:"lifecycle"`
+	ControlPlane bool `json:"controlPlane"`
+	Logs         bool `json:"logs"`
+	Workflows    bool `json:"workflows"`
+	// Mode echoes the CLI --mode value ("" = complete scan) so the SPA can
+	// adapt static fallbacks (e.g. the Logs page's dapr_* targets) to the
+	// server's discovery filter.
+	Mode string `json:"mode"`
+}
+```
+
+In `pkg/server/spa.go`, update the stale comment above `json.Marshal(caps)` from "caps is a bool-only struct, so marshaling cannot fail" to "caps holds only bools and a plain string, so marshaling cannot fail".
+
+- [ ] **Step 2: Thread the control-plane manager through serveDeps**
+
+In `cmd/serve.go`, add to `serveDeps` (after `Lifecycle`):
+
+```go
+	// ControlPlane lists/controls the placement+scheduler services, already
+	// filtered to the mode's families (cpSourcesFor).
+	ControlPlane controlplane.Manager
+```
+
+and in `assembleOptions` replace `ControlPlane: controlplane.New(controlplane.AllSources()),` with `ControlPlane: deps.ControlPlane,`.
+
+- [ ] **Step 3: Rebuild the runServe host branch**
+
+In `cmd/root.go`, replace the mode switch (Task 2 left it as `switch { case containerPosture: ... default: ... }`) so the default branch becomes:
+
+```go
+	default:
+		src := sourcesFor(mode, discovery.AspireContractPresent(os.Getenv))
+		_, crtRunner := containerruntime.Detect()
+		if src.NeedsRuntime && crtRunner == nil {
+			return fmt.Errorf("--mode %s requires a container runtime: install docker or podman (or set DASH_CONTAINER_RUNTIME)", mode)
+		}
+		var scanners []discovery.Scanner
+		if src.Standalone {
+			scanners = append(scanners, discovery.StandaloneScanner())
+		}
+		if src.Compose {
+			composeSrc := discovery.NewComposeSource(crtRunner)
+			scanners = append(scanners, composeSrc.Scanner())
+			composeEnv = composeSrc.Env
+		}
+		if src.Testcontainers {
+			tcSrc := discovery.NewTestcontainersSource(crtRunner)
+			scanners = append(scanners, tcSrc.Scanner())
+			extraRes = tcExtraResources(tcSrc)
+		}
+		if src.AspireContract {
+			as, err := discovery.NewAspireScanner(os.Getenv)
+			if err != nil {
+				return err
+			}
+			appNS = contractNamespaces(as)
+			scanners = append(scanners, as)
+		}
+		lifeReg := lifecycle.NewRegistry()
+		lifeProc := lifecycle.NewProcController()
+		appsSvc = lifecycle.Overlay(
+			discovery.New(discovery.Merge(scanners...), client), lifeReg, lifeProc)
+		if src.AspireFilter {
+			appsSvc = discovery.FilterAspire(appsSvc)
+		}
+		lifeMgr = lifecycle.New(appsSvc, lifeReg, crtRunner, lifeProc, lifecycle.NewStarter())
+		if src.Compose || src.Testcontainers {
+			containerLogs = containerLogStream(crtRunner)
+		}
+		updateCheck = updatecheck.New(&http.Client{Timeout: 5 * time.Second}, "https://api.github.com", "diagridio/dev-dashboard", version.Get().Version, time.Hour)
+```
+
+Set capabilities in both branches so `Mode` always reaches the SPA. In the `containerPosture` branch, extend the existing line:
+
+```go
+		caps = &server.Capabilities{Workflows: settings.StateStore != "", Mode: string(ModeAspire)}
+```
+
+At the end of the default branch:
+
+```go
+		c := server.FullCapabilities()
+		c.Mode = string(mode)
+		caps = &c
+```
+
+Add `ControlPlane` to the `assembleOptions` deps literal (near `Lifecycle`):
+
+```go
+		ControlPlane:     controlplane.New(cpSourcesFor(mode)),
+```
+
+and add `"github.com/diagridio/dev-dashboard/pkg/controlplane"` to `cmd/root.go` imports.
+
+- [ ] **Step 4: Update the --mode flag help**
+
+`cmd/root.go` line 68:
+
+```go
+	c.Flags().StringVar(&modeFlag, "mode", "", `discovery filter: "dapr-run", "compose", "test-containers", or "aspire" show only that source's resources ("aspire" also switches to container posture when the DEVDASHBOARD_APP_* contract is present); unset scans every source`)
+```
+
+- [ ] **Step 5: Build and run the full Go suite**
+
+Run: `go build ./... && go test -tags unit -race ./...`
+Expected: PASS. If `pkg/server` tests construct `Capabilities` literals positionally they will fail to compile — convert those literals to keyed fields.
+
+- [ ] **Step 6: Smoke-check the fail-fast and mode flows**
+
+Run: `go run . --mode bogus 2>&1 | head -2`
+Expected: `unknown mode "bogus": supported values are "dapr-run", "compose", "test-containers", "aspire" (or unset for the complete scan)`
+
+Run: `PATH=/usr/bin:/bin go run . --mode compose --no-open 2>&1 | head -2` (a PATH without docker/podman)
+Expected: `--mode compose requires a container runtime: install docker or podman (or set DASH_CONTAINER_RUNTIME)`
+
+Run: `go run . --mode dapr-run --no-open &` then `curl -s localhost:9090/api/controlplane | head -c 300`; kill the server.
+Expected: JSON listing only `dapr_scheduler`/`dapr_placement` services (no `composeProject` entries).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/root.go cmd/serve.go pkg/server/server.go pkg/server/spa.go
+git commit -m "feat(mode): wire exclusive discovery filters through runServe"
+```
+
+---
+
+### Task 7: Frontend — capabilities.mode gates the Logs static CP fallback
+
+**Files:**
+- Modify: `web/src/lib/capabilities.ts`
+- Modify: `web/src/pages/Logs.tsx:17-19,370-378`
+- Test: `web/src/pages/Logs.test.tsx`
+
+**Interfaces:**
+- Consumes: `window.__DASH_CAPABILITIES__.mode` (Task 6).
+- Produces: `Capabilities.mode?: string`; `staticCpForMode(mode: string): readonly string[]` (module-local to Logs.tsx).
+
+- [ ] **Step 1: Write the failing test**
+
+`web/src/pages/Logs.test.tsx` renders through its `renderAt(initialEntry)` helper (line 113) and stubs `/api/controlplane` with msw in `beforeEach`. Add a test that sets the injected capabilities before rendering and restores them after; override the CP endpoint to return no services so only the static fallback could produce `dapr_*` entries:
+
+```tsx
+it('omits the static dapr_* control-plane targets in compose mode', async () => {
+  window.__DASH_CAPABILITIES__ = { lifecycle: true, controlPlane: true, logs: true, workflows: true, mode: 'compose' }
+  server.use(http.get('/api/controlplane', () => HttpResponse.json({ ...CP_LIST_BASE, services: [] })))
+  try {
+    renderAt('/logs')
+    await screen.findByText('Logs') // page settled
+    expect(screen.queryByText('dapr_scheduler')).not.toBeInTheDocument()
+    expect(screen.queryByText('dapr_placement')).not.toBeInTheDocument()
+  } finally {
+    delete window.__DASH_CAPABILITIES__
+  }
+})
+```
+
+(Adapt the settle-assertion and how the CP selector's options are queried to whatever the file's existing CP-selector tests do — mirror them exactly.) Also add the inverse assertion for the default mode (no `__DASH_CAPABILITIES__` set → `dapr_scheduler` offered), again mirroring the existing CP-selector assertions.
+
+- [ ] **Step 2: Run tests to verify the new one fails**
+
+Run: `cd web && npm test -- src/pages/Logs.test.tsx`
+Expected: FAIL — dapr_scheduler is still offered in compose mode.
+
+- [ ] **Step 3: Implement**
+
+`web/src/lib/capabilities.ts`:
+
+```ts
+export interface Capabilities {
+  lifecycle: boolean
+  controlPlane: boolean
+  logs: boolean
+  workflows: boolean
+  /** CLI --mode value ('' = complete scan); lets the UI adapt static fallbacks. */
+  mode?: string
+}
+
+declare global {
+  interface Window {
+    __DASH_CAPABILITIES__?: Capabilities
+  }
+}
+
+const FULL: Capabilities = { lifecycle: true, controlPlane: true, logs: true, workflows: true, mode: '' }
+```
+
+(`getCapabilities` unchanged.)
+
+`web/src/pages/Logs.tsx` — import `getCapabilities` from `../lib/capabilities`, then replace the static-list block (lines 17-19):
+
+```ts
+// Static fallback so the selector renders before /api/controlplane answers;
+// compose-managed placement/scheduler containers are merged in from the API.
+// Only modes whose sidecars use the `dapr init` containers get the fallback —
+// compose / test-containers modes must not offer dapr_* targets.
+const CP_SERVICES = ['dapr_scheduler', 'dapr_placement'] as const
+const NO_CP_SERVICES: readonly string[] = []
+const staticCpForMode = (mode: string): readonly string[] =>
+  mode === '' || mode === 'dapr-run' || mode === 'aspire' ? CP_SERVICES : NO_CP_SERVICES
+```
+
+and in the component, replace the `cpNames` memo (lines 375-378):
+
+```ts
+  const staticCp = staticCpForMode(getCapabilities().mode ?? '')
+  const cpNames = useMemo(() => {
+    const fetched = (cpList?.services ?? []).filter(s => s.actionable).map(s => s.name)
+    return [...new Set<string>([...staticCp, ...fetched])]
+  }, [cpList, staticCp])
+```
+
+- [ ] **Step 4: Run web tests and the typecheck**
+
+Run: `cd web && npm test` then `make build` (vitest does not typecheck).
+Expected: PASS both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/capabilities.ts web/src/pages/Logs.tsx web/src/pages/Logs.test.tsx
+git commit -m "feat(web): mode-aware control-plane targets on the Logs page"
+```
+
+---
+
+### Task 8: Frontend — "Run template" → "Mode" relabel
+
+**Files:**
+- Create: `web/src/lib/modeLabel.ts`
+- Create: `web/src/lib/modeLabel.test.ts`
+- Modify: `web/src/pages/Applications.tsx:96,113-124,168-170`
+- Modify: `web/src/pages/AppDetail.tsx:257-258` (add row), imports
+- Test: `web/src/pages/Applications.test.tsx`
+
+**Interfaces:**
+- Consumes: `AppSummary.source` / `AppSummary.isAspire` (`web/src/types/api.ts`).
+- Produces: `modeLabel(app: Pick<AppSummary, 'source' | 'isAspire'>): string` returning exactly `'Aspire' | 'Compose' | 'TestContainers' | 'Dapr run' | '—'`.
+
+- [ ] **Step 1: Write the failing helper test**
+
+Create `web/src/lib/modeLabel.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { modeLabel } from './modeLabel'
+
+describe('modeLabel', () => {
+  it('maps sources to pretty mode names', () => {
+    expect(modeLabel({ source: 'standalone' })).toBe('Dapr run')
+    expect(modeLabel({ source: 'compose' })).toBe('Compose')
+    expect(modeLabel({ source: 'testcontainers' })).toBe('TestContainers')
+    expect(modeLabel({ source: 'aspire' })).toBe('Aspire')
+  })
+  it('prefers the Aspire flag over the standalone source', () => {
+    expect(modeLabel({ source: 'standalone', isAspire: true })).toBe('Aspire')
+  })
+  it('falls back to a dash for unknown sources', () => {
+    expect(modeLabel({ source: undefined })).toBe('—')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd web && npm test -- src/lib/modeLabel.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `web/src/lib/modeLabel.ts`:
+
+```ts
+import type { AppSummary } from '../types/api'
+
+/**
+ * Pretty discovery-mode label for an instance. Maps the wire `source` values
+ * to the CLI mode names (standalone → "Dapr run", testcontainers →
+ * "TestContainers"); host-mode Aspire apps arrive with source 'standalone'
+ * and isAspire set, so the flag wins.
+ */
+export function modeLabel(app: Pick<AppSummary, 'source' | 'isAspire'>): string {
+  if (app.isAspire || app.source === 'aspire') return 'Aspire'
+  switch (app.source) {
+    case 'compose':
+      return 'Compose'
+    case 'testcontainers':
+      return 'TestContainers'
+    case 'standalone':
+      return 'Dapr run'
+    default:
+      return '—'
+  }
+}
+```
+
+(If `AppSummary.source`/`isAspire` are not optional in `web/src/types/api.ts`, adjust the `Pick` accordingly — do not change the API type.)
+
+- [ ] **Step 4: Relabel the Applications column**
+
+In `web/src/pages/Applications.tsx`: import `{ modeLabel }` from `'../lib/modeLabel'`; change line 96 `<th>Run template</th>` → `<th>Mode</th>`; delete the `sourceLabel` ternary (lines 116-124); replace the cell (lines 168-170):
+
+```tsx
+      <td
+        className="mono muted"
+        title={
+          app.runTemplate
+            ? `run template: ${app.runTemplate}`
+            : app.composeProject
+              ? `compose project: ${app.composeProject}`
+              : undefined
+        }
+      >
+        {modeLabel(app)}
+      </td>
+```
+
+- [ ] **Step 5: Add the Mode row on AppDetail**
+
+In `web/src/pages/AppDetail.tsx`, import `{ modeLabel }` from `'../lib/modeLabel'` and insert after the Runtime row (lines 257-258):
+
+```tsx
+            <div className="kk">Mode</div>
+            <div className="vv">{modeLabel(app)}</div>
+```
+
+- [ ] **Step 6: Update Applications tests and run everything**
+
+In `web/src/pages/Applications.test.tsx`, update any assertion on the `Run template` header to `Mode`, and any assertion expecting a run-template name or `Testcontainers` in that column to the new labels (`Dapr run`, `TestContainers`, …).
+
+Run: `cd web && npm test` then `make build`.
+Expected: PASS both.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/lib/modeLabel.ts web/src/lib/modeLabel.test.ts web/src/pages/Applications.tsx web/src/pages/AppDetail.tsx web/src/pages/Applications.test.tsx
+git commit -m "feat(web): relabel Run template column to Mode with pretty source names"
+```
+
+---
+
+### Task 9: Documentation and final verification
+
+**Files:**
+- Modify: `README.md:104,166-171` (and the aspire-mode sections that say `dapr`/`compose` are reserved)
+- Modify: `docs/aspire-discovery.md` (host-mode note)
+
+**Interfaces:** none — docs only.
+
+- [ ] **Step 1: Update README**
+
+Line 104's table row becomes:
+
+```markdown
+| `--mode` flag / `DEVDASHBOARD_MODE` env | `dapr-run`, `compose`, `test-containers`, `aspire` | unset (complete scan) |
+```
+
+Replace the mode paragraph at lines 166-171 with:
+
+```markdown
+With `--mode`/`DEVDASHBOARD_MODE` unset (the default for host use), the dashboard performs the
+complete scan across all discovery sources described above. Setting a mode restricts every
+dashboard surface — applications, workflows, state stores, the Control Plane view, and log
+targets — to a single source; filters are exclusive and never combined:
+
+- `--mode dapr-run` — host `dapr run` processes only (Control Plane shows the `dapr init` containers).
+- `--mode compose` — Docker Compose containers only (Control Plane shows compose-run placement/scheduler).
+- `--mode test-containers` — Testcontainers discovery only (no control-plane detection yet).
+- `--mode aspire` — Aspire resources only. Inside an AppHost-managed container (the
+  `DEVDASHBOARD_APP_*` contract is present) this is the container serving posture described
+  below; on a plain host it filters the process scan to Aspire-managed apps.
+
+`compose` and `test-containers` require a container runtime (docker or podman) and fail at
+startup without one. `--bind` (default `127.0.0.1`, `0.0.0.0` in aspire container posture)
+controls the listen address alongside `--port`.
+```
+
+Search the README for other "reserved for future" mode phrasing (`grep -n "reserved" README.md`) and align it.
+
+- [ ] **Step 2: Note the host posture in docs/aspire-discovery.md**
+
+Add a short section stating: `--mode aspire` without the `DEVDASHBOARD_APP_*` contract runs the dashboard on the host with normal host defaults and filters the standalone process scan to instances flagged `IsAspire` (DCP-proxy heuristic); the env-contract container flow is unchanged; heuristic limitations (apps without an app port are missed; stopped apps drop out) are listed in `docs/superpowers/specs/2026-07-13-mode-filter-design.md`.
+
+- [ ] **Step 3: Full verification**
+
+Run: `make build && make test`
+Expected: build succeeds, Go + web suites PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/aspire-discovery.md
+git commit -m "docs: document exclusive --mode discovery filters"
+```

--- a/docs/superpowers/specs/2026-07-13-mode-filter-design.md
+++ b/docs/superpowers/specs/2026-07-13-mode-filter-design.md
@@ -1,0 +1,171 @@
+# Exclusive `--mode` discovery filters
+
+**Date:** 2026-07-13
+**Status:** Approved
+
+## Goal
+
+Extend `--mode` / `DEVDASHBOARD_MODE` from the single `aspire` value to four
+**exclusive** single-source filters. A filter mode shows only resources
+discovered through that source — applications, workflows, state stores,
+control-plane services, and log sources alike. Filters are never combined.
+Mode unset stays the complete scan across all sources (today's behavior).
+
+| CLI value | Discovery source | Pretty UI label |
+|---|---|---|
+| `dapr-run` | host `dapr run` process scan (`StandaloneScanner`) | Dapr run |
+| `compose` | Docker Compose container discovery | Compose |
+| `test-containers` | Testcontainers container discovery | TestContainers |
+| `aspire` | Aspire-managed resources (see dual posture below) | Aspire |
+| *(unset)* | all of the above | — |
+
+CLI values are user-facing names and intentionally differ from the discovery
+`Source` wire values (`standalone`, `testcontainers`); the mapping is
+deliberate, do not unify them.
+
+## Background
+
+- Mode plumbing: [`cmd/mode.go`](../../../cmd/mode.go) (`resolveMode`,
+  `resolveServeSettings`), consumed by [`cmd/root.go`](../../../cmd/root.go)
+  `runServe`, which today has two branches: `ModeAspire` (env-contract scanner
+  + container posture) and default (merge of standalone + compose +
+  testcontainers scanners, plus the aspire env-contract scanner when
+  `discovery.AspireContractPresent`).
+- All app-derived state (workflows, state-store election, stats, resources)
+  flows from the merged `discovery.Service`, so filtering the scanner set
+  filters those surfaces automatically.
+- The Control Plane view and the Logs view's control-plane targets do **not**
+  flow from discovery and need their own filtering (below).
+
+## Design
+
+### 1. Mode values and validation
+
+`cmd/mode.go` gains `ModeDaprRun("dapr-run")`, `ModeCompose("compose")`,
+`ModeTestcontainers("test-containers")` alongside the existing `ModeAspire`.
+`resolveMode` accepts the four values (flag wins over env, unset =
+`ModeDefault`); anything else errors at startup naming the supported values.
+
+### 2. `aspire` gets dual posture
+
+`--mode aspire` currently conflates *which resources* with *where the
+dashboard runs*. The split:
+
+- **Env contract present** (`DEVDASHBOARD_APP_COUNT` set →
+  `discovery.AspireContractPresent`): today's behavior, unchanged. The
+  dashboard is the AppHost-managed container: env-contract scanner, container
+  posture (port 8080, bind 0.0.0.0, no home-dir registry, no browser open,
+  relaxed Host guard).
+- **Contract absent**: new. The dashboard runs standalone on the host with
+  normal **host posture** (port 9090, bind 127.0.0.1, browser open, registry
+  persisted) and scans Aspire resources locally: the standalone process scan
+  runs, and results are filtered post-enrichment to instances flagged
+  `IsAspire` (the DCP-proxy heuristic in
+  [`pkg/discovery/appproc.go`](../../../pkg/discovery/appproc.go)
+  `appRuntime`). `IsAspire` is an enrichment-time signal, so this is a
+  `discovery.Service` wrapper (filtered `List`, `Get` returns `ErrNotFound`
+  for non-aspire keys) applied outside the lifecycle overlay — every consumer
+  sees the filtered view.
+
+Container-posture decisions (`resolveServeSettings` defaults, home dir,
+browser open, `AllowNonLoopback`, `QuietRegistry`, the non-loopback bind
+warning) key on `containerPosture = mode == ModeAspire && contractPresent`,
+not on the mode alone.
+
+### 3. Scanner selection per mode (host posture)
+
+| Mode | Scanners | Companion deps |
+|---|---|---|
+| unset | standalone + compose + testcontainers (+ env contract if present) | composeEnv, containerLogs, extraRes, all |
+| `dapr-run` | standalone | none of the container deps |
+| `compose` | compose | composeEnv, containerLogs |
+| `test-containers` | testcontainers | extraRes, containerLogs |
+| `aspire` (host) | standalone + `IsAspire` post-filter | none of the container deps |
+
+Lifecycle overlay/manager, update check, news, and full host capabilities stay
+enabled in every host mode.
+
+**Fail-fast:** `compose` and `test-containers` are exclusively
+container-backed; when `containerruntime.Detect()` finds no runtime, startup
+**fails** with an error naming the mode and the requirement (docker/podman on
+PATH, or `DASH_CONTAINER_RUNTIME`). A silent, permanently empty dashboard is
+not acceptable in an exclusive mode. Mode unset keeps today's degrade-to-empty
+behavior.
+
+### 4. Control Plane view filtering
+
+[`pkg/controlplane`](../../../pkg/controlplane/service.go) lists two
+families: the fixed `dapr init` containers (`LiveServiceNames`:
+`dapr_placement`, `dapr_scheduler`) and compose-labeled placement/scheduler
+containers (`composeControlPlane`). The manager gains a `Sources` selector
+(`Init`, `Compose` booleans) that gates both `List` **and** the
+`Do`/`LogStream` action allowlist:
+
+| Mode | Control-plane families |
+|---|---|
+| unset | Init + Compose (today) |
+| `dapr-run` | Init only |
+| `compose` | Compose only |
+| `test-containers` | none — honest empty state (detection **deferred to next iteration**) |
+| `aspire` (host) | Init only (CommunityToolkit sidecars use the `dapr init` containers; verify on a real AppHost) |
+| `aspire` (container) | n/a — capabilities already hide the view |
+
+### 5. Logs view filtering
+
+- The app target list comes from `/api/apps` → filtered automatically.
+- The control-plane target list merges a static `dapr_*` fallback
+  ([`web/src/pages/Logs.tsx`](../../../web/src/pages/Logs.tsx) `CP_SERVICES`)
+  with `/api/controlplane`. The fetch is filtered server-side by (4); the
+  static fallback must be mode-aware. The server-injected
+  `window.__DASH_CAPABILITIES__` blob gains a `mode` field (the CLI value; ""
+  = complete scan), and Logs includes the static `dapr_*` fallback only for
+  modes `""`, `dapr-run`, `aspire`. This is not a UI filter control — the UI
+  merely learns what the server was started with.
+
+### 6. "Run template" → "Mode" relabel
+
+- [`web/src/pages/Applications.tsx`](../../../web/src/pages/Applications.tsx)
+  column header **Run template** becomes **Mode**. The cell value becomes a
+  pure identity→label mapping (new shared helper `web/src/lib/modeLabel.ts`):
+  `isAspire || source === 'aspire'` → **Aspire** (checked first — host-mode
+  Aspire apps arrive with `source: 'standalone'`), `compose` → **Compose**,
+  `testcontainers` → **TestContainers** (casing change from today's
+  "Testcontainers"), `standalone` → **Dapr run**.
+- The run-template name (`app.runTemplate`) keeps a tooltip slot on the Mode
+  cell instead of the cell text.
+- [`web/src/pages/AppDetail.tsx`](../../../web/src/pages/AppDetail.tsx) gains
+  an explicit **Mode** row in the application identity card using the same
+  helper (today the source shows only implicitly via Compose project /
+  Session / CLI PID rows).
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| No container runtime in `compose` / `test-containers` mode | **Fail at startup** with a clear error |
+| Testcontainers control-plane detection (`org.testcontainers` labels) | **Deferred to next iteration**; empty state in v1 |
+| Aspire host-mode control-plane family | Init containers, same as `dapr-run` |
+| UI filter control | None — mode is CLI/env only |
+| Pretty labels | `Dapr run`, `Compose`, `TestContainers`, `Aspire` |
+
+## Known limitations (accepted for v1)
+
+- **Aspire host filter rides on a heuristic.** `IsAspire` requires daprd to
+  carry no app command and the app-port listener to be the DCP proxy; apps
+  with `AppPort == 0` are invisible in aspire host mode. A stopped aspire
+  app's ghost loses its DCP proxy, so it disappears from the filtered list
+  instead of showing as stopped. The long-term fix is the resource-service
+  gRPC scanner from
+  [2026-07-13-aspire-discovery-alternatives.md](2026-07-13-aspire-discovery-alternatives.md),
+  which would slot into this mode's source slot.
+- **Aspire-launched containers** (e.g. Redis) carry no matchable labels and
+  are not discovered in aspire host mode — same future fix.
+- **`test-containers` Control Plane view is empty** until label-based
+  detection lands (deferred).
+
+## Out of scope
+
+- Combining filters (explicitly never supported).
+- Any UI control to switch modes at runtime.
+- Testcontainers control-plane detection (next iteration).
+- Resource-service gRPC aspire scanner (separate spec).

--- a/pkg/controlplane/service.go
+++ b/pkg/controlplane/service.go
@@ -34,19 +34,20 @@ type Manager interface {
 type manager struct {
 	runtime RuntimeKind
 	run     containerruntime.Runner
+	src     Sources
 
 	mu           sync.Mutex
 	composeNames map[string]bool // compose CP containers found by the last List
 }
 
 // New resolves the container runtime from the environment and PATH.
-func New() Manager {
+func New(src Sources) Manager {
 	kind, run := containerruntime.Detect()
-	return newManager(kind, run)
+	return newManager(kind, run, src)
 }
 
-func newManager(kind RuntimeKind, run containerruntime.Runner) *manager {
-	return &manager{runtime: kind, run: run}
+func newManager(kind RuntimeKind, run containerruntime.Runner, src Sources) *manager {
+	return &manager{runtime: kind, run: run, src: src}
 }
 
 func (m *manager) List(ctx context.Context) (ListResult, error) {
@@ -57,12 +58,19 @@ func (m *manager) List(ctx context.Context) (ListResult, error) {
 	if _, err := m.run.Run(ctx, "info"); err != nil {
 		return ListResult{Runtime: m.runtime, Available: true, Reachable: false}, nil
 	}
-	composeSvcs := m.composeControlPlane(ctx)
-	statNames := append(append([]string{}, LiveServiceNames...), serviceNames(composeSvcs)...)
+	var composeSvcs []Service
+	if m.src.Compose {
+		composeSvcs = m.composeControlPlane(ctx)
+	}
+	var liveNames []string
+	if m.src.Init {
+		liveNames = LiveServiceNames
+	}
+	statNames := append(append([]string{}, liveNames...), serviceNames(composeSvcs)...)
 	mem := m.memory(ctx, statNames)
-	services := make([]Service, 0, len(LiveServiceNames)+len(composeSvcs))
+	services := make([]Service, 0, len(liveNames)+len(composeSvcs))
 	present := false
-	for _, name := range LiveServiceNames {
+	for _, name := range liveNames {
 		svc := Service{Name: name, Status: StatusStopped, Actionable: true}
 		out, err := m.run.Run(ctx, "inspect", name)
 		if err == nil {
@@ -159,11 +167,16 @@ func (m *manager) isComposeName(name string) bool {
 	return m.composeNames[name]
 }
 
+// allowed reports whether name belongs to a family this manager serves.
+func (m *manager) allowed(name string) bool {
+	return (m.src.Init && IsLiveName(name)) || (m.src.Compose && m.isComposeName(name))
+}
+
 func (m *manager) Do(ctx context.Context, action, name string) error {
 	if !ValidAction(action) {
 		return ErrInvalidAction
 	}
-	if !IsLiveName(name) && !m.isComposeName(name) {
+	if !m.allowed(name) {
 		return ErrUnknownService
 	}
 	if m.runtime == RuntimeNone {
@@ -174,7 +187,7 @@ func (m *manager) Do(ctx context.Context, action, name string) error {
 }
 
 func (m *manager) LogStream(ctx context.Context, name string) (<-chan string, error) {
-	if !IsLiveName(name) && !m.isComposeName(name) {
+	if !m.allowed(name) {
 		return nil, ErrUnknownService
 	}
 	if m.runtime == RuntimeNone {

--- a/pkg/controlplane/service.go
+++ b/pkg/controlplane/service.go
@@ -67,7 +67,14 @@ func (m *manager) List(ctx context.Context) (ListResult, error) {
 		liveNames = LiveServiceNames
 	}
 	statNames := append(append([]string{}, liveNames...), serviceNames(composeSvcs)...)
-	mem := m.memory(ctx, statNames)
+	// docker stats --no-stream with zero names samples ALL running containers
+	// (a ~1-2s block) and the result would be discarded anyway — skip the call
+	// entirely rather than pay that cost every poll (e.g. Sources{} in
+	// test-containers mode, where neither Init nor Compose containers exist).
+	mem := map[string]memStat{}
+	if len(statNames) > 0 {
+		mem = m.memory(ctx, statNames)
+	}
 	services := make([]Service, 0, len(liveNames)+len(composeSvcs))
 	present := false
 	for _, name := range liveNames {

--- a/pkg/controlplane/service_test.go
+++ b/pkg/controlplane/service_test.go
@@ -323,6 +323,30 @@ func TestListEmptySourcesIsHonestEmpty(t *testing.T) {
 	}
 }
 
+func TestListEmptySourcesNeverCallsStats(t *testing.T) {
+	// docker stats --no-stream with no names samples ALL running containers
+	// (~1-2s block) and the result would be discarded — with Sources{} (e.g.
+	// test-containers mode) List must skip the call entirely. Deliberately
+	// give the fakeRunner NO "stats --no-stream" output key: if List called
+	// it anyway, memory() would just return an empty map (masking the bug),
+	// so we additionally assert on f.calls that the runner was never invoked
+	// with a stats command.
+	f := &fakeRunner{outputs: map[string][]byte{"info": []byte("ok")}}
+	m := newManager(RuntimeDocker, f, Sources{})
+	res, err := m.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Available || !res.Reachable || len(res.Services) != 0 {
+		t.Fatalf("want available+reachable with zero services, got %+v", res)
+	}
+	for _, call := range f.calls {
+		if len(call) > 0 && call[0] == "stats" {
+			t.Fatalf("List invoked stats with Sources{}, want no stats call: %v", call)
+		}
+	}
+}
+
 func TestDoAndLogStreamRespectSources(t *testing.T) {
 	m := newManager(RuntimeDocker, &fakeRunner{outputs: map[string][]byte{}}, Sources{Compose: true})
 	if err := m.Do(context.Background(), "restart", "dapr_placement"); !errors.Is(err, ErrUnknownService) {

--- a/pkg/controlplane/service_test.go
+++ b/pkg/controlplane/service_test.go
@@ -40,7 +40,7 @@ func (f *fakeRunner) Stream(_ context.Context, args ...string) (<-chan string, e
 }
 
 func TestListUnavailableWhenNoRuntime(t *testing.T) {
-	m := newManager(RuntimeNone, nil)
+	m := newManager(RuntimeNone, nil, AllSources())
 	res, err := m.List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
@@ -60,7 +60,7 @@ func TestListRunningService(t *testing.T) {
 			"stats --no-stream":      stats,
 		},
 	}
-	m := newManager(RuntimeDocker, f)
+	m := newManager(RuntimeDocker, f, AllSources())
 	res, err := m.List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
@@ -87,11 +87,11 @@ func TestListRunningService(t *testing.T) {
 }
 
 func TestLogStreamValidation(t *testing.T) {
-	m := newManager(RuntimeDocker, &fakeRunner{outputs: map[string][]byte{}})
+	m := newManager(RuntimeDocker, &fakeRunner{outputs: map[string][]byte{}}, AllSources())
 	if _, err := m.LogStream(context.Background(), "dapr_redis"); err != ErrUnknownService {
 		t.Errorf("unknown name: got %v, want ErrUnknownService", err)
 	}
-	none := newManager(RuntimeNone, nil)
+	none := newManager(RuntimeNone, nil, AllSources())
 	if _, err := none.LogStream(context.Background(), "dapr_scheduler"); err != ErrRuntimeUnavailable {
 		t.Errorf("no runtime: got %v, want ErrRuntimeUnavailable", err)
 	}
@@ -99,7 +99,7 @@ func TestLogStreamValidation(t *testing.T) {
 
 func TestLogStreamEmitsLines(t *testing.T) {
 	f := &fakeRunner{streamLines: []string{"line one", "line two"}}
-	m := newManager(RuntimeDocker, f)
+	m := newManager(RuntimeDocker, f, AllSources())
 	ch, err := m.LogStream(context.Background(), "dapr_scheduler")
 	if err != nil {
 		t.Fatalf("LogStream: %v", err)
@@ -124,7 +124,7 @@ func TestListUnreachableDaemon(t *testing.T) {
 			"info": errors.New("cannot connect to docker daemon"),
 		},
 	}
-	m := newManager(RuntimeDocker, f)
+	m := newManager(RuntimeDocker, f, AllSources())
 	res, err := m.List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
@@ -151,7 +151,7 @@ func TestListReachableButNoContainers(t *testing.T) {
 			"inspect dapr_placement": errors.New("no such container"),
 		},
 	}
-	m := newManager(RuntimeDocker, f)
+	m := newManager(RuntimeDocker, f, AllSources())
 	res, err := m.List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
@@ -191,7 +191,7 @@ func TestListIncludesComposeControlPlane(t *testing.T) {
 			"stats --no-stream": stats,
 		},
 	}
-	m := newManager(RuntimeDocker, f)
+	m := newManager(RuntimeDocker, f, AllSources())
 	res, err := m.List(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -227,7 +227,7 @@ func TestDoAllowsDiscoveredComposeNames(t *testing.T) {
 			"stats --no-stream": stats,
 		},
 	}
-	m := newManager(RuntimeDocker, f)
+	m := newManager(RuntimeDocker, f, AllSources())
 	// Call List first to populate the allowlist.
 	if _, err := m.List(context.Background()); err != nil {
 		t.Fatal(err)
@@ -250,7 +250,7 @@ func TestDoRejectsComposeNamesBeforeList(t *testing.T) {
 	f := &fakeRunner{
 		outputs: map[string][]byte{},
 	}
-	m := newManager(RuntimeDocker, f)
+	m := newManager(RuntimeDocker, f, AllSources())
 	// No List call — compose names must be rejected.
 	if err := m.Do(context.Background(), "restart", "saga-placement-1"); !errors.Is(err, ErrUnknownService) {
 		t.Errorf("before List: got %v, want ErrUnknownService", err)
@@ -259,7 +259,7 @@ func TestDoRejectsComposeNamesBeforeList(t *testing.T) {
 
 func TestDoValidation(t *testing.T) {
 	f := &fakeRunner{outputs: map[string][]byte{}}
-	m := newManager(RuntimeDocker, f)
+	m := newManager(RuntimeDocker, f, AllSources())
 	if err := m.Do(context.Background(), "kill", "dapr_scheduler"); !errors.Is(err, ErrInvalidAction) {
 		t.Errorf("kill: got %v, want ErrInvalidAction", err)
 	}
@@ -272,5 +272,63 @@ func TestDoValidation(t *testing.T) {
 	last := f.calls[len(f.calls)-1]
 	if last[0] != "restart" || last[1] != "dapr_scheduler" {
 		t.Errorf("ran %v, want [restart dapr_scheduler]", last)
+	}
+}
+
+func TestListInitOnlyExcludesCompose(t *testing.T) {
+	f := &fakeRunner{outputs: map[string][]byte{
+		"info":                   []byte("ok"),
+		"inspect dapr_scheduler": []byte("[]"),
+		"inspect dapr_placement": []byte("[]"),
+	}}
+	m := newManager(RuntimeDocker, f, Sources{Init: true})
+	res, err := m.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, s := range res.Services {
+		if s.ComposeProject != "" {
+			t.Fatalf("init-only sources must not list compose services, got %+v", s)
+		}
+	}
+	if len(res.Services) != len(LiveServiceNames) {
+		t.Fatalf("want the %d init services, got %d", len(LiveServiceNames), len(res.Services))
+	}
+}
+
+func TestListComposeOnlyExcludesInit(t *testing.T) {
+	f := &fakeRunner{outputs: map[string][]byte{
+		"info":   []byte("ok"),
+		"ps -aq": []byte(""), // no compose containers running
+	}}
+	m := newManager(RuntimeDocker, f, Sources{Compose: true})
+	res, err := m.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Services) != 0 {
+		t.Fatalf("compose-only sources must not list the dapr_* init services, got %+v", res.Services)
+	}
+}
+
+func TestListEmptySourcesIsHonestEmpty(t *testing.T) {
+	f := &fakeRunner{outputs: map[string][]byte{"info": []byte("ok")}}
+	m := newManager(RuntimeDocker, f, Sources{})
+	res, err := m.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Available || !res.Reachable || len(res.Services) != 0 {
+		t.Fatalf("want available+reachable with zero services, got %+v", res)
+	}
+}
+
+func TestDoAndLogStreamRespectSources(t *testing.T) {
+	m := newManager(RuntimeDocker, &fakeRunner{outputs: map[string][]byte{}}, Sources{Compose: true})
+	if err := m.Do(context.Background(), "restart", "dapr_placement"); !errors.Is(err, ErrUnknownService) {
+		t.Fatalf("Do must reject a filtered-out init service, got %v", err)
+	}
+	if _, err := m.LogStream(context.Background(), "dapr_scheduler"); !errors.Is(err, ErrUnknownService) {
+		t.Fatalf("LogStream must reject a filtered-out init service, got %v", err)
 	}
 }

--- a/pkg/controlplane/types.go
+++ b/pkg/controlplane/types.go
@@ -40,6 +40,17 @@ func IsLiveName(name string) bool {
 	return contains(LiveServiceNames, name)
 }
 
+// Sources selects which control-plane families List reports and Do/LogStream
+// accept. The zero value shows nothing — e.g. test-containers mode, which has
+// no control-plane detection yet (deferred to a future iteration).
+type Sources struct {
+	Init    bool // fixed dapr_* containers created by `dapr init`
+	Compose bool // compose-labeled placement/scheduler containers
+}
+
+// AllSources is the mode-unset default: every family.
+func AllSources() Sources { return Sources{Init: true, Compose: true} }
+
 // ValidAction reports whether action is one of the allowed lifecycle verbs.
 func ValidAction(action string) bool {
 	switch action {

--- a/pkg/discovery/filter.go
+++ b/pkg/discovery/filter.go
@@ -1,0 +1,38 @@
+package discovery
+
+import "context"
+
+// FilterAspire restricts a Service to Aspire-managed instances. Aspire host
+// mode (dashboard on the host, no env contract) scans the full process table
+// — IsAspire is only known after enrichment (the DCP-proxy heuristic in
+// appproc.go), so the filter must wrap the Service rather than the Scanner.
+// Wrap the outermost Service (after the lifecycle overlay) so every consumer
+// — apps API, workflows, state-store election — sees the filtered view.
+func FilterAspire(inner Service) Service { return aspireOnly{inner: inner} }
+
+type aspireOnly struct{ inner Service }
+
+func (a aspireOnly) List(ctx context.Context) ([]Instance, error) {
+	all, err := a.inner.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Instance, 0, len(all))
+	for _, in := range all {
+		if in.IsAspire {
+			out = append(out, in)
+		}
+	}
+	return out, nil
+}
+
+func (a aspireOnly) Get(ctx context.Context, key string) (Instance, error) {
+	in, err := a.inner.Get(ctx, key)
+	if err != nil {
+		return Instance{}, err
+	}
+	if !in.IsAspire {
+		return Instance{}, ErrNotFound
+	}
+	return in, nil
+}

--- a/pkg/discovery/filter_test.go
+++ b/pkg/discovery/filter_test.go
@@ -1,0 +1,52 @@
+//go:build unit
+
+package discovery
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fakeFilterInner struct{ instances []Instance }
+
+func (f fakeFilterInner) List(context.Context) ([]Instance, error) { return f.instances, nil }
+
+func (f fakeFilterInner) Get(_ context.Context, key string) (Instance, error) {
+	for _, in := range f.instances {
+		if in.AppID == key {
+			return in, nil
+		}
+	}
+	return Instance{}, ErrNotFound
+}
+
+func newAspireFiltered() Service {
+	return FilterAspire(fakeFilterInner{instances: []Instance{
+		{AppID: "checkout", IsAspire: true},
+		{AppID: "plain-daprd", IsAspire: false},
+	}})
+}
+
+func TestFilterAspireListKeepsOnlyAspire(t *testing.T) {
+	got, err := newAspireFiltered().List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].AppID != "checkout" {
+		t.Fatalf("want only the aspire instance, got %+v", got)
+	}
+}
+
+func TestFilterAspireGet(t *testing.T) {
+	svc := newAspireFiltered()
+	if _, err := svc.Get(context.Background(), "checkout"); err != nil {
+		t.Fatalf("aspire instance must resolve: %v", err)
+	}
+	if _, err := svc.Get(context.Background(), "plain-daprd"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("non-aspire instance must be ErrNotFound, got %v", err)
+	}
+	if _, err := svc.Get(context.Background(), "missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unknown key must stay ErrNotFound, got %v", err)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -64,6 +64,10 @@ type Capabilities struct {
 	ControlPlane bool `json:"controlPlane"`
 	Logs         bool `json:"logs"`
 	Workflows    bool `json:"workflows"`
+	// Mode echoes the CLI --mode value ("" = complete scan) so the SPA can
+	// adapt static fallbacks (e.g. the Logs page's dapr_* targets) to the
+	// server's discovery filter.
+	Mode string `json:"mode"`
 }
 
 // FullCapabilities is the host-mode default: everything on.

--- a/pkg/server/spa.go
+++ b/pkg/server/spa.go
@@ -61,7 +61,7 @@ func serveIndex(w http.ResponseWriter, _ *http.Request, fsys fs.FS, telemetryEna
 	if telemetryEnabled {
 		flag = "true"
 	}
-	// caps is a bool-only struct, so marshaling cannot fail.
+	// caps holds only bools and a plain string, so marshaling cannot fail.
 	capsJSON, _ := json.Marshal(caps)
 	// strconv.Quote produces a safely-escaped JS string literal for the version.
 	script := []byte("<script>window.__DASH_TELEMETRY_ENABLED__=" + flag +

--- a/pkg/server/spa_test.go
+++ b/pkg/server/spa_test.go
@@ -99,7 +99,7 @@ func TestServeIndexInjectsCapabilities(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	h.ServeHTTP(rec, req)
 	body := rec.Body.String()
-	want := `window.__DASH_CAPABILITIES__={"lifecycle":false,"controlPlane":false,"logs":false,"workflows":true}`
+	want := `window.__DASH_CAPABILITIES__={"lifecycle":false,"controlPlane":false,"logs":false,"workflows":true,"mode":""}`
 	if !strings.Contains(body, want) {
 		t.Fatalf("body missing %q:\n%s", want, body)
 	}

--- a/web/src/lib/capabilities.test.ts
+++ b/web/src/lib/capabilities.test.ts
@@ -28,8 +28,10 @@ describe('getCapabilities', () => {
       controlPlane: false,
       logs: false,
       workflows: true,
+      mode: 'compose',
     }
     expect(getCapabilities().lifecycle).toBe(false)
     expect(getCapabilities().workflows).toBe(true)
+    expect(getCapabilities().mode).toBe('compose')
   })
 })

--- a/web/src/lib/capabilities.test.ts
+++ b/web/src/lib/capabilities.test.ts
@@ -18,6 +18,7 @@ describe('getCapabilities', () => {
       controlPlane: true,
       logs: true,
       workflows: true,
+      mode: '',
     })
   })
 

--- a/web/src/lib/capabilities.ts
+++ b/web/src/lib/capabilities.ts
@@ -3,6 +3,8 @@ export interface Capabilities {
   controlPlane: boolean
   logs: boolean
   workflows: boolean
+  /** CLI --mode value ('' = complete scan); lets the UI adapt static fallbacks. */
+  mode?: string
 }
 
 declare global {
@@ -11,7 +13,7 @@ declare global {
   }
 }
 
-const FULL: Capabilities = { lifecycle: true, controlPlane: true, logs: true, workflows: true }
+const FULL: Capabilities = { lifecycle: true, controlPlane: true, logs: true, workflows: true, mode: '' }
 
 // getCapabilities reads the server-injected capability flags. Absent flag
 // (Vite dev server, tests) means everything on — matching the host-mode

--- a/web/src/lib/modeLabel.test.ts
+++ b/web/src/lib/modeLabel.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { modeLabel } from './modeLabel'
+
+describe('modeLabel', () => {
+  it('maps sources to pretty mode names', () => {
+    expect(modeLabel({ source: 'standalone' })).toBe('Dapr run')
+    expect(modeLabel({ source: 'compose' })).toBe('Compose')
+    expect(modeLabel({ source: 'testcontainers' })).toBe('TestContainers')
+    expect(modeLabel({ source: 'aspire' })).toBe('Aspire')
+  })
+  it('prefers the Aspire flag over the standalone source', () => {
+    expect(modeLabel({ source: 'standalone', isAspire: true })).toBe('Aspire')
+  })
+  it('falls back to a dash for unknown sources', () => {
+    expect(modeLabel({ source: undefined })).toBe('—')
+  })
+})

--- a/web/src/lib/modeLabel.ts
+++ b/web/src/lib/modeLabel.ts
@@ -1,0 +1,21 @@
+import type { AppSummary } from '../types/api'
+
+/**
+ * Pretty discovery-mode label for an instance. Maps the wire `source` values
+ * to the CLI mode names (standalone → "Dapr run", testcontainers →
+ * "TestContainers"); host-mode Aspire apps arrive with source 'standalone'
+ * and isAspire set, so the flag wins.
+ */
+export function modeLabel(app: Pick<AppSummary, 'source' | 'isAspire'>): string {
+  if (app.isAspire || app.source === 'aspire') return 'Aspire'
+  switch (app.source) {
+    case 'compose':
+      return 'Compose'
+    case 'testcontainers':
+      return 'TestContainers'
+    case 'standalone':
+      return 'Dapr run'
+    default:
+      return '—'
+  }
+}

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -12,6 +12,7 @@ import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { appKey } from '../lib/appKey'
 import { formatUptime, useNow } from '../lib/uptime'
 import { getCapabilities } from '../lib/capabilities'
+import { modeLabel } from '../lib/modeLabel'
 
 // ---------- content ----------
 
@@ -256,6 +257,9 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
 
             <div className="kk">Runtime</div>
             <div className="vv">{app.runtime || <span className="faint">—</span>}</div>
+
+            <div className="kk">Mode</div>
+            <div className="vv">{modeLabel(app)}</div>
 
             <div className="kk">App port</div>
             <div className="vv mono">{app.appPort || <span className="faint">—</span>}</div>

--- a/web/src/pages/Applications.test.tsx
+++ b/web/src/pages/Applications.test.tsx
@@ -82,8 +82,8 @@ describe('Applications', () => {
     expect(screen.getAllByText(/^healthy$/i).length).toBeGreaterThanOrEqual(1)
     expect(screen.getAllByText(/^starting$/i).length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText('Unhealthy')).toBeInTheDocument()
-    // The run-template stat card is gone; only the table column header remains.
-    expect(screen.getAllByText(/run template/i)).toHaveLength(1)
+    // The run-template stat card is gone; only the Mode table column header remains.
+    expect(screen.getAllByText(/^mode$/i)).toHaveLength(1)
   })
 
   it('unhealthy stat shows 0 without the bad class when all apps are fine', async () => {
@@ -145,7 +145,7 @@ describe('Applications', () => {
       { ...baseApp, appId: 'workflow-patterns-app', source: 'testcontainers', runTemplate: '' },
     ])
     renderAt()
-    const cells = await screen.findAllByText('Testcontainers')
+    const cells = await screen.findAllByText('TestContainers')
     expect(cells.length).toBeGreaterThanOrEqual(1)
   })
 

--- a/web/src/pages/Applications.tsx
+++ b/web/src/pages/Applications.tsx
@@ -4,6 +4,7 @@ import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { runtimeSwatch } from '../lib/runtimeSwatch'
 import { appKey } from '../lib/appKey'
 import { appDisplayState } from '../lib/appDisplayState'
+import { modeLabel } from '../lib/modeLabel'
 import type { AppSummary } from '../types/api'
 
 // Fully stopped: both the app process/container and its daprd sidecar report 'stopped'.
@@ -93,7 +94,7 @@ export function Applications() {
                 <th>daprd PID</th>
                 <th>App PID</th>
                 <th>Age</th>
-                <th>Run template</th>
+                <th>Mode</th>
                 <th></th>
               </tr>
             </thead>
@@ -113,15 +114,6 @@ export function Applications() {
 function AppRow({ app, onOpen }: { app: AppSummary; onOpen: () => void }) {
   const num = (v: number) =>
     v ? <td className="mono tabnum">{v}</td> : <td className="mono tabnum faint">—</td>
-  const sourceLabel =
-    app.runTemplate ||
-    (app.isAspire
-      ? 'Aspire'
-      : app.source === 'compose'
-        ? 'Compose'
-        : app.source === 'testcontainers'
-          ? 'Testcontainers'
-          : '—')
   const state = appDisplayState(app)
   const unreachable = app.source === 'compose' && app.sidecarReachable === false && app.daprdStatus !== 'stopped'
   const key = appKey(app)
@@ -165,8 +157,17 @@ function AppRow({ app, onOpen }: { app: AppSummary; onOpen: () => void }) {
       {num(app.daprdPid)}
       {num(app.appPid)}
       <td className="muted mono tabnum">{app.age}</td>
-      <td className="mono muted" title={app.composeProject ? `compose project: ${app.composeProject}` : undefined}>
-        {sourceLabel}
+      <td
+        className="mono muted"
+        title={
+          app.runTemplate
+            ? `run template: ${app.runTemplate}`
+            : app.composeProject
+              ? `compose project: ${app.composeProject}`
+              : undefined
+        }
+      >
+        {modeLabel(app)}
       </td>
       <td className="kebab">⋯</td>
     </tr>

--- a/web/src/pages/ControlPlane.test.tsx
+++ b/web/src/pages/ControlPlane.test.tsx
@@ -45,6 +45,34 @@ describe('ControlPlane', () => {
     expect(await screen.findByText(/no dapr control plane found/i)).toBeInTheDocument()
   })
 
+  it('shows test-containers-specific copy (no dapr init suggestion) in test-containers mode', async () => {
+    window.__DASH_CAPABILITIES__ = { lifecycle: true, controlPlane: true, logs: true, workflows: true, mode: 'test-containers' }
+    try {
+      mockList({ runtime: 'docker', available: true, reachable: true, controlPlanePresent: false, services: [] })
+      renderPage()
+      expect(
+        await screen.findByText(/control-plane detection is not available in test-containers mode/i),
+      ).toBeInTheDocument()
+      expect(screen.queryByText(/dapr init/i)).not.toBeInTheDocument()
+    } finally {
+      delete window.__DASH_CAPABILITIES__
+    }
+  })
+
+  it('shows compose-specific copy (no dapr init suggestion) in compose mode', async () => {
+    window.__DASH_CAPABILITIES__ = { lifecycle: true, controlPlane: true, logs: true, workflows: true, mode: 'compose' }
+    try {
+      mockList({ runtime: 'docker', available: true, reachable: true, controlPlanePresent: false, services: [] })
+      renderPage()
+      expect(
+        await screen.findByText(/no compose-managed placement\/scheduler containers were found/i),
+      ).toBeInTheDocument()
+      expect(screen.queryByText(/dapr init/i)).not.toBeInTheDocument()
+    } finally {
+      delete window.__DASH_CAPABILITIES__
+    }
+  })
+
   it('renders a running service with a Restart action', async () => {
     mockList({
       runtime: 'docker', available: true, reachable: true, controlPlanePresent: true,

--- a/web/src/pages/ControlPlane.tsx
+++ b/web/src/pages/ControlPlane.tsx
@@ -2,8 +2,27 @@ import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 import { useControlPlane, useControlPlaneAction } from '../hooks/useControlPlane'
+import { getCapabilities } from '../lib/capabilities'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
 import type { ControlPlaneService, ControlPlaneAction } from '../types/controlplane'
+
+// noControlPlaneCopy tailors the "no control plane found" message to the
+// active discovery mode: test-containers has no dapr_* containers to find and
+// no compose-managed placement/scheduler containers to look for either, so
+// suggesting `dapr init` would be actively misleading in both cases.
+function noControlPlaneCopy(mode: string | undefined) {
+  if (mode === 'test-containers') {
+    return 'Control-plane detection is not available in test-containers mode yet.'
+  }
+  if (mode === 'compose') {
+    return 'No compose-managed placement/scheduler containers were found.'
+  }
+  return (
+    <>
+      No Dapr control plane found. Run <span className="mono">dapr init</span> to start it.
+    </>
+  )
+}
 
 export function ControlPlane() {
   useDocumentTitle('Control Plane')
@@ -48,12 +67,11 @@ export function ControlPlane() {
   }
 
   if (data.available && data.reachable && !data.controlPlanePresent) {
+    const mode = getCapabilities().mode
     return (
       <div className="page">
         {header}
-        <p className="muted">
-          No Dapr control plane found. Run <span className="mono">dapr init</span> to start it.
-        </p>
+        <p className="muted">{noControlPlaneCopy(mode)}</p>
       </div>
     )
   }

--- a/web/src/pages/Logs.test.tsx
+++ b/web/src/pages/Logs.test.tsx
@@ -906,6 +906,39 @@ describe('Logs', () => {
     expect(names.filter(n => n === 'dapr_placement')).toHaveLength(1)
   })
 
+  // Mode-aware static fallback: only host-mode-ish modes (complete scan / dapr-run
+  // / aspire) get the dapr_* fallback entries — compose (and test-containers) must
+  // not offer them, since those sidecars never run as `dapr init` containers.
+  it('CP — compose mode omits the static dapr_* control-plane targets', async () => {
+    window.__DASH_CAPABILITIES__ = { lifecycle: true, controlPlane: true, logs: true, workflows: true, mode: 'compose' }
+    try {
+      server.use(
+        http.get('/api/apps', () => HttpResponse.json([])),
+        http.get('/api/controlplane', () => HttpResponse.json({ ...CP_LIST_BASE, services: [] })),
+      )
+
+      renderAt('/logs')
+
+      await waitFor(() => expect(screen.getByRole('heading', { name: 'Logs' })).toBeInTheDocument())
+      expect(screen.queryByRole('option', { name: 'dapr_scheduler' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('option', { name: 'dapr_placement' })).not.toBeInTheDocument()
+    } finally {
+      delete window.__DASH_CAPABILITIES__
+    }
+  })
+
+  it('CP — default mode (no injected capabilities) offers the static dapr_scheduler target', async () => {
+    server.use(
+      http.get('/api/apps', () => HttpResponse.json([])),
+      http.get('/api/controlplane', () => HttpResponse.json({ ...CP_LIST_BASE, services: [] })),
+    )
+
+    renderAt('/logs')
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Logs' })).toBeInTheDocument())
+    expect(screen.getByRole('option', { name: 'dapr_scheduler' })).toBeInTheDocument()
+  })
+
   it('CP — ?cp=<compose service> streams its container logs', async () => {
     server.use(
       http.get('/api/apps', () => HttpResponse.json([])),

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -455,7 +455,7 @@ export function Logs() {
     setFollowing(f => !f)
   }
 
-  // cp is already validated against CP_SERVICES above (garbage → '').
+  // cp is already validated against cpNames above (garbage → '').
   const isCpView = cp !== ''
 
   useDocumentTitle(

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -9,6 +9,7 @@ import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { parseLogTime } from '../lib/logtime'
 import { parseEnum } from '../lib/parseEnum'
 import { appKey } from '../lib/appKey'
+import { getCapabilities } from '../lib/capabilities'
 
 // LogSource is wider than the hook's 'daprd' | 'app'; 'both' composes two streams.
 const LOG_SOURCES = ['both', 'daprd', 'app'] as const
@@ -16,7 +17,12 @@ type LogSource = (typeof LOG_SOURCES)[number]
 
 // Static fallback so the selector renders before /api/controlplane answers;
 // compose-managed placement/scheduler containers are merged in from the API.
+// Only modes whose sidecars use the `dapr init` containers get the fallback —
+// compose / test-containers modes must not offer dapr_* targets.
 const CP_SERVICES = ['dapr_scheduler', 'dapr_placement'] as const
+const NO_CP_SERVICES: readonly string[] = []
+const staticCpForMode = (mode: string): readonly string[] =>
+  mode === '' || mode === 'dapr-run' || mode === 'aspire' ? CP_SERVICES : NO_CP_SERVICES
 
 /** A merged row carries the original LogLine plus its tagged source. */
 interface MergedLine {
@@ -372,10 +378,11 @@ export function Logs() {
   // is validated against this list; until the fetch lands a compose name is
   // simply "not yet valid" and no stream opens.
   const { data: cpList, isError: cpListError } = useControlPlane()
+  const staticCp = staticCpForMode(getCapabilities().mode ?? '')
   const cpNames = useMemo(() => {
     const fetched = (cpList?.services ?? []).filter(s => s.actionable).map(s => s.name)
-    return [...new Set<string>([...CP_SERVICES, ...fetched])]
-  }, [cpList])
+    return [...new Set<string>([...staticCp, ...fetched])]
+  }, [cpList, staticCp])
   const cpParam = searchParams.get('cp') ?? ''
   const cp = cpNames.includes(cpParam) ? cpParam : ''
   // A cp target that isn't (yet) in the list is pending until the fetch


### PR DESCRIPTION
## Summary

Extends `--mode` / `DEVDASHBOARD_MODE` from the single `aspire` value to four **exclusive** single-source discovery filters. A filter mode restricts every dashboard surface — applications, workflows, state stores, the Control Plane view, and Logs targets — to one discovery source. Mode unset remains the complete scan.

| CLI value | Discovery source | UI label |
|---|---|---|
| `dapr-run` | host `dapr run` process scan | Dapr run |
| `compose` | Docker Compose containers | Compose |
| `test-containers` | Testcontainers containers | TestContainers |
| `aspire` | Aspire-managed resources | Aspire |

Spec: `docs/superpowers/specs/2026-07-13-mode-filter-design.md` (committed on this branch along with the implementation plan).

## Key behaviors

- **`aspire` dual posture**: with the `DEVDASHBOARD_APP_*` env contract present, behavior is unchanged (AppHost container posture). Without it, the dashboard runs host-posture and filters the process scan to Aspire-managed instances via a post-enrichment `IsAspire` service wrapper (DCP-proxy heuristic).
- **Fail-fast**: `--mode compose` / `--mode test-containers` error at startup when no container runtime (docker/podman) is found instead of showing a permanently empty dashboard.
- **Control Plane filtering**: `controlplane.Sources` gates both what `List` reports and what `Do`/`LogStream` accept (`dapr-run`/`aspire` → `dapr init` containers; `compose` → compose-run placement/scheduler; `test-containers` → honest empty state, detection deferred to a next iteration). Empty source set no longer issues a no-name `docker stats` (which sampled all containers).
- **Logs page**: the static `dapr_*` fallback is gated on the server-injected `window.__DASH_CAPABILITIES__.mode`; the Control Plane empty-state copy is mode-aware (no more `dapr init` advice in modes where it can't help).
- **Relabel**: the Applications "Run template" column is now **Mode** with pretty source names (run-template name preserved as tooltip); AppDetail gains a Mode row.

## Known v1 limitations (documented in the spec)

- The aspire host filter rides on the DCP-proxy heuristic: apps with no app port are missed, stopped aspire ghosts drop out, and Aspire-launched containers aren't discovered. The long-term fix is the resource-service gRPC scanner (`docs/superpowers/specs/2026-07-13-aspire-discovery-alternatives.md`).
- Testcontainers control-plane detection is deferred.

## Test plan

- `make build && make test` green at HEAD (all Go packages with `-race`; web 719 tests / 86 files).
- New unit coverage: mode validation, container-posture split, `FilterAspire`, `controlplane.Sources` gating (incl. a non-vacuous no-stats-call assertion), `sourcesFor`/`cpSourcesFor` tables, Logs CP-fallback gating, mode-aware CP empty state, `modeLabel`.
- Smoke-checked: unknown mode error, compose fail-fast without a runtime, `--mode dapr-run` control-plane JSON showing only `dapr_*` services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)