### PR TITLE
fix: exclude stopped apps from state-store election and rescue dismissed running stores

### DIFF
--- a/cmd/derive.go
+++ b/cmd/derive.go
@@ -25,6 +25,14 @@ import (
 func derivePaths(apps []discovery.Instance, homeDir, stateStorePath string, extraResPaths []string) (resPaths, scanPaths []string, loaded map[string]bool, appPaths []string) {
 	loaded = make(map[string]bool)
 	for _, a := range apps {
+		// Election inputs (loaded, appPaths) count only running apps: a stopped
+		// app's daprd no longer serves its store, so it must not provide the
+		// active store (a stopped compose project would otherwise win election
+		// over a running app's own store). The store still stays detectable and
+		// listable via scanPaths/resPaths below, which include every app.
+		if !appRunning(a) {
+			continue
+		}
 		for _, c := range a.Components {
 			if strings.HasPrefix(c.Type, "state.") {
 				loaded[c.Name] = true
@@ -65,14 +73,25 @@ func derivePaths(apps []discovery.Instance, homeDir, stateStorePath string, extr
 	return resPaths, scanPaths, loaded, appPaths
 }
 
+// appRunning reports whether an app's daprd sidecar is live enough for its
+// state store to count toward active-store election. A daprd reported
+// "stopped" is excluded; an unknown ("") status counts as running, preserving
+// behavior for discovery sources that don't report daprd status.
+func appRunning(a discovery.Instance) bool {
+	return a.DaprdStatus != "stopped"
+}
+
 // appsFingerprint hashes the apps-derived inputs that the reconciler depends on:
 // the set of app IDs, the list (multiset, no dedup) of resource paths +
-// config-file dirs, and the set of loaded state-store component names.
+// config-file dirs, the set of loaded state-store component names, and the set
+// of currently-running app IDs. The running set is included so a running->
+// stopped flip re-triggers reconcile (and thus re-election), even when ids,
+// paths, and stores are otherwise unchanged.
 // Deduplication of paths happens downstream in statestore.Detect.
 // Order-independent: same content yields the same fingerprint regardless of
 // app ordering.
 func appsFingerprint(apps []discovery.Instance) string {
-	var ids, paths, stores []string
+	var ids, paths, stores, running []string
 	for _, a := range apps {
 		ids = append(ids, a.AppID)
 		paths = append(paths, a.ResourcePaths...)
@@ -84,10 +103,14 @@ func appsFingerprint(apps []discovery.Instance) string {
 				stores = append(stores, c.Name)
 			}
 		}
+		if appRunning(a) {
+			running = append(running, a.AppID)
+		}
 	}
 	sort.Strings(ids)
 	sort.Strings(paths)
 	sort.Strings(stores)
+	sort.Strings(running)
 
 	// Sentinel bytes keep the encoding unambiguous: every item is terminated by
 	// 0x00 and every group boundary is a bare 0x01, so a group separator can
@@ -95,7 +118,7 @@ func appsFingerprint(apps []discovery.Instance) string {
 	// Fingerprints are compared only in-memory within one process run (rc.fp),
 	// never persisted, so changing the encoding is safe.
 	h := sha256.New()
-	for gi, group := range [][]string{ids, paths, stores} {
+	for gi, group := range [][]string{ids, paths, stores, running} {
 		if gi > 0 {
 			h.Write([]byte{1})
 		}

--- a/cmd/derive_test.go
+++ b/cmd/derive_test.go
@@ -44,6 +44,41 @@ func TestDerivePaths_AppPaths(t *testing.T) {
 	require.NotContains(t, appPaths, "/home/me/.dapr/components")
 }
 
+// A stopped app must not provide the active store: a dead project's state
+// store keeps polluting election otherwise (e.g. a stopped compose project
+// winning over a running Aspire app's own store). Election inputs (loaded,
+// appPaths) exclude stopped apps; detection/resource paths keep them so the
+// stopped store stays inspectable in the panel.
+func TestDerivePaths_ExcludesStoppedAppsFromElectionInputs(t *testing.T) {
+	apps := []discovery.Instance{
+		{AppID: "running", DaprdStatus: "running", ResourcePaths: []string{"/run/resources"},
+			Components: []discovery.Component{{Name: "runstore", Type: "state.redis"}}},
+		{AppID: "stopped", DaprdStatus: "stopped", ResourcePaths: []string{"/stop/resources"},
+			Components: []discovery.Component{{Name: "stopstore", Type: "state.postgresql"}}},
+	}
+	resPaths, scanPaths, loaded, appPaths := derivePaths(apps, "/home/me", "", nil)
+
+	// Election inputs exclude the stopped app.
+	require.True(t, loaded["runstore"])
+	require.False(t, loaded["stopstore"], "a stopped app's store must not count as loaded")
+	require.Contains(t, appPaths, "/run/resources")
+	require.NotContains(t, appPaths, "/stop/resources", "a stopped app's paths must not feed election")
+
+	// Detection + resource paths still include the stopped app so its store
+	// remains detectable and listable in the panel.
+	require.Contains(t, scanPaths, "/stop/resources")
+	require.Contains(t, resPaths, "/stop/resources")
+}
+
+func TestAppsFingerprint_SensitiveToRunningStatus(t *testing.T) {
+	running := []discovery.Instance{{AppID: "a", DaprdStatus: "running",
+		ResourcePaths: []string{"/p"}, Components: []discovery.Component{{Name: "s", Type: "state.redis"}}}}
+	stopped := []discovery.Instance{{AppID: "a", DaprdStatus: "stopped",
+		ResourcePaths: []string{"/p"}, Components: []discovery.Component{{Name: "s", Type: "state.redis"}}}}
+	require.NotEqual(t, appsFingerprint(running), appsFingerprint(stopped),
+		"a running->stopped flip must change the fingerprint so re-election runs")
+}
+
 func TestAppsFingerprint_StableAndChangeSensitive(t *testing.T) {
 	a := []discovery.Instance{
 		{AppID: "b", ResourcePaths: []string{"/p2"}, Components: []discovery.Component{{Name: "s", Type: "state.redis"}}},

--- a/cmd/reconciler.go
+++ b/cmd/reconciler.go
@@ -159,6 +159,11 @@ func (rc *reconciler) reconcile(apps []discovery.Instance, fp string) {
 	newReg := newStoreRegistry(detected, loaded, appPaths)
 
 	rc.undismissActive(newReg.active())
+	// A store a running app provides must never stay hidden — even when it is
+	// not the one elected active (undismissActive only rescues the elected
+	// store). loaded/appPaths are already running-only (see derivePaths), so
+	// "app-provided" here means "provided by a running app".
+	rc.undismissAppProvided(detected, loaded, appPaths)
 
 	rc.mu.Lock()
 	if rc.closed {
@@ -190,6 +195,28 @@ func (rc *reconciler) undismissActive(active *statestore.Component) {
 	}
 	if err := rc.registry.Undismiss(active.Path); err != nil {
 		slog.Default().With("component", "reconciler").Warn("un-dismiss active store failed", "store", active.Name, "err", err)
+	}
+}
+
+// undismissAppProvided clears the dismissal tombstone for every detected store
+// a running app provides: loaded by name AND located under a running app's
+// resource path (the same "app-provided" test the election uses). Because
+// loaded/appPaths are running-only, this rescues stores a live app is using
+// but that lost election to another store, which undismissActive alone misses.
+// A nil registry is a no-op.
+func (rc *reconciler) undismissAppProvided(detected []statestore.Component, loaded map[string]bool, appPaths []string) {
+	if rc.registry == nil {
+		return
+	}
+	log := slog.Default().With("component", "reconciler")
+	for i := range detected {
+		c := detected[i]
+		if c.Path == "" || !loaded[c.Name] || !pathUnder(c.Path, appPaths) {
+			continue
+		}
+		if err := rc.registry.Undismiss(c.Path); err != nil {
+			log.Warn("un-dismiss app-provided store failed", "store", c.Name, "err", err)
+		}
 	}
 }
 

--- a/cmd/reconciler_test.go
+++ b/cmd/reconciler_test.go
@@ -601,3 +601,58 @@ func TestReconciler_UndismissActiveStore(t *testing.T) {
 	rc.undismissActive(nil)
 	rc.undismissActive(&statestore.Component{Name: "manual-ish"})
 }
+
+// A store provided by a RUNNING app must be un-dismissed on reconcile even
+// when it is not the one elected active — otherwise a store a live app is
+// using stays hidden forever (undismissActive only rescues the elected store).
+func TestReconciler_UndismissAppProvidedRunningStore(t *testing.T) {
+	home := t.TempDir()
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+
+	pathA := seedAutoComponentYAML(t, dirA, "storea", filepath.Join(dirA, "a.db"))
+	pathB := seedAutoComponentYAML(t, dirB, "storeb", filepath.Join(dirB, "b.db"))
+
+	reg := LoadRegistry(home)
+	require.NoError(t, reg.UpsertAuto(ConnEntry{Name: "storea", Type: "state.sqlite", Source: SourceAuto, Path: pathA}))
+	require.NoError(t, reg.UpsertAuto(ConnEntry{Name: "storeb", Type: "state.sqlite", Source: SourceAuto, Path: pathB}))
+
+	dismissed := func(path string) bool {
+		for _, e := range reg.List() {
+			if e.Path == path {
+				return e.Dismissed
+			}
+		}
+		return false
+	}
+	var idB string
+	for _, e := range reg.List() {
+		if e.Path == pathB {
+			idB = e.ID
+		}
+	}
+	require.NoError(t, reg.Delete(idB)) // user dismissed store B earlier
+	require.True(t, dismissed(pathB))
+
+	o := &fakeOpener{}
+	pool := newConnPool("default", &http.Client{}, nil, o.open, nil)
+	rc := newReconciler(context.Background(), nil, "default", home, "", &http.Client{}, reg, pool, nil, nil)
+	t.Cleanup(func() { _ = rc.Close() })
+
+	// Two RUNNING apps, each providing its own store. App A's store wins
+	// election (first in scan order); app B's is provided but not active.
+	apps := []discovery.Instance{
+		{AppID: "a", DaprdStatus: "running", ResourcePaths: []string{dirA},
+			Components: []discovery.Component{{Name: "storea", Type: "state.sqlite"}}},
+		{AppID: "b", DaprdStatus: "running", ResourcePaths: []string{dirB},
+			Components: []discovery.Component{{Name: "storeb", Type: "state.sqlite"}}},
+	}
+	rc.reconcile(apps, "fp1")
+
+	require.False(t, dismissed(pathB), "a store provided by a running app must be un-dismissed even when not active")
+	var names []string
+	for _, i := range rc.Stores() {
+		names = append(names, i.Name)
+	}
+	require.Contains(t, names, "storeb", "the un-dismissed store must reappear in the panel")
+}


### PR DESCRIPTION
## Problem

A running Aspire app (`pr-digest`, using Valkey/Redis on `localhost:16379`) showed an **empty workflow view**, and its state store was **missing from the workflow state-store list** — even though the app, its components, its gRPC port, and its workflows were all discovered correctly.

Discovery was fine. Two compounding bugs in **state-store election** and the **store panel** caused it:

1. **Stopped apps polluted election.** `derivePaths`/`newStoreRegistry` treated stopped apps identically to running ones. A stopped `dapr-mq` **compose** project (postgres, `actorStateStore: true`, first in scan order) won active-store election over the running app's own redis store. The workflow view defaults to the elected store → a dead postgres store with no data.

2. **A dismissed store from a running app could never come back.** The running app's `statestore.yaml` was marked `dismissed: true` in `connections.yaml`, so `reconciler.Stores()` hid it from the panel. `undismissActive` only un-dismisses the *elected* store — and because of bug #1 the running app's store never won election, so it stayed hidden forever.

## Fix

- **`cmd/derive.go`** — new `appRunning()` helper. Election inputs (`loaded`, `appPaths`) now count only running apps (daprd not `"stopped"`); `scanPaths`/`resPaths` still include every app so stopped stores stay detectable and listable. `appsFingerprint` now includes the running-app set so a running→stopped flip re-triggers reconcile/re-election.
- **`cmd/reconciler.go`** — new `undismissAppProvided()`. Reconcile un-dismisses **every** store a running app provides, not just the elected-active one.

## Tests (TDD)

New failing-first tests, all green:
- `TestDerivePaths_ExcludesStoppedAppsFromElectionInputs`
- `TestAppsFingerprint_SensitiveToRunningStatus`
- `TestReconciler_UndismissAppProvidedRunningStore`

Full unit suite (`-race`), cmd integration tests, `go build ./...`, `go vet`, and `gofmt` all pass.

## End-to-end verification

Built the new binary and ran it against the live repro (running Aspire app + stopped compose project):
- The app's redis store (`localhost:16379`) is now **`active`** and **present** in the statestore list (was dismissed/hidden; the dead postgres store was active).
- `/api/workflows` returned **50 workflows** resolved through the active store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)