### PR TITLE
Rename binary to diagrid-dev-dashboard (breaking)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -27,7 +27,7 @@ body:
     id: dashboard-version
     attributes:
       label: Dashboard version
-      description: Output of `dev-dashboard --version`.
+      description: Output of `diagrid-dev-dashboard --version`.
       placeholder: e.g. 1.2.0
     validations:
       required: true
@@ -71,7 +71,7 @@ body:
       label: Steps to reproduce
       description: Step-by-step instructions to reproduce the behavior. Include what actually happened.
       placeholder: |
-        1. Start the dashboard with `dev-dashboard`
+        1. Start the dashboard with `diagrid-dev-dashboard`
         2. Open the Workflows page
         3. Click on ...
         4. See error

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,5 @@
 version: 2
-project_name: dev-dashboard
+project_name: diagrid-dev-dashboard
 
 before:
   hooks:
@@ -7,9 +7,9 @@ before:
     - sh -c "cd web && npm ci && npm run build"
 
 builds:
-  - id: dev-dashboard
+  - id: diagrid-dev-dashboard
     main: .
-    binary: dev-dashboard
+    binary: diagrid-dev-dashboard
     env:
       - CGO_ENABLED=0
     goos: [linux, darwin, windows]
@@ -33,7 +33,7 @@ archives:
 
 dockers:
   - id: linux-amd64
-    ids: [dev-dashboard]
+    ids: [diagrid-dev-dashboard]
     goos: linux
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
@@ -43,7 +43,7 @@ dockers:
     build_flag_templates:
       - "--platform=linux/amd64"
   - id: linux-arm64
-    ids: [dev-dashboard]
+    ids: [diagrid-dev-dashboard]
     goos: linux
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
@@ -75,7 +75,7 @@ snapshot:
 release:
   github:
     owner: diagridio
-    name: dev-dashboard
+    name: dev-dashboard   # GitHub REPO name — not the binary
   draft: false
   prerelease: auto
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ For how the system fits together and where to extend it, see [ARCHITECTURE.md](A
 
 ## What this is
 
-`dev-dashboard` is a **single Go binary** that embeds a React + Vite SPA (via `go:embed`) and
+`diagrid-dev-dashboard` is a **single Go binary** that embeds a React + Vite SPA (via `go:embed`) and
 acts as a passive, read-only observer for local Dapr development. There is **no Node.js at
 runtime** — the frontend is compiled to `web/dist` and baked into the binary at build time.
 
@@ -48,17 +48,17 @@ The SPA must be built **before** the Go binary (the binary embeds `web/dist`). `
 does both in order.
 
 ```sh
-make build                    # builds web/dist, then bin/dev-dashboard
+make build                    # builds web/dist, then bin/diagrid-dev-dashboard
 make web                      # build the SPA only (cd web && npm install && npm run build)
-./bin/dev-dashboard           # run it (serves http://localhost:9090, opens browser)
-./bin/dev-dashboard --no-open --verbose   # no browser, diagnostic logs to stderr
+./bin/diagrid-dev-dashboard   # run it (serves http://localhost:9090, opens browser)
+./bin/diagrid-dev-dashboard --no-open --verbose   # no browser, diagnostic logs to stderr
 ```
 
 Manual equivalent (no `make`):
 
 ```sh
 cd web && npm install && npm run build && cd ..
-go build -o bin/dev-dashboard .
+go build -o bin/diagrid-dev-dashboard .
 ```
 
 Sub-path mount: `DASH_BASE_PATH=/dashboard/ make build` then run with `--base-path /dashboard`
@@ -120,7 +120,7 @@ make release-snapshot         # = goreleaser release --snapshot --clean --skip=p
 
 Release matrix is **5 archives**: macOS + Linux (amd64 + arm64) and Windows (amd64). No native
 Windows/arm64 — it runs the amd64 build via emulation. Version string is injected from the tag
-via ldflags (`dev-dashboard --version`).
+via ldflags (`diagrid-dev-dashboard --version`).
 
 ## Conventions for agents
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,18 +39,18 @@ apps, whose containers belong to ryuk and whose app belongs to the test process)
 ### Top-level data flow
 
 ```
-                         ┌──────────────────────────────────────────────┐
-   Browser (SPA) ──HTTP──▶  dev-dashboard binary (127.0.0.1:9090)        │
-        ▲   ▲             │                                              │
-        │   │  SSE        │  cmd/         cobra root, flags, serve boot  │
-        │   └─────────────┤  pkg/server   chi router + go:embed SPA      │
-        │                 │  reconciler   apps → stores → active store   │
-        │  static assets  │  pkg/discovery standalone.List + metadata    │
-        └─────────────────┤  pkg/workflow list / history / purge         │
-                          │  pkg/statestore redis / postgres / sqlite    │
-                          │  pkg/controlplane docker/podman inspect+logs │
-                          │  pkg/resources / logs / news / metadata      │
-                          └───────┬───────────────────────┬──────────────┘
+                         ┌──────────────────────────────────────────────────────┐
+   Browser (SPA) ──HTTP──▶  diagrid-dev-dashboard binary (127.0.0.1:9090)        │
+        ▲   ▲             │                                                      │
+        │   │  SSE        │  cmd/         cobra root, flags, serve boot          │
+        │   └─────────────┤  pkg/server   chi router + go:embed SPA              │
+        │                 │  reconciler   apps → stores → active store           │
+        │  static assets  │  pkg/discovery standalone.List + metadata            │
+        └─────────────────┤  pkg/workflow list / history / purge                 │
+                          │  pkg/statestore redis / postgres / sqlite            │
+                          │  pkg/controlplane docker/podman inspect+logs         │
+                          │  pkg/resources / logs / news / metadata              │
+                          └───────┬───────────────────────┬──────────────────────┘
                     HTTP /v1.0/*  │                        │ files / TCP / exec
                                   ▼                        ▼
                        running daprd sidecars   ~/.dapr, resource paths,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ docs improvements, and features.
 Open a [GitHub issue](https://github.com/diagridio/dev-dashboard/issues) with:
 
 - What you did, what you expected, and what happened instead.
-- Your OS, dashboard version (`dev-dashboard --version`), and Dapr version (`dapr --version`).
-- If relevant, diagnostic output from `dev-dashboard --verbose` (logs go to stderr).
+- Your OS, dashboard version (`diagrid-dev-dashboard --version`), and Dapr version (`dapr --version`).
+- If relevant, diagnostic output from `diagrid-dev-dashboard --verbose` (logs go to stderr).
 
 For feature requests, describe the use case rather than a specific implementation —
 it helps us evaluate the best way to fit it into the dashboard.
@@ -35,8 +35,8 @@ Pull requests with unsigned commits cannot be merged.
 ```sh
 git clone https://github.com/diagridio/dev-dashboard.git
 cd dev-dashboard
-make build            # builds web/dist, then the Go binary at bin/dev-dashboard
-./bin/dev-dashboard
+make build            # builds web/dist, then the Go binary at bin/diagrid-dev-dashboard
+./bin/diagrid-dev-dashboard
 ```
 
 See [Building from source](README.md#building-from-source) in the README for manual steps

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ RUN CGO_ENABLED=0 go build \
     -X github.com/diagridio/dev-dashboard/pkg/version.Version=${VERSION} \
     -X github.com/diagridio/dev-dashboard/pkg/version.Commit=${COMMIT} \
     -X github.com/diagridio/dev-dashboard/pkg/version.Date=${DATE}" \
-    -o /out/dev-dashboard .
+    -o /out/diagrid-dev-dashboard .
 
 FROM gcr.io/distroless/static:nonroot
-COPY --from=build /out/dev-dashboard /dev-dashboard
+COPY --from=build /out/diagrid-dev-dashboard /diagrid-dev-dashboard
 ENV DEVDASHBOARD_MODE=aspire
 EXPOSE 8080
-ENTRYPOINT ["/dev-dashboard"]
+ENTRYPOINT ["/diagrid-dev-dashboard"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,5 +1,5 @@
 FROM gcr.io/distroless/static:nonroot
-COPY dev-dashboard /dev-dashboard
+COPY diagrid-dev-dashboard /diagrid-dev-dashboard
 ENV DEVDASHBOARD_MODE=aspire
 EXPOSE 8080
-ENTRYPOINT ["/dev-dashboard"]
+ENTRYPOINT ["/diagrid-dev-dashboard"]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ web:
 	cd web && npm install && npm run build
 
 build: web
-	go build -o bin/dev-dashboard .
+	go build -o bin/diagrid-dev-dashboard .
 
 lint: lint-go lint-web
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The dashboard ships as a standalone binary published on GitHub Releases.
 curl -sSL https://raw.githubusercontent.com/diagridio/dev-dashboard/main/scripts/install.sh | sh
 ```
 
-*Windows (PowerShell) — installs to %LOCALAPPDATA%\Programs\dev-dashboard*
+*Windows (PowerShell) — installs to %LOCALAPPDATA%\Programs\diagrid-dev-dashboard*
 
 ```powershell
 iwr -useb https://raw.githubusercontent.com/diagridio/dev-dashboard/main/scripts/install.ps1 | iex
@@ -61,29 +61,34 @@ If the install directory is not on your `PATH`, the script prints the export lin
 go install github.com/diagridio/dev-dashboard@latest
 ```
 
+> **Note:** `go install` names the binary after the module path, so it produces
+> `dev-dashboard`, not `diagrid-dev-dashboard` — rename it afterwards
+> (`mv "$(go env GOPATH)/bin/dev-dashboard" "$(go env GOPATH)/bin/diagrid-dev-dashboard"`)
+> or use the install script above.
+
 **Manual download:**
 
-Download the archive for your platform from the [GitHub Releases](https://github.com/diagridio/dev-dashboard/releases) page, extract it, and place `dev-dashboard` (or `dev-dashboard.exe`) on your `PATH`. Verify with:
+Download the archive for your platform from the [GitHub Releases](https://github.com/diagridio/dev-dashboard/releases) page, extract it, and place `diagrid-dev-dashboard` (or `diagrid-dev-dashboard.exe`) on your `PATH`. Verify with:
 
 ```sh
-dev-dashboard --version
+diagrid-dev-dashboard --version
 ```
 
 ## Run the dashboard
 
 ```sh
 # Start on the default port (9090) and open your browser automatically
-dev-dashboard
+diagrid-dev-dashboard
 ```
 
 ```sh
 # Start on a custom port
-dev-dashboard --port 8080
+diagrid-dev-dashboard --port 8080
 ```
 
 ```sh
 # Enable diagnostic logging to stderr (server startup, app discovery, state-store connection, log streams, workflow operations)
-dev-dashboard --verbose
+diagrid-dev-dashboard --verbose
 ```
 
 No additional setup is needed: the dashboard discovers running Dapr apps the same way
@@ -189,13 +194,13 @@ it is skipped for source/dev builds and fails silently when offline.
 Update to the latest release (no-op if already current)
 
 ```sh
-dev-dashboard update
+diagrid-dev-dashboard update
 ```
 
 Install a specific version (can downgrade or reinstall)
 
 ```sh
-dev-dashboard update 1.2.0
+diagrid-dev-dashboard update 1.2.0
 ```
 
 `update` downloads the release archive for your platform, verifies its SHA256
@@ -207,7 +212,7 @@ Restart any running dashboard to use the new version.
 If the dashboard does not behave as expected, run it with `--verbose` to print diagnostic logs to stderr:
 
 ```sh
-dev-dashboard --verbose
+diagrid-dev-dashboard --verbose
 ```
 
 Logs are grouped by `component=` (values: `server`, `discovery`, `workflow`, `registry`, `reconciler`) and use levels INFO (normal milestones), WARN (degraded but still working, e.g. a state store that failed to initialise), and ERROR (an operation failed, e.g. the server could not bind its port). Without `--verbose`, no diagnostic logs are emitted.
@@ -276,24 +281,24 @@ does both in the right order.
 **macOS / Linux:**
 
 ```sh
-make build            # builds web/dist, then the Go binary at bin/dev-dashboard
-./bin/dev-dashboard
+make build            # builds web/dist, then the Go binary at bin/diagrid-dev-dashboard
+./bin/diagrid-dev-dashboard
 ```
 
 Equivalent manual steps (if you don't have `make`):
 
 ```sh
 cd web && npm install && npm run build && cd ..
-go build -o bin/dev-dashboard .
-./bin/dev-dashboard
+go build -o bin/diagrid-dev-dashboard .
+./bin/diagrid-dev-dashboard
 ```
 
 **Windows (PowerShell):** `make` is usually unavailable, so run the steps directly:
 
 ```powershell
 cd web; npm install; npm run build; cd ..
-go build -o bin/dev-dashboard.exe .
-.\bin\dev-dashboard.exe
+go build -o bin/diagrid-dev-dashboard.exe .
+.\bin\diagrid-dev-dashboard.exe
 ```
 
 To build for a sub-path mount, set `DASH_BASE_PATH` before building (see
@@ -330,7 +335,7 @@ you just run both on the same machine.
    dashboard only shows state that already exists — an idle store shows an empty list.
 3. Start your from-source build:
    ```sh
-   ./bin/dev-dashboard            # opens http://localhost:9090
+   ./bin/diagrid-dev-dashboard    # opens http://localhost:9090
    ```
 4. In the UI: the **Apps** table shows your app (health, ports, PIDs); the **Workflows** page
    lists instances read from the state store — open one for its live event history, input/output,
@@ -343,7 +348,7 @@ marked `actorStateStore: "true"` (falling back to the first detected). Check:
 
 - If detection is ambiguous (several stores), either pick one with the store selector on the
   Workflows page, or point it explicitly:
-  `./bin/dev-dashboard --statestore ~/.dapr/components/statestore.yaml`. You can also add a
+  `./bin/diagrid-dev-dashboard --statestore ~/.dapr/components/statestore.yaml`. You can also add a
   store by hand via the connection manager on the Components page.
 - Workflow keys are namespaced; the dashboard defaults to `default`. For another namespace, pass
   `--namespace <ns>`.
@@ -460,7 +465,7 @@ single commit with `git commit --no-verify`.
 > For maintainers with push access. Releases are built and published by the
 > [`release` GitHub Actions workflow](.github/workflows/release.yaml): pushing a `vX.Y.Z` tag
 > runs [GoReleaser](https://goreleaser.com), which compiles the cross-platform archives plus
-> `checksums.txt` and publishes them to a GitHub Release. The version (`dev-dashboard --version`)
+> `checksums.txt` and publishes them to a GitHub Release. The version (`diagrid-dev-dashboard --version`)
 > is injected from the tag via build-time ldflags. The same tag-driven run also builds and
 > pushes the multi-arch container image to `ghcr.io/diagridio/dev-dashboard` via goreleaser.
 > Prerelease tags (any `-suffix`, e.g. `v1.5.0-rc.1`) push their version-tagged image but
@@ -508,21 +513,21 @@ sidecars and state store.
 > [ARCHITECTURE.md](ARCHITECTURE.md). The summary below is the quick tour.
 
 ```
-┌───────────────────────────────────────────────────────┐
-│  dev-dashboard (single Go binary)                     │
-│                                                       │
-│  cmd/            cobra root, flags, serve boot,       │
-│                  connection registry + reconciler     │
-│  pkg/server      chi router + go:embed SPA            │
-│  pkg/discovery   standalone.List() + /v1.0/metadata   │
-│  pkg/workflow    list / history / purge               │
-│  pkg/statestore  client (redis / postgres / sqlite)   │
-│  pkg/controlplane docker/podman inspect + lifecycle   │
-│  pkg/metadata    component metadata catalog           │
-│  pkg/resources   component + configuration YAML loader│
-│  pkg/logs        file tail → SSE                      │
-│  web/            React + Vite SPA → dist/ (embedded)  │
-└───────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────┐
+│  diagrid-dev-dashboard (single Go binary)                     │
+│                                                               │
+│  cmd/            cobra root, flags, serve boot,               │
+│                  connection registry + reconciler             │
+│  pkg/server      chi router + go:embed SPA                    │
+│  pkg/discovery   standalone.List() + /v1.0/metadata           │
+│  pkg/workflow    list / history / purge                       │
+│  pkg/statestore  client (redis / postgres / sqlite)           │
+│  pkg/controlplane docker/podman inspect + lifecycle           │
+│  pkg/metadata    component metadata catalog                   │
+│  pkg/resources   component + configuration YAML loader        │
+│  pkg/logs        file tail → SSE                              │
+│  web/            React + Vite SPA → dist/ (embedded)          │
+└───────────────────────────────────────────────────────────────┘
    │ HTTP /v1.0/*   │ files / TCP        │ docker/podman
    ▼                ▼                    ▼
  running daprd   ~/.dapr, resource paths,   control-plane

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Package cmd wires the dev-dashboard CLI.
+// Package cmd wires the diagrid-dev-dashboard CLI.
 package cmd
 
 import (
@@ -46,7 +46,7 @@ func NewRootCmd() *cobra.Command {
 	)
 	info := version.Get()
 	c := &cobra.Command{
-		Use:           "dev-dashboard",
+		Use:           "diagrid-dev-dashboard",
 		Short:         "Local dashboard for Dapr apps, workflows, and sidecars",
 		Version:       info.Version,
 		SilenceUsage:  true,
@@ -64,7 +64,7 @@ func NewRootCmd() *cobra.Command {
 			return runServe(cmd.Context(), mode, posture, settings, basePath, noOpen, verbose)
 		},
 	}
-	c.SetVersionTemplate(fmt.Sprintf("dev-dashboard {{.Version}} (commit %s, built %s)\n", info.Commit, info.Date))
+	c.SetVersionTemplate(fmt.Sprintf("diagrid-dev-dashboard {{.Version}} (commit %s, built %s)\n", info.Commit, info.Date))
 	c.Flags().IntVar(&port, "port", 9090, "port to serve the dashboard on")
 	c.Flags().StringVar(&bind, "bind", "127.0.0.1", "address to bind (aspire container posture defaults to 0.0.0.0); binding a non-loopback address outside container posture leaves the loopback Host guard in place, which rejects remote clients")
 	c.Flags().StringVar(&modeFlag, "mode", "", `discovery filter: "dapr-run", "compose", "test-containers", or "aspire" show only that source's resources ("aspire" also switches to container posture when the DEVDASHBOARD_APP_* contract is present); unset scans every source`)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -18,7 +18,7 @@ func TestVersionFlag(t *testing.T) {
 	require.NoError(t, c.Execute())
 	out := buf.String()
 	require.Contains(t, out, version.Get().Version)
-	require.Contains(t, out, "dev-dashboard")
+	require.Contains(t, out, "diagrid-dev-dashboard")
 	require.Contains(t, out, "commit none")
 	require.Contains(t, out, "built unknown")
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -10,9 +10,9 @@ import (
 func newUpdateCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "update [version]",
-		Short: "Update dev-dashboard to the latest or a specific release",
-		Long: "Download and install the latest dev-dashboard release in place, or a " +
-			"specific version (e.g. `dev-dashboard update 1.2.0`). Restart any running " +
+		Short: "Update diagrid-dev-dashboard to the latest or a specific release",
+		Long: "Download and install the latest diagrid-dev-dashboard release in place, or a " +
+			"specific version (e.g. `diagrid-dev-dashboard update 1.2.0`). Restart any running " +
 			"instance to use the new binary.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/update_notice.go
+++ b/cmd/update_notice.go
@@ -25,7 +25,7 @@ func formatUpdateNotice(current, latest, releaseURL string) string {
 	}
 	return fmt.Sprintf(
 		"A new version of the Dapr Dev Dashboard is available: %s → %s%s\n"+
-			"Run `dev-dashboard update` to upgrade.\n\n",
+			"Run `diagrid-dev-dashboard update` to upgrade.\n\n",
 		current, latest, link)
 }
 

--- a/cmd/update_notice_test.go
+++ b/cmd/update_notice_test.go
@@ -18,7 +18,7 @@ func TestFormatUpdateNotice(t *testing.T) {
 	// The trailing blank line separates the notice from the startup message.
 	require.Equal(t,
 		"A new version of the Dapr Dev Dashboard is available: v1.2.0 → v1.3.0 (https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0)\n"+
-			"Run `dev-dashboard update` to upgrade.\n\n",
+			"Run `diagrid-dev-dashboard update` to upgrade.\n\n",
 		got)
 }
 
@@ -26,7 +26,7 @@ func TestFormatUpdateNoticeWithoutReleaseURL(t *testing.T) {
 	got := formatUpdateNotice("v1.2.0", "v1.3.0", "")
 	require.Equal(t,
 		"A new version of the Dapr Dev Dashboard is available: v1.2.0 → v1.3.0\n"+
-			"Run `dev-dashboard update` to upgrade.\n\n",
+			"Run `diagrid-dev-dashboard update` to upgrade.\n\n",
 		got)
 }
 
@@ -39,7 +39,7 @@ func TestPrintUpdateNoticeWhenAvailable(t *testing.T) {
 		ReleaseURL:      "https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0",
 	})
 	require.Contains(t, buf.String(), "v1.2.0 → v1.3.0 (https://github.com/diagridio/dev-dashboard/releases/tag/v1.3.0)")
-	require.Contains(t, buf.String(), "dev-dashboard update")
+	require.Contains(t, buf.String(), "diagrid-dev-dashboard update")
 }
 
 func TestPrintUpdateNoticeSuppressedWhenNotAvailable(t *testing.T) {

--- a/docs/aspire-discovery.md
+++ b/docs/aspire-discovery.md
@@ -259,7 +259,7 @@ Aspire inputs it does much less:
  .NET AppHost + hosting integration
         │  injects DEVDASHBOARD_APP_* (static, once)
         ▼
- dev-dashboard (container, mode=aspire)
+ diagrid-dev-dashboard (container, mode=aspire)
         │  NewAspireScanner → []ScanResult (Source=aspire, DaprHTTPBaseURL set)
         ▼
  discovery.List  ──(per poll, parallel)──▶  each sidecar:

--- a/docs/release-notes/binary-rename-snippet.md
+++ b/docs/release-notes/binary-rename-snippet.md
@@ -1,0 +1,21 @@
+### ⚠️ Breaking: the binary is now `diagrid-dev-dashboard`
+
+The CLI, release archives, and installed binary are renamed from `dev-dashboard`
+to `diagrid-dev-dashboard`. **Existing installs cannot self-update across this
+rename** — `dev-dashboard update` (and the startup update prompt) will fail with
+"release not found". Reinstall once with the one-liner:
+
+```sh
+curl -sSL https://raw.githubusercontent.com/diagridio/dev-dashboard/main/scripts/install.sh | sh
+```
+
+Windows (PowerShell):
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/diagridio/dev-dashboard/main/scripts/install.ps1 | iex
+```
+
+then delete the old `dev-dashboard` binary (the installer prints its location if
+one is found). The GitHub repo, Go module path, container image names
+(`ghcr.io/diagridio/dev-dashboard`), and `DEVDASHBOARD_*` environment variables
+are unchanged.

--- a/docs/release-notes/binary-rename-snippet.md
+++ b/docs/release-notes/binary-rename-snippet.md
@@ -17,5 +17,5 @@ iwr -useb https://raw.githubusercontent.com/diagridio/dev-dashboard/main/scripts
 
 then delete the old `dev-dashboard` binary (the installer prints its location if
 one is found). The GitHub repo, Go module path, container image names
-(`ghcr.io/diagridio/dev-dashboard`), and `DEVDASHBOARD_*` environment variables
-are unchanged.
+(`ghcr.io/diagridio/dev-dashboard`), `DEVDASHBOARD_*` environment variables,
+and your saved state-store connections in `~/.dapr/dev-dashboard/` are unchanged.

--- a/docs/superpowers/plans/2026-07-14-binary-rename.md
+++ b/docs/superpowers/plans/2026-07-14-binary-rename.md
@@ -1,0 +1,458 @@
+# Binary Rename to `diagrid-dev-dashboard` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the shipped binary from `dev-dashboard` to `diagrid-dev-dashboard` everywhere it matters — build outputs, release archives, self-update expectations, install scripts, CLI help — as an accepted breaking change for existing installs.
+
+**Architecture:** This is a coordinated string rename across four layers that must stay in lockstep: goreleaser (archive + inner binary names), `pkg/selfupdate` (what the updater downloads and extracts), the install scripts (what they fetch and write), and the CLI/docs surface. The repo, Go module path, GHCR image names, and the `DEVDASHBOARD_*` env prefix are explicitly NOT renamed.
+
+**Tech Stack:** Go (cobra, goreleaser v2), POSIX sh + PowerShell install scripts, Docker.
+
+## Global Constraints
+
+- New binary name is exactly `diagrid-dev-dashboard` (`diagrid-dev-dashboard.exe` on Windows).
+- Release asset template becomes `diagrid-dev-dashboard_{version}_{os}_{arch}.tar.gz` (`.zip` on Windows) — goreleaser derives it from `project_name`, so `project_name` changes too.
+- **MUST NOT change:** the repo / Go module path `github.com/diagridio/dev-dashboard` (incl. every `-X github.com/diagridio/dev-dashboard/...` ldflag), goreleaser `release.github.name: dev-dashboard` (that is the GitHub *repo* name), the GHCR image names `ghcr.io/diagridio/dev-dashboard*` (external consumers incl. the Aspire hosting integration), the `defaultRepo = "diagridio/dev-dashboard"` / `"diagridio/dev-dashboard"` repo strings in `pkg/selfupdate` and `cmd` (updatecheck), the `DEVDASHBOARD_*` env-var prefix, and the `diagrid.ws/dev-dashboard-*` marketing links in the web UI.
+- Breaking change is accepted: NO compatibility shims for old updaters. Binaries ≤ the last old-named release will fail `update` with "release X not found"; the release notes of the first renamed release must say so and give the reinstall one-liners (Task 5 writes that snippet).
+- Go tests run with `go test -tags unit -race ./...`; run `gofmt -w` on every touched Go file before committing.
+- Reference inventory (verified 2026-07-14): the only files carrying the *binary/asset* name are `pkg/selfupdate/{asset,extract,replace,selfupdate,resolve}.go` (+ their tests), `cmd/{root,update,update_notice}.go`, `pkg/updatecheck/updatecheck.go` (doc comment), `.goreleaser.yaml`, `Dockerfile`, `Dockerfile.goreleaser`, `Makefile`, `scripts/install.sh`, `scripts/install.ps1`, `README.md`, `ARCHITECTURE.md`.
+
+---
+
+### Task 1: Self-update naming (`pkg/selfupdate`)
+
+**Files:**
+- Modify: `pkg/selfupdate/asset.go:10,19`
+- Modify: `pkg/selfupdate/extract.go:13-22`
+- Modify: `pkg/selfupdate/replace.go:17`
+- Modify: `pkg/selfupdate/selfupdate.go:86`
+- Modify: `pkg/selfupdate/resolve.go:1` (package doc comment)
+- Test: `pkg/selfupdate/asset_test.go`, `extract_test.go`, `replace_test.go`, `selfupdate_integration_test.go`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: `assetName(...)` returning `diagrid-dev-dashboard_{num}_{os}_{arch}.{ext}` and `binaryFileName(goos)` returning `diagrid-dev-dashboard[.exe]` — these must match Task 3's goreleaser output exactly.
+
+- [ ] **Step 1: Update the test expectations first**
+
+In `pkg/selfupdate/asset_test.go`, `extract_test.go`, `replace_test.go`, and `selfupdate_integration_test.go`, apply this exact mechanical substitution to every string literal (expected asset names, fixture archive entry names, temp-file prefixes):
+
+- `dev-dashboard_` → `diagrid-dev-dashboard_`
+- `"dev-dashboard"` → `"diagrid-dev-dashboard"`
+- `"dev-dashboard.exe"` → `"diagrid-dev-dashboard.exe"`
+- `.dev-dashboard-update-` → `.diagrid-dev-dashboard-update-`
+
+Do NOT touch `diagridio/dev-dashboard` repo strings or `github.com/diagridio/dev-dashboard` import paths. Sanity-check with:
+
+```bash
+grep -rn "dev-dashboard" pkg/selfupdate/*_test.go | grep -v "diagrid-dev-dashboard" | grep -v "diagridio/dev-dashboard" | grep -v "github.com/diagridio"
+```
+
+Expected: no output (every remaining bare `dev-dashboard` is renamed or is a repo/module reference).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -tags unit -race ./pkg/selfupdate/`
+Expected: FAIL — asset/extract tests now expect `diagrid-dev-dashboard*` while the implementation still produces `dev-dashboard*`.
+
+- [ ] **Step 3: Rename in the implementation**
+
+`pkg/selfupdate/asset.go` — comment and format string:
+
+```go
+//	diagrid-dev-dashboard_{num}_{os}_{arch}.tar.gz   (.zip on windows)
+```
+
+```go
+	return fmt.Sprintf("diagrid-dev-dashboard_%s_%s_%s.%s", num, goos, goarch, ext)
+```
+
+`pkg/selfupdate/extract.go` — both returns and the two doc comments:
+
+```go
+// binaryFileName returns the name of the diagrid-dev-dashboard binary inside a release
+```
+
+```go
+		return "diagrid-dev-dashboard.exe"
+	}
+	return "diagrid-dev-dashboard"
+```
+
+```go
+// extractBinary pulls the diagrid-dev-dashboard binary bytes out of a release archive:
+```
+
+`pkg/selfupdate/replace.go:17`:
+
+```go
+	tmp, err := os.CreateTemp(dir, ".diagrid-dev-dashboard-update-*")
+```
+
+`pkg/selfupdate/selfupdate.go:86`:
+
+```go
+	fmt.Fprintf(u.Out, "downloading diagrid-dev-dashboard %s (%s/%s)…\n", target, u.GOOS, u.GOARCH)
+```
+
+`pkg/selfupdate/resolve.go:1`:
+
+```go
+// Package selfupdate updates the diagrid-dev-dashboard binary in place from GitHub Releases.
+```
+
+Leave `selfupdate.go`'s `const defaultRepo = "diagridio/dev-dashboard"` untouched.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test -tags unit -race ./pkg/selfupdate/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/selfupdate/
+git commit -m "feat(selfupdate)!: expect diagrid-dev-dashboard asset and binary names"
+```
+
+---
+
+### Task 2: CLI surface strings (`cmd/`, `pkg/updatecheck`)
+
+**Files:**
+- Modify: `cmd/root.go:1,49,67`
+- Modify: `cmd/update.go:13-15`
+- Modify: `cmd/update_notice.go:28`
+- Modify: `pkg/updatecheck/updatecheck.go:1` (doc comment)
+- Test: existing `cmd/` suites (some assert usage/notice text)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `--version` output starts with `diagrid-dev-dashboard`; cobra `Use` is `diagrid-dev-dashboard` (drives help/usage text).
+
+- [ ] **Step 1: Rename the user-visible strings**
+
+`cmd/root.go`:
+
+```go
+// Package cmd wires the diagrid-dev-dashboard CLI.
+```
+
+```go
+		Use:           "diagrid-dev-dashboard",
+```
+
+```go
+	c.SetVersionTemplate(fmt.Sprintf("diagrid-dev-dashboard {{.Version}} (commit %s, built %s)\n", info.Commit, info.Date))
+```
+
+`cmd/update.go`:
+
+```go
+		Short: "Update diagrid-dev-dashboard to the latest or a specific release",
+		Long: "Download and install the latest diagrid-dev-dashboard release in place, or a " +
+			"specific version (e.g. `diagrid-dev-dashboard update 1.2.0`). Restart any running " +
+```
+
+(keep the rest of the `Long` string as-is)
+
+`cmd/update_notice.go:28`:
+
+```go
+			"Run `diagrid-dev-dashboard update` to upgrade.\n\n",
+```
+
+`pkg/updatecheck/updatecheck.go:1`:
+
+```go
+// Package updatecheck reports whether a newer diagrid-dev-dashboard release exists.
+```
+
+- [ ] **Step 2: Run the affected suites and fix text assertions**
+
+Run: `go test -tags unit -race ./cmd/... ./pkg/updatecheck/...`
+Expected: any failures are string assertions on the old name in `cmd` tests (e.g. update-notice copy). Update those expected strings to the new name — behavior assertions must not change. Re-run until PASS.
+
+- [ ] **Step 3: Verify the version banner end-to-end**
+
+Run: `go run . --version`
+Expected output shape: `diagrid-dev-dashboard dev (commit unknown, built unknown)` (values vary; the leading name must be `diagrid-dev-dashboard`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/ pkg/updatecheck/
+git commit -m "feat(cli)!: rename command surface to diagrid-dev-dashboard"
+```
+
+---
+
+### Task 3: Build & release plumbing (goreleaser, Dockerfiles, Makefile)
+
+**Files:**
+- Modify: `.goreleaser.yaml`
+- Modify: `Dockerfile.goreleaser`
+- Modify: `Dockerfile:24,27,30`
+- Modify: `Makefile:7`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: release archives named `diagrid-dev-dashboard_{version}_{os}_{arch}.*` containing a binary named `diagrid-dev-dashboard[.exe]` — exactly what Task 1's updater and Task 4's scripts expect.
+
+- [ ] **Step 1: Update .goreleaser.yaml**
+
+Apply exactly these changes (everything else stays):
+
+```yaml
+project_name: diagrid-dev-dashboard
+```
+
+```yaml
+builds:
+  - id: diagrid-dev-dashboard
+    main: .
+    binary: diagrid-dev-dashboard
+```
+
+In BOTH `dockers` entries, update the build reference:
+
+```yaml
+    ids: [diagrid-dev-dashboard]
+```
+
+Do NOT change: the `-X github.com/diagridio/dev-dashboard/...` ldflags, `image_templates` / `docker_manifests` (all `ghcr.io/diagridio/dev-dashboard*`), or:
+
+```yaml
+release:
+  github:
+    owner: diagridio
+    name: dev-dashboard   # GitHub REPO name — not the binary
+```
+
+Add that trailing comment on the `name:` line so nobody "fixes" it later.
+
+- [ ] **Step 2: Update the container Dockerfiles (image names stay, inner path renames)**
+
+`Dockerfile.goreleaser` (goreleaser copies the built binary by its `binary:` name):
+
+```dockerfile
+FROM gcr.io/distroless/static:nonroot
+COPY diagrid-dev-dashboard /diagrid-dev-dashboard
+ENV DEVDASHBOARD_MODE=aspire
+EXPOSE 8080
+ENTRYPOINT ["/diagrid-dev-dashboard"]
+```
+
+`Dockerfile` — line 24 build output, line 27 copy, line 30 entrypoint:
+
+```dockerfile
+    -o /out/diagrid-dev-dashboard .
+```
+
+```dockerfile
+COPY --from=build /out/diagrid-dev-dashboard /diagrid-dev-dashboard
+```
+
+```dockerfile
+ENTRYPOINT ["/diagrid-dev-dashboard"]
+```
+
+- [ ] **Step 3: Update the Makefile build output**
+
+`Makefile:7`:
+
+```make
+	go build -o bin/diagrid-dev-dashboard .
+```
+
+- [ ] **Step 4: Validate**
+
+Run: `make release-check`
+Expected: `goreleaser check` reports the config is valid.
+
+Run: `make build && ls bin/`
+Expected: build succeeds; `bin/` contains `diagrid-dev-dashboard` (the stale `bin/dev-dashboard` may linger from earlier builds — ignore or delete it).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .goreleaser.yaml Dockerfile Dockerfile.goreleaser Makefile
+git commit -m "feat(release)!: rename build outputs and archives to diagrid-dev-dashboard"
+```
+
+---
+
+### Task 4: Install scripts
+
+**Files:**
+- Modify: `scripts/install.sh`
+- Modify: `scripts/install.ps1`
+
+**Interfaces:**
+- Consumes: Task 3's asset name `diagrid-dev-dashboard_{num}_{os}_{arch}.tar.gz|zip` and inner binary `diagrid-dev-dashboard[.exe]`.
+- Produces: installs at `~/.local/bin/diagrid-dev-dashboard` (sh) and `%LOCALAPPDATA%\Programs\diagrid-dev-dashboard\diagrid-dev-dashboard.exe` (ps1).
+
+- [ ] **Step 1: Update install.sh**
+
+Header comments (lines 2-4): change `Install dev-dashboard` → `Install diagrid-dev-dashboard`. Then:
+
+```sh
+file="diagrid-dev-dashboard_${num}_${os}_${arch}.tar.gz"
+```
+
+```sh
+install -m 0755 "$tmp/diagrid-dev-dashboard" "$BIN_DIR/diagrid-dev-dashboard"
+echo "installed diagrid-dev-dashboard $VERSION → $BIN_DIR/diagrid-dev-dashboard"
+if [ -e "$BIN_DIR/dev-dashboard" ]; then
+  echo "note: found a previous install under the old name; remove it with: rm \"$BIN_DIR/dev-dashboard\""
+fi
+```
+
+`REPO="diagridio/dev-dashboard"` stays (repo name).
+
+- [ ] **Step 2: Update install.ps1**
+
+Header comments (lines 1-2): `Install diagrid-dev-dashboard to %LOCALAPPDATA%\Programs\diagrid-dev-dashboard`. Then:
+
+```powershell
+$binDir = Join-Path $env:LOCALAPPDATA 'Programs\diagrid-dev-dashboard'
+```
+
+```powershell
+$file = "diagrid-dev-dashboard_${num}_windows_${file_arch}.zip"
+```
+
+```powershell
+    Copy-Item (Join-Path $tmp 'diagrid-dev-dashboard.exe') (Join-Path $binDir 'diagrid-dev-dashboard.exe') -Force
+    Write-Host "installed diagrid-dev-dashboard $version -> $binDir\diagrid-dev-dashboard.exe"
+```
+
+After the PATH note block, add the old-install notice:
+
+```powershell
+$oldDir = Join-Path $env:LOCALAPPDATA 'Programs\dev-dashboard'
+if (Test-Path $oldDir) {
+    Write-Host "note: found a previous install under the old name at $oldDir; you can remove that folder (and its PATH entry)."
+}
+```
+
+`$repo = 'diagridio/dev-dashboard'` stays.
+
+- [ ] **Step 3: Verify the URL construction**
+
+Run: `DRY_RUN=1 VERSION=v9.9.9 sh scripts/install.sh`
+Expected output: `https://github.com/diagridio/dev-dashboard/releases/download/v9.9.9/diagrid-dev-dashboard_9.9.9_<os>_<arch>.tar.gz` (repo path old, asset name new).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/install.sh scripts/install.ps1
+git commit -m "feat(install)!: fetch and install diagrid-dev-dashboard"
+```
+
+---
+
+### Task 5: Docs + breaking-change release note
+
+**Files:**
+- Modify: `README.md` (~31 occurrences)
+- Modify: `ARCHITECTURE.md` (command examples / build-output mentions, if any — grep)
+- Create: `docs/release-notes/binary-rename-snippet.md`
+
+**Interfaces:** none — docs only.
+
+- [ ] **Step 1: Update README command examples and install text**
+
+Replace every *command/binary/asset* occurrence of `dev-dashboard` with `diagrid-dev-dashboard`: the `--version` / `--port` / `--verbose` / `update` examples (lines ~69, 81, 86, 192, 198, 210), the `./bin/dev-dashboard --statestore ...` example (~346), the release-artifact description (~463), and any `~/.local/bin` install-path prose. Do NOT change: `github.com/diagridio/dev-dashboard` module/repo URLs, `ghcr.io/diagridio/dev-dashboard` image references, `DEVDASHBOARD_*` env vars, or the raw install-script URLs (they live in the repo, whose name is unchanged). Verify the split with:
+
+```bash
+grep -n "dev-dashboard" README.md | grep -v "diagrid-dev-dashboard" | grep -v "diagridio/dev-dashboard" | grep -v "ghcr.io" | grep -v "DEVDASHBOARD"
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Add the `go install` caveat to README**
+
+Next to the `go install github.com/diagridio/dev-dashboard@<version>` instruction, add:
+
+```markdown
+> **Note:** `go install` names the binary after the module path, so it produces
+> `dev-dashboard`, not `diagrid-dev-dashboard` — rename it afterwards
+> (`mv "$(go env GOPATH)/bin/dev-dashboard" "$(go env GOPATH)/bin/diagrid-dev-dashboard"`)
+> or use the install script above.
+```
+
+- [ ] **Step 3: Sweep ARCHITECTURE.md**
+
+Run `grep -n "dev-dashboard" ARCHITECTURE.md | grep -v diagrid- | grep -v "diagridio/"` and rename only binary-name mentions (e.g. `bin/dev-dashboard`, `dev-dashboard binary`, CLI invocations); module paths and image names stay.
+
+- [ ] **Step 4: Write the release-note snippet**
+
+Create `docs/release-notes/binary-rename-snippet.md`:
+
+```markdown
+### ⚠️ Breaking: the binary is now `diagrid-dev-dashboard`
+
+The CLI, release archives, and installed binary are renamed from `dev-dashboard`
+to `diagrid-dev-dashboard`. **Existing installs cannot self-update across this
+rename** — `dev-dashboard update` (and the startup update prompt) will fail with
+"release not found". Reinstall once with the one-liner:
+
+​```sh
+curl -sSL https://raw.githubusercontent.com/diagridio/dev-dashboard/main/scripts/install.sh | sh
+​```
+
+Windows (PowerShell):
+
+​```powershell
+iwr -useb https://raw.githubusercontent.com/diagridio/dev-dashboard/main/scripts/install.ps1 | iex
+​```
+
+then delete the old `dev-dashboard` binary (the installer prints its location if
+one is found). The GitHub repo, Go module path, container image names
+(`ghcr.io/diagridio/dev-dashboard`), and `DEVDASHBOARD_*` environment variables
+are unchanged.
+```
+
+(The `​` marks above are literal triple-backtick fences — un-escape them in the real file.) This snippet is pasted into the first renamed release's notes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md ARCHITECTURE.md docs/release-notes/
+git commit -m "docs!: document the diagrid-dev-dashboard rename and update reinstall path"
+```
+
+---
+
+### Task 6: Full verification
+
+**Files:** none new.
+
+- [ ] **Step 1: Whole-repo leftover sweep**
+
+```bash
+grep -rn "dev-dashboard" --include="*.go" --include="*.yaml" --include="*.yml" --include="Makefile" --include="Dockerfile*" --include="*.sh" --include="*.ps1" . \
+  | grep -v node_modules | grep -v "diagrid-dev-dashboard" \
+  | grep -v "diagridio/dev-dashboard" | grep -v "github.com/diagridio" \
+  | grep -v "ghcr.io" | grep -v "DEVDASHBOARD" | grep -v "diagrid.ws" | grep -v docs/superpowers
+```
+
+Expected: no output, or only deliberate leftovers (e.g. `.github/workflows/ci.yaml`'s local `docker build -t dev-dashboard:ci .` tag, which is a throwaway CI tag and may stay). Judge each hit against the Global Constraints' do-not-change list.
+
+- [ ] **Step 2: Full build + test**
+
+Run: `make build && make test`
+Expected: build succeeds producing `bin/diagrid-dev-dashboard`; all Go and web suites pass.
+
+- [ ] **Step 3: Snapshot release dry-run (conclusive artifact check)**
+
+Run: `goreleaser release --snapshot --clean --skip=publish,docker` (use plain `make release-snapshot` if docker buildx is available locally)
+Then: `ls dist/ | head` and `tar -tzf dist/diagrid-dev-dashboard_*_$(go env GOOS)_$(go env GOARCH).tar.gz`
+Expected: archives named `diagrid-dev-dashboard_<ver>-snapshot_<os>_<arch>.*`, each containing a `diagrid-dev-dashboard` binary — proving Task 1's updater expectations match Task 3's outputs.
+
+- [ ] **Step 4: Commit any final fixes**
+
+```bash
+git status --porcelain   # commit stragglers if the sweep/verification changed anything
+```

--- a/pkg/selfupdate/asset.go
+++ b/pkg/selfupdate/asset.go
@@ -7,7 +7,7 @@ import (
 
 // assetName reproduces the GoReleaser name_template for a release archive:
 //
-//	dev-dashboard_{num}_{os}_{arch}.tar.gz   (.zip on windows)
+//	diagrid-dev-dashboard_{num}_{os}_{arch}.tar.gz   (.zip on windows)
 //
 // where num is the version without a leading "v".
 func assetName(version, goos, goarch string) string {
@@ -16,5 +16,5 @@ func assetName(version, goos, goarch string) string {
 	if goos == "windows" {
 		ext = "zip"
 	}
-	return fmt.Sprintf("dev-dashboard_%s_%s_%s.%s", num, goos, goarch, ext)
+	return fmt.Sprintf("diagrid-dev-dashboard_%s_%s_%s.%s", num, goos, goarch, ext)
 }

--- a/pkg/selfupdate/asset_test.go
+++ b/pkg/selfupdate/asset_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestAssetName(t *testing.T) {
-	require.Equal(t, "dev-dashboard_1.2.0_linux_amd64.tar.gz", assetName("v1.2.0", "linux", "amd64"))
-	require.Equal(t, "dev-dashboard_1.2.0_linux_arm64.tar.gz", assetName("1.2.0", "linux", "arm64"))
-	require.Equal(t, "dev-dashboard_1.2.0_darwin_amd64.tar.gz", assetName("v1.2.0", "darwin", "amd64"))
-	require.Equal(t, "dev-dashboard_1.2.0_darwin_arm64.tar.gz", assetName("v1.2.0", "darwin", "arm64"))
-	require.Equal(t, "dev-dashboard_1.2.0_windows_amd64.zip", assetName("v1.2.0", "windows", "amd64"))
+	require.Equal(t, "diagrid-dev-dashboard_1.2.0_linux_amd64.tar.gz", assetName("v1.2.0", "linux", "amd64"))
+	require.Equal(t, "diagrid-dev-dashboard_1.2.0_linux_arm64.tar.gz", assetName("1.2.0", "linux", "arm64"))
+	require.Equal(t, "diagrid-dev-dashboard_1.2.0_darwin_amd64.tar.gz", assetName("v1.2.0", "darwin", "amd64"))
+	require.Equal(t, "diagrid-dev-dashboard_1.2.0_darwin_arm64.tar.gz", assetName("v1.2.0", "darwin", "arm64"))
+	require.Equal(t, "diagrid-dev-dashboard_1.2.0_windows_amd64.zip", assetName("v1.2.0", "windows", "amd64"))
 }

--- a/pkg/selfupdate/checksum_test.go
+++ b/pkg/selfupdate/checksum_test.go
@@ -14,7 +14,7 @@ func TestVerifyChecksum(t *testing.T) {
 	archive := []byte("the archive bytes")
 	sum := sha256.Sum256(archive)
 	hexSum := hex.EncodeToString(sum[:])
-	name := "dev-dashboard_1.2.0_linux_amd64.tar.gz"
+	name := "diagrid-dev-dashboard_1.2.0_linux_amd64.tar.gz"
 	checksums := "deadbeef  other-file.zip\n" + hexSum + "  " + name + "\n"
 
 	require.NoError(t, verifyChecksum(archive, name, checksums))

--- a/pkg/selfupdate/extract.go
+++ b/pkg/selfupdate/extract.go
@@ -10,16 +10,16 @@ import (
 	"io"
 )
 
-// binaryFileName returns the name of the dev-dashboard binary inside a release
+// binaryFileName returns the name of the diagrid-dev-dashboard binary inside a release
 // archive for the given OS.
 func binaryFileName(goos string) string {
 	if goos == "windows" {
-		return "dev-dashboard.exe"
+		return "diagrid-dev-dashboard.exe"
 	}
-	return "dev-dashboard"
+	return "diagrid-dev-dashboard"
 }
 
-// extractBinary pulls the dev-dashboard binary bytes out of a release archive:
+// extractBinary pulls the diagrid-dev-dashboard binary bytes out of a release archive:
 // a .zip on windows, a .tar.gz elsewhere.
 func extractBinary(archive []byte, goos string) ([]byte, error) {
 	name := binaryFileName(goos)

--- a/pkg/selfupdate/extract_test.go
+++ b/pkg/selfupdate/extract_test.go
@@ -39,7 +39,7 @@ func makeZip(t *testing.T, name string, content []byte) []byte {
 
 func TestExtractBinaryTarGz(t *testing.T) {
 	content := []byte("fake-linux-binary")
-	archive := makeTarGz(t, "dev-dashboard", content)
+	archive := makeTarGz(t, "diagrid-dev-dashboard", content)
 	got, err := extractBinary(archive, "linux")
 	require.NoError(t, err)
 	require.Equal(t, content, got)
@@ -47,7 +47,7 @@ func TestExtractBinaryTarGz(t *testing.T) {
 
 func TestExtractBinaryZip(t *testing.T) {
 	content := []byte("fake-windows-binary")
-	archive := makeZip(t, "dev-dashboard.exe", content)
+	archive := makeZip(t, "diagrid-dev-dashboard.exe", content)
 	got, err := extractBinary(archive, "windows")
 	require.NoError(t, err)
 	require.Equal(t, content, got)

--- a/pkg/selfupdate/replace.go
+++ b/pkg/selfupdate/replace.go
@@ -14,7 +14,7 @@ import (
 // restored if the install fails.
 func replaceExecutable(path string, newBin []byte) error {
 	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".dev-dashboard-update-*")
+	tmp, err := os.CreateTemp(dir, ".diagrid-dev-dashboard-update-*")
 	if err != nil {
 		return fmt.Errorf("create temp file in %s: %w", dir, err)
 	}

--- a/pkg/selfupdate/replace_test.go
+++ b/pkg/selfupdate/replace_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestReplaceExecutable(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "dev-dashboard")
+	path := filepath.Join(dir, "diagrid-dev-dashboard")
 	require.NoError(t, os.WriteFile(path, []byte("old-binary"), 0o755))
 
 	require.NoError(t, replaceExecutable(path, []byte("new-binary")))

--- a/pkg/selfupdate/resolve.go
+++ b/pkg/selfupdate/resolve.go
@@ -1,4 +1,4 @@
-// Package selfupdate updates the dev-dashboard binary in place from GitHub Releases.
+// Package selfupdate updates the diagrid-dev-dashboard binary in place from GitHub Releases.
 package selfupdate
 
 import (

--- a/pkg/selfupdate/selfupdate.go
+++ b/pkg/selfupdate/selfupdate.go
@@ -83,7 +83,7 @@ func (u *Updater) Run(ctx context.Context, requested string) (Result, error) {
 	archiveURL := base + "/" + name
 	checksumsURL := base + "/checksums.txt"
 
-	fmt.Fprintf(u.Out, "downloading dev-dashboard %s (%s/%s)…\n", target, u.GOOS, u.GOARCH)
+	fmt.Fprintf(u.Out, "downloading diagrid-dev-dashboard %s (%s/%s)…\n", target, u.GOOS, u.GOARCH)
 	archive, err := httpGet(ctx, u.HTTP, archiveURL)
 	if err != nil {
 		if errors.Is(err, errNotFound) {

--- a/pkg/selfupdate/selfupdate_integration_test.go
+++ b/pkg/selfupdate/selfupdate_integration_test.go
@@ -21,16 +21,16 @@ import (
 // archive bytes plus a matching checksums.txt body.
 func newFakeRelease(t *testing.T, binary []byte) (archive []byte, checksums string) {
 	t.Helper()
-	archive = makeTarGz(t, "dev-dashboard", binary) // helper from extract_test.go
+	archive = makeTarGz(t, "diagrid-dev-dashboard", binary) // helper from extract_test.go
 	sum := sha256.Sum256(archive)
-	name := "dev-dashboard_1.2.0_linux_amd64.tar.gz"
+	name := "diagrid-dev-dashboard_1.2.0_linux_amd64.tar.gz"
 	checksums = hex.EncodeToString(sum[:]) + "  " + name + "\n"
 	return archive, checksums
 }
 
 func newUpdater(t *testing.T, srvURL, current string) (*Updater, string) {
 	t.Helper()
-	exe := filepath.Join(t.TempDir(), "dev-dashboard")
+	exe := filepath.Join(t.TempDir(), "diagrid-dev-dashboard")
 	require.NoError(t, os.WriteFile(exe, []byte("old-binary"), 0o755))
 	return &Updater{
 		Repo:           "diagridio/dev-dashboard",
@@ -99,7 +99,7 @@ func TestRunAlreadyCurrent(t *testing.T) {
 
 func TestRunChecksumMismatch(t *testing.T) {
 	archive, _ := newFakeRelease(t, []byte("new"))
-	badChecksums := "0000  dev-dashboard_1.2.0_linux_amd64.tar.gz\n"
+	badChecksums := "0000  diagrid-dev-dashboard_1.2.0_linux_amd64.tar.gz\n"
 	srv := releaseServer(t, archive, badChecksums, http.StatusOK)
 	defer srv.Close()
 

--- a/pkg/updatecheck/updatecheck.go
+++ b/pkg/updatecheck/updatecheck.go
@@ -1,4 +1,4 @@
-// Package updatecheck reports whether a newer dev-dashboard release exists.
+// Package updatecheck reports whether a newer diagrid-dev-dashboard release exists.
 package updatecheck
 
 import (

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,9 +1,9 @@
-# Install dev-dashboard to %LOCALAPPDATA%\Programs\dev-dashboard (no admin).
+# Install diagrid-dev-dashboard to %LOCALAPPDATA%\Programs\diagrid-dev-dashboard (no admin).
 #   iwr -useb https://raw.githubusercontent.com/diagridio/dev-dashboard/main/scripts/install.ps1 | iex
 # Env: $env:VERSION = 'vX.Y.Z' (default latest); $env:DRY_RUN = '1'
 $ErrorActionPreference = 'Stop'
 $repo = 'diagridio/dev-dashboard'
-$binDir = Join-Path $env:LOCALAPPDATA 'Programs\dev-dashboard'
+$binDir = Join-Path $env:LOCALAPPDATA 'Programs\diagrid-dev-dashboard'
 
 # There is no native windows/arm64 build (go-winjob cannot compile for it).
 # Windows 11 on ARM runs x64 binaries via built-in emulation, so we always
@@ -20,7 +20,7 @@ if (-not $version) {
     $version = $rel.tag_name
 }
 $num = $version.TrimStart('v')
-$file = "dev-dashboard_${num}_windows_${file_arch}.zip"
+$file = "diagrid-dev-dashboard_${num}_windows_${file_arch}.zip"
 $url = "https://github.com/$repo/releases/download/$version/$file"
 
 if ($env:DRY_RUN -eq '1') { Write-Output $url; exit 0 }
@@ -31,8 +31,8 @@ try {
     Invoke-WebRequest $url -OutFile (Join-Path $tmp $file)
     Expand-Archive -Path (Join-Path $tmp $file) -DestinationPath $tmp -Force
     New-Item -ItemType Directory -Force -Path $binDir | Out-Null
-    Copy-Item (Join-Path $tmp 'dev-dashboard.exe') (Join-Path $binDir 'dev-dashboard.exe') -Force
-    Write-Host "installed dev-dashboard $version -> $binDir\dev-dashboard.exe"
+    Copy-Item (Join-Path $tmp 'diagrid-dev-dashboard.exe') (Join-Path $binDir 'diagrid-dev-dashboard.exe') -Force
+    Write-Host "installed diagrid-dev-dashboard $version -> $binDir\diagrid-dev-dashboard.exe"
 } finally {
     if ($tmp -and (Test-Path $tmp)) { Remove-Item -Recurse -Force $tmp }
 }
@@ -40,4 +40,9 @@ try {
 if (($env:PATH -split ';') -notcontains $binDir) {
     Write-Host "note: $binDir is not on your PATH. Add it (user scope):"
     Write-Host "  setx PATH `"$binDir;`$env:PATH`""
+}
+
+$oldDir = Join-Path $env:LOCALAPPDATA 'Programs\dev-dashboard'
+if (Test-Path $oldDir) {
+    Write-Host "note: found a previous install under the old name at $oldDir; you can remove that folder (and its PATH entry)."
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# Install dev-dashboard to ~/.local/bin (no sudo).
+# Install diagrid-dev-dashboard to ~/.local/bin (no sudo).
 #   curl -sSL https://raw.githubusercontent.com/diagridio/dev-dashboard/main/scripts/install.sh | sh
 # Env: VERSION=vX.Y.Z (default: latest), BIN_DIR (default: ~/.local/bin), DRY_RUN=1
 set -eu
@@ -27,7 +27,7 @@ fi
 [ -n "$VERSION" ] || { echo "could not resolve latest version" >&2; exit 1; }
 
 num="${VERSION#v}"
-file="dev-dashboard_${num}_${os}_${arch}.tar.gz"
+file="diagrid-dev-dashboard_${num}_${os}_${arch}.tar.gz"
 url="https://github.com/$REPO/releases/download/$VERSION/$file"
 
 if [ "${DRY_RUN:-}" = "1" ]; then
@@ -41,8 +41,11 @@ trap 'rm -rf "$tmp"' EXIT
 curl -fsSL "$url" -o "$tmp/$file"
 tar -xzf "$tmp/$file" -C "$tmp"
 mkdir -p "$BIN_DIR"
-install -m 0755 "$tmp/dev-dashboard" "$BIN_DIR/dev-dashboard"
-echo "installed dev-dashboard $VERSION → $BIN_DIR/dev-dashboard"
+install -m 0755 "$tmp/diagrid-dev-dashboard" "$BIN_DIR/diagrid-dev-dashboard"
+echo "installed diagrid-dev-dashboard $VERSION → $BIN_DIR/diagrid-dev-dashboard"
+if [ -e "$BIN_DIR/dev-dashboard" ]; then
+  echo "note: found a previous install under the old name; remove it with: rm \"$BIN_DIR/dev-dashboard\""
+fi
 
 case ":$PATH:" in
   *":$BIN_DIR:"*) : ;;


### PR DESCRIPTION
## Summary

Renames the shipped binary from `dev-dashboard` to **`diagrid-dev-dashboard`** across every layer that must stay in lockstep: release archives, the binary inside them, self-update expectations, install scripts, CLI surface, container inner paths, and docs.

**⚠️ Breaking change (accepted):** existing installs cannot self-update across this rename — `dev-dashboard update` and the startup update prompt will fail with "release not found". Users reinstall once via the install one-liners. `docs/release-notes/binary-rename-snippet.md` contains ready-to-paste copy for the first renamed release's notes.

Plan: `docs/superpowers/plans/2026-07-14-binary-rename.md` (committed on main).

## What renames

- **goreleaser**: `project_name`/`binary` → archives become `diagrid-dev-dashboard_{ver}_{os}_{arch}.*` containing `diagrid-dev-dashboard[.exe]`; both docker builds' `ids` updated; inner container path `/diagrid-dev-dashboard` in both Dockerfiles.
- **`pkg/selfupdate`**: asset name, inner binary name, temp-file prefix — so a renamed binary upgrades cleanly to future renamed releases.
- **CLI**: cobra `Use`, `--version` banner, `update` help, startup upgrade hint.
- **Install scripts**: fetch/install the new names (`~/.local/bin/diagrid-dev-dashboard`, `%LOCALAPPDATA%\Programs\diagrid-dev-dashboard`), and print a notice when an old-named install is found.
- **Docs**: README (incl. a `go install` caveat — the module path still yields `dev-dashboard`), ARCHITECTURE.md, AGENTS.md, CONTRIBUTING.md, aspire-discovery.md diagram, issue template.

## What deliberately does NOT rename

- GitHub repo / Go module path `github.com/diagridio/dev-dashboard` (incl. goreleaser `release.github.name`, now guard-commented)
- Container image names `ghcr.io/diagridio/dev-dashboard*` (external consumers, incl. the Aspire hosting integration)
- `DEVDASHBOARD_*` env vars, `diagrid.ws/dev-dashboard-*` links, internal logger/UTM/telemetry identifiers
- `~/.dapr/dev-dashboard/` config dir — saved state-store connections carry over unchanged

## Test plan

- `make build && make test` green at c834147 (all Go packages with `-race`, web 719/719); the one commit after is docs-only.
- `make release-snapshot` end-to-end artifact check: `dist/` produced `diagrid-dev-dashboard_*` archives containing the renamed binary, and correctly still-named `ghcr.io/diagridio/dev-dashboard:*` images.
- `DRY_RUN=1` install-script check: URL is `…/diagridio/dev-dashboard/releases/download/v9.9.9/diagrid-dev-dashboard_9.9.9_<os>_<arch>.tar.gz`.
- Final whole-branch review verdict: mergeable; cross-layer name agreement independently verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)