### PR TITLE
Prefill LinkedIn share with message body

### DIFF
--- a/web/src/content/share.yaml
+++ b/web/src/content/share.yaml
@@ -21,5 +21,6 @@ fullMessage: |
 
 # Short blurb for social posts (X, BlueSky, LinkedIn) — the repo URL is
 # appended by each builder. Keep it under 254 chars so it still fits X's
-# 280-char limit once the repo URL is added.
-shortSocial: "I'm using the Diagrid Dev Dashboard — a practical companion for local Dapr development. A live view of everything Dapr running locally plus guided builders for component files & resiliency policies. Free & open source 👇"
+# 280-char limit once the repo URL is added. Avoid literal "&": LinkedIn's
+# feed composer truncates its text param at the first ampersand (write "and").
+shortSocial: "I'm using the Diagrid Dev Dashboard — a practical companion for local Dapr development. A live view of everything Dapr running locally plus guided builders for component files and resiliency policies. Free and open source 👇"

--- a/web/src/content/share.yaml
+++ b/web/src/content/share.yaml
@@ -19,8 +19,7 @@ fullMessage: |
 
   Give it a try!
 
-# Short blurb for X — repo URL is appended by the builder via ?url=.
-shortX: "I'm using the Diagrid Dev Dashboard — a practical companion for local Dapr development. A live view of everything Dapr running locally plus guided builders for component files & resiliency policies. Free & open source 👇"
-
-# Short blurb for BlueSky — repo URL is appended to the text by the builder.
-shortBluesky: "I'm using the Diagrid Dev Dashboard — a practical companion for local Dapr development. A live view of everything Dapr running locally plus guided builders for component files & resiliency policies. Free & open source 👇"
+# Short blurb for social posts (X, BlueSky, LinkedIn) — the repo URL is
+# appended by each builder. Keep it under 254 chars so it still fits X's
+# 280-char limit once the repo URL is added.
+shortSocial: "I'm using the Diagrid Dev Dashboard — a practical companion for local Dapr development. A live view of everything Dapr running locally plus guided builders for component files & resiliency policies. Free & open source 👇"

--- a/web/src/lib/share.test.ts
+++ b/web/src/lib/share.test.ts
@@ -52,6 +52,10 @@ describe('channel URL builders', () => {
     expect(url).toContain(encodeURIComponent(REPO_URL))
   })
 
+  it('social copy avoids literal ampersands (LinkedIn truncates its text param there)', () => {
+    expect(shareContent.shortSocial).not.toContain('&')
+  })
+
   it('composed social messages fit their platform character limits', () => {
     const graphemes = (s: string) => [...new Intl.Segmenter().segment(s)].length
     const bluesky = `${shareContent.shortSocial}\n${REPO_URL}`

--- a/web/src/lib/share.test.ts
+++ b/web/src/lib/share.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe('shareContent', () => {
   it('has all required non-empty keys', () => {
-    for (const key of ['emailSubject', 'fullMessage', 'shortX', 'shortBluesky'] as const) {
+    for (const key of ['emailSubject', 'fullMessage', 'shortSocial'] as const) {
       expect(typeof shareContent[key]).toBe('string')
       expect(shareContent[key].trim().length).toBeGreaterThan(0)
     }
@@ -34,28 +34,29 @@ describe('channel URL builders', () => {
   it('xUrl points at the intent endpoint with short text and repo url', () => {
     const url = xUrl()
     expect(url.startsWith('https://x.com/intent/tweet?')).toBe(true)
-    expect(url).toContain(`text=${encodeURIComponent(shareContent.shortX)}`)
+    expect(url).toContain(`text=${encodeURIComponent(shareContent.shortSocial)}`)
     expect(url).toContain(`url=${encodeURIComponent(REPO_URL)}`)
   })
 
   it('blueskyUrl includes short text and the repo url in the text', () => {
     const url = blueskyUrl()
     expect(url.startsWith('https://bsky.app/intent/compose?')).toBe(true)
-    expect(url).toContain(encodeURIComponent(shareContent.shortBluesky))
+    expect(url).toContain(encodeURIComponent(shareContent.shortSocial))
     expect(url).toContain(encodeURIComponent(REPO_URL))
   })
 
-  it('linkedinUrl shares the repo url only', () => {
+  it('linkedinUrl opens the feed composer with prefilled text and the repo url', () => {
     const url = linkedinUrl()
-    expect(url.startsWith('https://www.linkedin.com/sharing/share-offsite/?')).toBe(true)
-    expect(url).toContain(`url=${encodeURIComponent(REPO_URL)}`)
+    expect(url.startsWith('https://www.linkedin.com/feed/?shareActive=true&text=')).toBe(true)
+    expect(url).toContain(encodeURIComponent(shareContent.shortSocial))
+    expect(url).toContain(encodeURIComponent(REPO_URL))
   })
 
   it('composed social messages fit their platform character limits', () => {
     const graphemes = (s: string) => [...new Intl.Segmenter().segment(s)].length
-    const bluesky = `${shareContent.shortBluesky}\n${REPO_URL}`
+    const bluesky = `${shareContent.shortSocial}\n${REPO_URL}`
     expect(graphemes(bluesky)).toBeLessThanOrEqual(300)
-    const x = `${shareContent.shortX} ${REPO_URL}`
+    const x = `${shareContent.shortSocial} ${REPO_URL}`
     expect(graphemes(x)).toBeLessThanOrEqual(280)
   })
 })

--- a/web/src/lib/share.ts
+++ b/web/src/lib/share.ts
@@ -6,8 +6,7 @@ export const REPO_URL = 'https://github.com/diagridio/dev-dashboard'
 export interface ShareContent {
   emailSubject: string
   fullMessage: string
-  shortX: string
-  shortBluesky: string
+  shortSocial: string
 }
 
 /** Parsed at module load from the editable YAML content file. */
@@ -24,18 +23,24 @@ export function emailUrl(): string {
 
 /** X intent — short text plus repo URL as a separate param. */
 export function xUrl(): string {
-  const text = encodeURIComponent(shareContent.shortX)
+  const text = encodeURIComponent(shareContent.shortSocial)
   const url = encodeURIComponent(REPO_URL)
   return `https://x.com/intent/tweet?text=${text}&url=${url}`
 }
 
 /** BlueSky compose intent — repo URL appended to the text (no url param). */
 export function blueskyUrl(): string {
-  const text = encodeURIComponent(`${shareContent.shortBluesky}\n${REPO_URL}`)
+  const text = encodeURIComponent(`${shareContent.shortSocial}\n${REPO_URL}`)
   return `https://bsky.app/intent/compose?text=${text}`
 }
 
-/** LinkedIn share — URL only; LinkedIn ignores prefilled text. */
+/**
+ * LinkedIn — open the feed composer prefilled with the message. The older
+ * share-offsite endpoint accepts a URL only (title/summary params were
+ * deprecated), so we use the feed composer, which prefills body text and
+ * auto-generates a link preview from the repo URL embedded in it.
+ */
 export function linkedinUrl(): string {
-  return `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(REPO_URL)}`
+  const text = encodeURIComponent(`${shareContent.shortSocial}\n${REPO_URL}`)
+  return `https://www.linkedin.com/feed/?shareActive=true&text=${text}`
 }


### PR DESCRIPTION
## Summary

Makes the **LinkedIn** share option prefill a message body, not just a link.

The previous `linkedinUrl()` used LinkedIn's `share-offsite` endpoint, which accepts a **URL only** — LinkedIn deprecated its `title`/`summary`/text parameters years ago, so no body text could be attached. This switches to LinkedIn's feed composer endpoint:

```
https://www.linkedin.com/feed/?shareActive=true&text=<blurb + repo URL>
```

which opens the "Start a post" composer prefilled with the blurb, and auto-generates the link preview from the repo URL embedded in the text — the same approach already used for BlueSky.

## Changes

- `linkedinUrl()` now targets the feed composer with prefilled text (`web/src/lib/share.ts`).
- Consolidated the now-identical `shortX` and `shortBluesky` copy into a single `shortSocial` key used by all three social channels (X, BlueSky, LinkedIn), avoiding a third duplicate blurb.

## Trade-off (intentional)

The feed composer endpoint is unofficial (vs. the documented `share-offsite`), but a prefilled body is far more useful for "share with a colleague," and the risk is low for a plain link share. It opens the home-feed composer and requires the user to be logged in.

## Testing

- Updated `share.test.ts`: `linkedinUrl` now asserts the feed-composer format with prefilled text + repo URL; X/BlueSky builders and the grapheme-limit guard updated for the `shortSocial` key.
- `ShareDialog` tests already assert the LinkedIn anchor's href equals `linkedinUrl()`, so they cover the new format automatically.
- Full web suite: **733 passing**. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
