### PR TITLE
Add Share the dashboard feature

### DIFF
--- a/web/src/components/ShareDialog.test.tsx
+++ b/web/src/components/ShareDialog.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ShareDialog } from './ShareDialog'
+import { copyText } from '../lib/clipboard'
+import { trackAction } from '../lib/telemetry'
+import { shareContent, emailUrl, xUrl, linkedinUrl, blueskyUrl } from '../lib/share'
+
+vi.mock('../lib/clipboard', () => ({ copyText: vi.fn() }))
+vi.mock('../lib/telemetry', () => ({ trackAction: vi.fn() }))
+
+const noop = () => {}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ShareDialog', () => {
+  it('renders nothing when closed', () => {
+    render(<ShareDialog open={false} onClose={noop} />)
+    expect(screen.queryByText('Share the dashboard')).toBeNull()
+  })
+
+  it('shows the full message preview when open', () => {
+    render(<ShareDialog open onClose={noop} />)
+    const preview = screen.getByLabelText('Share message preview') as HTMLTextAreaElement
+    expect(preview.value).toBe(shareContent.fullMessage)
+  })
+
+  it('Copy button copies the full message, shows a toast, and tracks the click', () => {
+    render(<ShareDialog open onClose={noop} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
+    expect(copyText).toHaveBeenCalledWith(shareContent.fullMessage)
+    expect(trackAction).toHaveBeenCalledWith('share_click', { channel: 'copy' })
+    expect(screen.getByText('Copied')).toBeInTheDocument()
+  })
+
+  it('renders channel anchors with the correct hrefs', () => {
+    render(<ShareDialog open onClose={noop} />)
+    expect(screen.getByRole('link', { name: 'Email' })).toHaveAttribute('href', emailUrl())
+    expect(screen.getByRole('link', { name: 'X' })).toHaveAttribute('href', xUrl())
+    expect(screen.getByRole('link', { name: 'LinkedIn' })).toHaveAttribute('href', linkedinUrl())
+    expect(screen.getByRole('link', { name: 'BlueSky' })).toHaveAttribute('href', blueskyUrl())
+  })
+
+  it('tracks the channel when a social anchor is clicked', () => {
+    render(<ShareDialog open onClose={noop} />)
+    fireEvent.click(screen.getByRole('link', { name: 'X' }))
+    expect(trackAction).toHaveBeenCalledWith('share_click', { channel: 'x' })
+  })
+})

--- a/web/src/components/ShareDialog.tsx
+++ b/web/src/components/ShareDialog.tsx
@@ -1,0 +1,88 @@
+import { useRef } from 'react'
+import { Modal } from './Modal'
+import { copyText } from '../lib/clipboard'
+import { useToast } from '../lib/toast'
+import { trackAction } from '../lib/telemetry'
+import {
+  shareContent,
+  emailUrl,
+  xUrl,
+  linkedinUrl,
+  blueskyUrl,
+  type ShareChannel,
+} from '../lib/share'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+export function ShareDialog({ open, onClose }: Props) {
+  const { toast, toastNode } = useToast()
+  const copyRef = useRef<HTMLButtonElement>(null)
+
+  function track(channel: ShareChannel) {
+    trackAction('share_click', { channel })
+  }
+
+  function handleCopy() {
+    copyText(shareContent.fullMessage)
+    toast.show('Copied')
+    track('copy')
+  }
+
+  return (
+    <Modal
+      open={open}
+      title="Share the dashboard"
+      onClose={onClose}
+      initialFocusRef={copyRef}
+      narrow
+    >
+      <p className="share-intro">Enjoying the dashboard? Send it to a colleague.</p>
+      <textarea
+        className="share-preview"
+        aria-label="Share message preview"
+        readOnly
+        rows={12}
+        value={shareContent.fullMessage}
+      />
+      <div className="modal-actions share-actions">
+        <button ref={copyRef} type="button" className="btn primary" onClick={handleCopy}>
+          Copy
+        </button>
+        <a className="btn ghost" href={emailUrl()} onClick={() => track('email')}>
+          Email
+        </a>
+        <a
+          className="btn ghost"
+          href={xUrl()}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => track('x')}
+        >
+          X
+        </a>
+        <a
+          className="btn ghost"
+          href={linkedinUrl()}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => track('linkedin')}
+        >
+          LinkedIn
+        </a>
+        <a
+          className="btn ghost"
+          href={blueskyUrl()}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => track('bluesky')}
+        >
+          BlueSky
+        </a>
+      </div>
+      {toastNode}
+    </Modal>
+  )
+}

--- a/web/src/components/TopNav.test.tsx
+++ b/web/src/components/TopNav.test.tsx
@@ -86,6 +86,25 @@ describe('TopNav', () => {
     expect(screen.getByRole('button', { name: /pause auto-refresh/i })).toBeInTheDocument()
   })
 
+  it('renders a Share button', () => {
+    renderNav()
+    expect(
+      screen.getByRole('button', { name: 'Share the dashboard' }),
+    ).toBeInTheDocument()
+  })
+
+  it('opens the Share dialog and tracks share_open', () => {
+    renderNav()
+    expect(
+      screen.queryByText('Enjoying the dashboard? Send it to a colleague.'),
+    ).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Share the dashboard' }))
+    expect(
+      screen.getByText('Enjoying the dashboard? Send it to a colleague.'),
+    ).toBeInTheDocument()
+    expect(trackAction).toHaveBeenCalledWith('share_open')
+  })
+
   it('does not render DensityToggle', () => {
     renderNav()
     expect(screen.queryByRole('button', { name: /toggle density/i })).not.toBeInTheDocument()

--- a/web/src/components/TopNav.tsx
+++ b/web/src/components/TopNav.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import { Logo } from './Logo'
 import { ThemeToggle } from './ThemeToggle'
 import { RefreshControl } from './RefreshControl'
+import { ShareDialog } from './ShareDialog'
 import type { Theme } from '../lib/prefs'
 import { trackAction } from '../lib/telemetry'
 import { getCapabilities, type Capabilities } from '../lib/capabilities'
@@ -34,6 +35,13 @@ export function TopNav({ theme, onThemeChange }: TopNavProps) {
   const headerRef = useRef<HTMLElement>(null)
   const caps = getCapabilities()
   const items = NAV_ITEMS.filter((item) => !item.cap || caps[item.cap])
+
+  const [shareOpen, setShareOpen] = useState(false)
+
+  function openShare() {
+    setShareOpen(true)
+    trackAction('share_open')
+  }
 
   // The nav can wrap onto extra rows on narrow/zoomed windows; the fixed
   // sidebar reads --topbar-h to start below the topbar's real height.
@@ -75,9 +83,19 @@ export function TopNav({ theme, onThemeChange }: TopNavProps) {
       </nav>
 
       <div className="topright">
+        <button
+          type="button"
+          className="tbtn"
+          aria-label="Share the dashboard"
+          onClick={openShare}
+        >
+          ↗ Share
+        </button>
         <RefreshControl />
         <ThemeToggle theme={theme} onThemeChange={onThemeChange} />
       </div>
+
+      <ShareDialog open={shareOpen} onClose={() => setShareOpen(false)} />
     </header>
   )
 }

--- a/web/src/components/TopNav.tsx
+++ b/web/src/components/TopNav.tsx
@@ -83,6 +83,8 @@ export function TopNav({ theme, onThemeChange }: TopNavProps) {
       </nav>
 
       <div className="topright">
+        <RefreshControl />
+        <ThemeToggle theme={theme} onThemeChange={onThemeChange} />
         <button
           type="button"
           className="tbtn"
@@ -91,8 +93,6 @@ export function TopNav({ theme, onThemeChange }: TopNavProps) {
         >
           ↗ Share
         </button>
-        <RefreshControl />
-        <ThemeToggle theme={theme} onThemeChange={onThemeChange} />
       </div>
 
       <ShareDialog open={shareOpen} onClose={() => setShareOpen(false)} />

--- a/web/src/content/share.yaml
+++ b/web/src/content/share.yaml
@@ -1,0 +1,26 @@
+# Copy shown by the Share dialog. Edit wording here — no code changes needed.
+# NOTE: keep the install commands in sync with the README (the source of truth).
+
+emailSubject: "Check out the Diagrid Dev Dashboard for local Dapr development"
+
+# Full message — used by Copy and Email. Install commands included.
+fullMessage: |
+  Hi!
+
+  I'm using the Diagrid Dev Dashboard, a practical companion for local Dapr development. It gives you a live view of everything Dapr running locally — apps, workflows, actors, components, logs, plus guided builders for Dapr component files and resiliency policies. It's free & open source.
+
+  GitHub: https://github.com/diagridio/dev-dashboard
+
+  Install (macOS / Linux):
+  curl -sSL https://raw.githubusercontent.com/diagridio/dev-dashboard/main/scripts/install.sh | sh
+
+  Install (Windows, PowerShell):
+  iwr -useb https://raw.githubusercontent.com/diagridio/dev-dashboard/main/scripts/install.ps1 | iex
+
+  Give it a try!
+
+# Short blurb for X — repo URL is appended by the builder via ?url=.
+shortX: "I'm using the Diagrid Dev Dashboard — a practical companion for local Dapr development. A live view of everything Dapr running locally plus guided builders for component files & resiliency policies. Free & open source 👇"
+
+# Short blurb for BlueSky — repo URL is appended to the text by the builder.
+shortBluesky: "I'm using the Diagrid Dev Dashboard — a practical companion for local Dapr development. A live view of everything Dapr running locally (apps, workflows, actors, components, logs) plus guided builders for component files & resiliency policies. Free & open source 👇"

--- a/web/src/content/share.yaml
+++ b/web/src/content/share.yaml
@@ -23,4 +23,4 @@ fullMessage: |
 shortX: "I'm using the Diagrid Dev Dashboard — a practical companion for local Dapr development. A live view of everything Dapr running locally plus guided builders for component files & resiliency policies. Free & open source 👇"
 
 # Short blurb for BlueSky — repo URL is appended to the text by the builder.
-shortBluesky: "I'm using the Diagrid Dev Dashboard — a practical companion for local Dapr development. A live view of everything Dapr running locally (apps, workflows, actors, components, logs) plus guided builders for component files & resiliency policies. Free & open source 👇"
+shortBluesky: "I'm using the Diagrid Dev Dashboard — a practical companion for local Dapr development. A live view of everything Dapr running locally plus guided builders for component files & resiliency policies. Free & open source 👇"

--- a/web/src/lib/share.test.ts
+++ b/web/src/lib/share.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import {
+  REPO_URL,
+  shareContent,
+  emailUrl,
+  xUrl,
+  linkedinUrl,
+  blueskyUrl,
+} from './share'
+
+describe('shareContent', () => {
+  it('has all required non-empty keys', () => {
+    for (const key of ['emailSubject', 'fullMessage', 'shortX', 'shortBluesky'] as const) {
+      expect(typeof shareContent[key]).toBe('string')
+      expect(shareContent[key].trim().length).toBeGreaterThan(0)
+    }
+  })
+
+  it('full message contains the repo URL and both install commands', () => {
+    expect(shareContent.fullMessage).toContain(REPO_URL)
+    expect(shareContent.fullMessage).toContain('scripts/install.sh | sh')
+    expect(shareContent.fullMessage).toContain('scripts/install.ps1 | iex')
+  })
+})
+
+describe('channel URL builders', () => {
+  it('emailUrl encodes subject and full-message body', () => {
+    const url = emailUrl()
+    expect(url.startsWith('mailto:?')).toBe(true)
+    expect(url).toContain(`subject=${encodeURIComponent(shareContent.emailSubject)}`)
+    expect(url).toContain(`body=${encodeURIComponent(shareContent.fullMessage)}`)
+  })
+
+  it('xUrl points at the intent endpoint with short text and repo url', () => {
+    const url = xUrl()
+    expect(url.startsWith('https://x.com/intent/tweet?')).toBe(true)
+    expect(url).toContain(`text=${encodeURIComponent(shareContent.shortX)}`)
+    expect(url).toContain(`url=${encodeURIComponent(REPO_URL)}`)
+  })
+
+  it('blueskyUrl includes short text and the repo url in the text', () => {
+    const url = blueskyUrl()
+    expect(url.startsWith('https://bsky.app/intent/compose?')).toBe(true)
+    expect(url).toContain(encodeURIComponent(shareContent.shortBluesky))
+    expect(url).toContain(encodeURIComponent(REPO_URL))
+  })
+
+  it('linkedinUrl shares the repo url only', () => {
+    const url = linkedinUrl()
+    expect(url.startsWith('https://www.linkedin.com/sharing/share-offsite/?')).toBe(true)
+    expect(url).toContain(`url=${encodeURIComponent(REPO_URL)}`)
+  })
+})

--- a/web/src/lib/share.test.ts
+++ b/web/src/lib/share.test.ts
@@ -50,4 +50,12 @@ describe('channel URL builders', () => {
     expect(url.startsWith('https://www.linkedin.com/sharing/share-offsite/?')).toBe(true)
     expect(url).toContain(`url=${encodeURIComponent(REPO_URL)}`)
   })
+
+  it('composed social messages fit their platform character limits', () => {
+    const graphemes = (s: string) => [...new Intl.Segmenter().segment(s)].length
+    const bluesky = `${shareContent.shortBluesky}\n${REPO_URL}`
+    expect(graphemes(bluesky)).toBeLessThanOrEqual(300)
+    const x = `${shareContent.shortX} ${REPO_URL}`
+    expect(graphemes(x)).toBeLessThanOrEqual(280)
+  })
 })

--- a/web/src/lib/share.ts
+++ b/web/src/lib/share.ts
@@ -1,0 +1,41 @@
+import { load } from 'js-yaml'
+import shareYamlRaw from '../content/share.yaml?raw'
+
+export const REPO_URL = 'https://github.com/diagridio/dev-dashboard'
+
+export interface ShareContent {
+  emailSubject: string
+  fullMessage: string
+  shortX: string
+  shortBluesky: string
+}
+
+/** Parsed at module load from the editable YAML content file. */
+export const shareContent = load(shareYamlRaw) as ShareContent
+
+export type ShareChannel = 'copy' | 'email' | 'x' | 'linkedin' | 'bluesky'
+
+/** mailto: with prefilled subject + full message body. */
+export function emailUrl(): string {
+  const subject = encodeURIComponent(shareContent.emailSubject)
+  const body = encodeURIComponent(shareContent.fullMessage)
+  return `mailto:?subject=${subject}&body=${body}`
+}
+
+/** X intent — short text plus repo URL as a separate param. */
+export function xUrl(): string {
+  const text = encodeURIComponent(shareContent.shortX)
+  const url = encodeURIComponent(REPO_URL)
+  return `https://x.com/intent/tweet?text=${text}&url=${url}`
+}
+
+/** BlueSky compose intent — repo URL appended to the text (no url param). */
+export function blueskyUrl(): string {
+  const text = encodeURIComponent(`${shareContent.shortBluesky}\n${REPO_URL}`)
+  return `https://bsky.app/intent/compose?text=${text}`
+}
+
+/** LinkedIn share — URL only; LinkedIn ignores prefilled text. */
+export function linkedinUrl(): string {
+  return `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(REPO_URL)}`
+}

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -515,3 +515,8 @@ pre.stacktrace { white-space: pre-wrap; overflow-wrap: anywhere; }
 .cp-label { font-family: var(--mono); font-size: 10px; letter-spacing: .08em; text-transform: uppercase; color: var(--muted); margin-bottom: 4px; }
 .cp-value { font-size: 12.5px; }
 .cp-logpath { word-break: break-all; }
+
+/* ---- Share dialog ---- */
+.share-intro { color: var(--muted); font-size: 13px; margin: 0 0 12px; }
+.share-preview { width: 100%; box-sizing: border-box; font: inherit; font-size: 12.5px; line-height: 1.5; color: var(--text); background: var(--surface-2); border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; resize: vertical; }
+.share-actions { flex-wrap: wrap; justify-content: flex-start; }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2021",
-    "lib": ["ES2021", "DOM", "DOM.Iterable"],
+    "lib": ["ES2021", "ES2022.Intl", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

Adds a **Share the dashboard** feature so users can easily pass the dashboard along to colleagues and friends. A Share button in the top nav opens a modal with a pre-written message — a short intro, the GitHub repo link, and the macOS/Linux & Windows install one-liners — sendable via **Copy**, **Email**, **X**, **LinkedIn**, or **BlueSky**.

Frontend-only; no backend changes.

## How it works

- **`web/src/content/share.yaml`** — all message copy lives here so wording is editable without touching code. Two variants: a full message (with install commands) for Copy/Email, and short blurbs for social (which link to the repo, where install docs already live).
- **`web/src/lib/share.ts`** — parses the YAML at build time (`?raw` + existing `js-yaml`) and exposes `REPO_URL` plus per-channel URL builders. Pure and unit-tested.
- **`web/src/components/ShareDialog.tsx`** — modal (built on the existing `Modal`) with a read-only message preview and the five channel controls. Channels are `<a>` anchors whose `href` is the builder output (simpler than `window.open`, no popup-blocker issues).
- **`web/src/components/TopNav.tsx`** — Share button in `.topright` (right of the Theme toggle) that toggles the dialog.

Telemetry: `share_open` when the dialog opens, `share_click { channel }` on each channel.

## Testing

- New unit tests for the content/builders (`share.test.ts`) including a grapheme-count guard that keeps social copy under X's 280 and BlueSky's 300 limits.
- Component tests for `ShareDialog` (preview, copy path, channel hrefs, telemetry) and TopNav (button + open + telemetry).
- Full web suite: **733 passing**. Typecheck clean.

## Notes / deferred

Reviewed via subagent-driven development; the final whole-branch review caught that the BlueSky copy overran the 300-grapheme limit — fixed and now guarded by a test. Four Minor findings deferred (non-blocking): unchecked YAML cast, Email anchor a11y label, a missing negative test for Email `target`/`rel`, and dialog DOM placement (cosmetic). Live click-through of each channel composer has not been run.

Design spec and implementation plan are included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
