### PR TITLE
fix(e2e): make aspire discovery e2e race-free (fixes CI failure)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,7 +51,12 @@ jobs:
 
       - name: dapr init (full)
         if: steps.gate.outputs.run == 'true' && matrix.mode == 'aspire'
-        run: dapr init
+        # Pin the runtime so the placement/scheduler containers and the daprd
+        # the Aspire sidecar launches match the Dapr.Workflow 1.18.4 SDK the
+        # fixture is built against. An unpinned `dapr init` installs whatever is
+        # latest, which can skew against the SDK and break workflow scheduling
+        # (the sidecar never brings up its actor/workflow runtime).
+        run: dapr init --runtime-version 1.18.1
 
       - name: Build dashboard
         if: steps.gate.outputs.run == 'true'

--- a/test/e2e/aspire_e2e_test.go
+++ b/test/e2e/aspire_e2e_test.go
@@ -4,6 +4,7 @@ package e2e_test
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -129,6 +130,28 @@ spec:
 			strings.Contains(body, `"source":"aspire"`)
 	})
 
+	// dumpDiag surfaces why the orderservice sidecar isn't working: the
+	// dashboard's view of the app (health + any recorded error) and a direct
+	// probe of the sidecar's own HTTP port. Aspire runs headless here
+	// (DisableDashboard) and does not forward daprd/OrderService logs, so
+	// this is the only window into the sidecar's state from CI.
+	dumpDiag := func(context string) {
+		t.Logf("DIAG [%s] --------------------------------", context)
+		body, status := getJSON(t, base, "/api/apps/")
+		t.Logf("DIAG /api/apps/ (status %d): %s", status, body)
+		for _, path := range []string{"/v1.0/metadata", "/v1.0/healthz"} {
+			url := fmt.Sprintf("http://127.0.0.1:%d%s", daprHTTPPort, path)
+			res, err := http.Get(url)
+			if err != nil {
+				t.Logf("DIAG sidecar %s: ERROR %v", path, err)
+				continue
+			}
+			b, _ := io.ReadAll(res.Body)
+			_ = res.Body.Close()
+			t.Logf("DIAG sidecar %s: status %d body %s", path, res.StatusCode, string(b))
+		}
+	}
+
 	// The daprd sidecar must actually be up before workflows can run — its
 	// health is enriched from a live /v1.0/metadata call. Assert it here (with
 	// a generous window for the placement/scheduler handshake) so a sidecar
@@ -136,10 +159,20 @@ spec:
 	// diagnostic point rather than silently timing out at the workflow step
 	// below. App discovery above is satisfied by the env contract alone and
 	// does not prove the sidecar works.
-	waitFor(t, 3*time.Minute, func() bool {
+	healthy := false
+	healthDeadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(healthDeadline) {
 		body, _ := getJSON(t, base, "/api/apps/")
-		return strings.Contains(body, `"health":"healthy"`)
-	})
+		if strings.Contains(body, `"health":"healthy"`) {
+			healthy = true
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if !healthy {
+		dumpDiag("sidecar never healthy")
+		t.Fatal("orderservice sidecar never became healthy within 3m")
+	}
 
 	// Components: e2easpirestatestore from DEVDASHBOARD_RESOURCES_PATH.
 	waitFor(t, 30*time.Second, func() bool {
@@ -148,10 +181,20 @@ spec:
 	})
 
 	// Workflows: instance from the Aspire-managed Redis.
-	waitFor(t, 90*time.Second, func() bool {
+	scheduled := false
+	wfDeadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(wfDeadline) {
 		body, status := getJSON(t, base, "/api/workflows/")
-		return status == 200 && strings.Contains(body, "e2e-order-1")
-	})
+		if status == 200 && strings.Contains(body, "e2e-order-1") {
+			scheduled = true
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if !scheduled {
+		dumpDiag("workflow instance never appeared")
+		t.Fatal("workflow instance e2e-order-1 never appeared within 90s")
+	}
 
 	// Negative: controlplane and per-app logs are gated off in aspire mode.
 	_, status := getJSON(t, base, "/api/controlplane/")

--- a/test/e2e/aspire_e2e_test.go
+++ b/test/e2e/aspire_e2e_test.go
@@ -5,6 +5,7 @@ package e2e_test
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -71,12 +72,38 @@ spec:
   version: v1
   metadata:
   - name: redisHost
-    value: localhost:%d
+    value: 127.0.0.1:%d
   - name: actorStateStore
     value: "true"
 `, redisPort)
 	require.NoError(t, os.WriteFile(
 		filepath.Join(componentsDir, "e2easpirestatestore.yaml"), []byte(component), 0o644))
+
+	// Start Redis (the actor state store) and wait until it accepts connections
+	// BEFORE launching the AppHost. The daprd sidecar loads the state-store
+	// component at startup and fatally exits if Redis isn't reachable, and
+	// Aspire starts the sidecar outside its WaitFor graph — so an
+	// Aspire-managed Redis container races the sidecar and loses under load
+	// (the sidecar dies with "connection refused" and the app never becomes
+	// healthy). Owning Redis here, ready-first, makes that init race-free.
+	redisName := fmt.Sprintf("e2e-aspire-redis-%d", redisPort)
+	_ = exec.Command("docker", "rm", "-f", redisName).Run() // clear any stale container
+	runRedis := exec.Command("docker", "run", "-d", "--rm",
+		"--name", redisName,
+		"-p", fmt.Sprintf("127.0.0.1:%d:6379", redisPort),
+		"redis:7-alpine")
+	if out, err := runRedis.CombinedOutput(); err != nil {
+		t.Fatalf("docker run redis: %v: %s", err, out)
+	}
+	t.Cleanup(func() { _ = exec.Command("docker", "rm", "-f", redisName).Run() })
+	waitFor(t, 30*time.Second, func() bool {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", redisPort), time.Second)
+		if err != nil {
+			return false
+		}
+		_ = conn.Close()
+		return true
+	})
 
 	// Build first, then run the compiled native apphost binary directly rather
 	// than `dotnet run --project AppHost`: `dotnet run` spawns the apphost as a
@@ -99,7 +126,6 @@ spec:
 	apphost.Env = append(os.Environ(),
 		"DASH_BIN="+bin,
 		"DASH_PORT="+fmt.Sprint(port),
-		"REDIS_PORT="+fmt.Sprint(redisPort),
 		"ORDERSERVICE_DAPR_HTTP_PORT="+fmt.Sprint(daprHTTPPort),
 		"COMPONENTS_DIR="+componentsDir,
 	)
@@ -139,9 +165,12 @@ spec:
 		t.Logf("DIAG [%s] --------------------------------", context)
 		body, status := getJSON(t, base, "/api/apps/")
 		t.Logf("DIAG /api/apps/ (status %d): %s", status, body)
+		// Bounded client: the sidecar accepts connections even while its runtime
+		// is stuck initializing, so an unbounded GET to /v1.0/metadata hangs.
+		probe := &http.Client{Timeout: 5 * time.Second}
 		for _, path := range []string{"/v1.0/metadata", "/v1.0/healthz"} {
 			url := fmt.Sprintf("http://127.0.0.1:%d%s", daprHTTPPort, path)
-			res, err := http.Get(url)
+			res, err := probe.Get(url)
 			if err != nil {
 				t.Logf("DIAG sidecar %s: ERROR %v", path, err)
 				continue

--- a/test/e2e/aspire_e2e_test.go
+++ b/test/e2e/aspire_e2e_test.go
@@ -129,6 +129,18 @@ spec:
 			strings.Contains(body, `"source":"aspire"`)
 	})
 
+	// The daprd sidecar must actually be up before workflows can run — its
+	// health is enriched from a live /v1.0/metadata call. Assert it here (with
+	// a generous window for the placement/scheduler handshake) so a sidecar
+	// that never initializes its actor/workflow runtime fails at this
+	// diagnostic point rather than silently timing out at the workflow step
+	// below. App discovery above is satisfied by the env contract alone and
+	// does not prove the sidecar works.
+	waitFor(t, 3*time.Minute, func() bool {
+		body, _ := getJSON(t, base, "/api/apps/")
+		return strings.Contains(body, `"health":"healthy"`)
+	})
+
 	// Components: e2easpirestatestore from DEVDASHBOARD_RESOURCES_PATH.
 	waitFor(t, 30*time.Second, func() bool {
 		body, _ := getJSON(t, base, "/api/resources/?kind=component")

--- a/test/e2e/fixtures/aspire/AppHost/Program.cs
+++ b/test/e2e/fixtures/aspire/AppHost/Program.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
+using Aspire.Hosting.ApplicationModel;
 using CommunityToolkit.Aspire.Hosting.Dapr;
+using Microsoft.Extensions.DependencyInjection;
 
 // Every host-facing port and path is chosen by the Go e2e test (which uses
 // the harness's freePort helper, matching the compose/testcontainers
@@ -18,7 +20,6 @@ static string Required(string name) =>
     Environment.GetEnvironmentVariable(name)
     ?? throw new InvalidOperationException($"{name} not set");
 
-var redisPort = RequiredPort("REDIS_PORT");
 var orderServiceDaprHttpPort = RequiredPort("ORDERSERVICE_DAPR_HTTP_PORT");
 // Directory the Go test wrote e2easpirestatestore.yaml into (redisHost
 // already points at the chosen redis port). Shared by the daprd sidecar
@@ -37,14 +38,15 @@ var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOpt
     DisableDashboard = true,
 });
 
-// Redis for the Dapr state store component. AddContainer + WithEndpoint(...,
-// isProxied: false) publishes the chosen host port straight through to the
-// container so the component YAML (written by the Go test) can name it;
-// Aspire.Hosting.Redis's AddRedis() helper instead enables TLS and a random
-// per-run password by default, which daprd would then need extra wiring to
-// trust/authenticate against.
-builder.AddContainer("statestore-redis", "redis", "7-alpine")
-    .WithEndpoint(port: redisPort, targetPort: 6379, scheme: "tcp", name: "tcp", isProxied: false);
+// NOTE: Redis (the actor state store) is intentionally NOT an Aspire resource.
+// The daprd sidecar loads the state-store component during startup and FATALLY
+// EXITS if Redis isn't yet accepting connections. Aspire starts the sidecar as
+// its own resource outside the WaitFor graph (WaitFor on the sidecar is not
+// honored), so it always races an Aspire-managed Redis container and loses
+// under load. Instead the Go test starts Redis and waits for it to accept
+// connections BEFORE launching this AppHost, and the component YAML it writes
+// points daprd at 127.0.0.1:<redisPort>. That makes the sidecar's component
+// init race-free by construction.
 
 // The OrderService Dapr workflow app, with its sidecar HTTP port pinned to
 // the test-chosen port so the dashboard's env contract (below) can name it.
@@ -86,4 +88,35 @@ builder.AddExecutable("dashboard", dashBin, componentsDir,
     // enough here.
     .WithEnvironment("DEVDASHBOARD_STATESTORE_FILE", stateStoreFile);
 
-builder.Build().Run();
+var app = builder.Build();
+
+// Aspire runs headless here (DisableDashboard) and does not otherwise surface
+// child-resource logs. Forward every resource's logs to the AppHost's stdout so
+// CI captures daprd/OrderService output — the only window into why the sidecar
+// fails to initialize on the runner.
+_ = Task.Run(async () =>
+{
+    var notifications = app.Services.GetRequiredService<ResourceNotificationService>();
+    var loggers = app.Services.GetRequiredService<ResourceLoggerService>();
+    var watched = new HashSet<string>();
+    await foreach (var evt in notifications.WatchAsync())
+    {
+        if (!watched.Add(evt.ResourceId))
+        {
+            continue;
+        }
+        var resourceId = evt.ResourceId;
+        _ = Task.Run(async () =>
+        {
+            await foreach (var batch in loggers.WatchAsync(resourceId))
+            {
+                foreach (var line in batch)
+                {
+                    Console.WriteLine($"[resource:{resourceId}] {line.Content}");
+                }
+            }
+        });
+    }
+});
+
+app.Run();


### PR DESCRIPTION
## Summary

Fixes the Aspire discovery e2e test failing in CI (added in #66). Root-caused from daprd's own logs and verified on the CI runner.

## Root cause

The daprd sidecar loads the Redis state-store component at startup and **fatally exits** if Redis isn't yet accepting connections (`dial tcp 127.0.0.1:<port>: connect: connection refused` → `exit status 1`). Aspire starts the Dapr sidecar as its own resource **outside its `WaitFor` graph** — `WaitFor` is honored for neither the project nor the sidecar resource — so an Aspire-managed Redis container always races the sidecar and loses under load. Result: constant failure in CI, ~1-in-3 locally. The app/component checks passed anyway because they're satisfied by the env contract + resources dir without exercising the sidecar; the failure only surfaced at the workflow step.

## Fix

The Go test now **owns the Redis lifecycle** — it starts Redis and waits for it to accept connections *before* launching the AppHost, and the component YAML points daprd at it. This makes the sidecar's component init race-free by construction. Redis is removed from the Aspire graph.

## Also included (from the investigation)

- **AppHost forwards all resource logs to stdout** — headless Aspire (`DisableDashboard`) surfaced nothing; this is what exposed the daprd error.
- **On-failure diagnostics** in the test: dumps `/api/apps/` and probes the sidecar with a bounded HTTP client (an unbounded probe hung).
- **CI pins `dapr init --runtime-version 1.18.1`** to match the `Dapr.Workflow` 1.18.4 SDK.

## Verification

- **8/8** consecutive local runs pass (previously 3/8 failed).
- **2/2** CI runs green on the runner that was failing 3/3 (runs 29495508093, 29495512465).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
