### PR TITLE
feat: context-sensitive CLI drawer with Dapr commands

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { http, HttpResponse } from 'msw'
 import { server } from './test/setup'
+import { App } from './App'
 import { Placeholder } from './pages/Placeholder'
 import { routes } from './router'
 import { QueryProvider, makeQueryClient } from './lib/query'
@@ -136,5 +137,44 @@ describe('RUM tracking', () => {
       </QueryProvider>,
     )
     expect(trackView).toHaveBeenCalledWith('Workflows')
+  })
+})
+
+describe('App CLI drawer wiring', () => {
+  function renderAppAt(path: string) {
+    const client = makeQueryClient()
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/',
+          element: <App />,
+          children: [
+            { path: 'apps/:appId', element: <div>app detail</div>, handle: { rumView: 'AppDetail' } },
+            { path: 'configurations', element: <div>configs</div>, handle: { rumView: 'Configurations' } },
+          ],
+        },
+      ],
+      { initialEntries: [path], future: { v7_relativeSplatPath: true } },
+    )
+    return render(
+      <QueryProvider client={client}>
+        <RefreshProvider>
+          <ConnectionContext value={{ online: true }}>
+            <RouterProvider router={router} future={{ v7_startTransition: true }} />
+          </ConnectionContext>
+        </RefreshProvider>
+      </QueryProvider>,
+    )
+  }
+
+  it('shows the CLI tab with the route appId resolved on AppDetail', () => {
+    renderAppAt('/apps/order')
+    fireEvent.click(screen.getByRole('button', { name: 'CLI commands' }))
+    expect(screen.getByText('dapr stop --app-id order')).toBeInTheDocument()
+  })
+
+  it('does not render the CLI tab on a context without content', () => {
+    renderAppAt('/configurations')
+    expect(screen.queryByRole('button', { name: 'CLI commands' })).toBeNull()
   })
 })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react'
-import { Outlet, useMatches } from 'react-router-dom'
+import { Outlet, useMatches, useSearchParams } from 'react-router-dom'
 import { SmallScreenGuard } from './components/SmallScreenGuard'
 import { TopNav } from './components/TopNav'
 import { ResourcesSidebar } from './components/ResourcesSidebar'
+import { CliDrawer } from './components/CliDrawer'
 import { getTheme, type Theme } from './lib/prefs'
 import { safeGet } from './lib/safeStorage'
 import { trackAction, trackView } from './lib/telemetry'
@@ -29,6 +30,13 @@ export function App() {
     .map((m) => (m.handle as RouteHandle | undefined)?.rumView)
     .find(Boolean)
 
+  const [searchParams] = useSearchParams()
+  const leafParams = (matches[matches.length - 1]?.params ?? {}) as Record<string, string | undefined>
+  const cliValues = {
+    appId: leafParams.appId ?? searchParams.get('app') ?? undefined,
+    instanceId: leafParams.instanceId ?? undefined,
+  }
+
   useEffect(() => {
     trackAction('app_startup')
   }, [])
@@ -54,6 +62,7 @@ export function App() {
         <main className="body">
           <Outlet />
         </main>
+        <CliDrawer context={rumView} values={cliValues} />
       </div>
     </SmallScreenGuard>
   )

--- a/web/src/components/CliCommand.test.tsx
+++ b/web/src/components/CliCommand.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CliCommand } from './CliCommand'
+import { copyText } from '../lib/clipboard'
+
+vi.mock('../lib/clipboard', () => ({ copyText: vi.fn() }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('CliCommand', () => {
+  it('renders the title and command text', () => {
+    render(<CliCommand title="Stop this app" command="dapr stop --app-id order" />)
+    expect(screen.getByText('Stop this app')).toBeInTheDocument()
+    expect(screen.getByText('dapr stop --app-id order')).toBeInTheDocument()
+  })
+
+  it('copies the exact command and calls onCopied when Copy is clicked', () => {
+    const onCopied = vi.fn()
+    render(
+      <CliCommand title="Stop this app" command="dapr stop --app-id order" onCopied={onCopied} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /copy/i }))
+    expect(copyText).toHaveBeenCalledWith('dapr stop --app-id order')
+    expect(onCopied).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders a docs link only when docs is set', () => {
+    const { rerender } = render(<CliCommand title="A" command="dapr list" />)
+    expect(screen.queryByRole('link')).toBeNull()
+    rerender(<CliCommand title="A" command="dapr list" docs="https://docs.dapr.io/x/" />)
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://docs.dapr.io/x/')
+  })
+})

--- a/web/src/components/CliCommand.tsx
+++ b/web/src/components/CliCommand.tsx
@@ -36,9 +36,7 @@ export function CliCommand({ title, command, docs, onCopied }: CliCommandProps) 
           className="btn ghost cli-copy"
           aria-label={`Copy command: ${command}`}
           onClick={handleCopy}
-        >
-          Copy
-        </button>
+        />
       </div>
     </div>
   )

--- a/web/src/components/CliCommand.tsx
+++ b/web/src/components/CliCommand.tsx
@@ -1,0 +1,45 @@
+import { copyText } from '../lib/clipboard'
+
+interface CliCommandProps {
+  title: string
+  command: string
+  docs?: string
+  onCopied?: () => void
+}
+
+export function CliCommand({ title, command, docs, onCopied }: CliCommandProps) {
+  function handleCopy() {
+    copyText(command)
+    onCopied?.()
+  }
+
+  return (
+    <div className="cli-command">
+      <div className="cli-command-head">
+        <span className="cli-command-title">{title}</span>
+        {docs && (
+          <a
+            className="cli-command-docs"
+            href={docs}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`${title} — Dapr CLI docs`}
+          >
+            ↗
+          </a>
+        )}
+      </div>
+      <div className="cli-command-row">
+        <code className="cli-command-code">{command}</code>
+        <button
+          type="button"
+          className="btn ghost cli-copy"
+          aria-label={`Copy command: ${command}`}
+          onClick={handleCopy}
+        >
+          Copy
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/CliCommand.tsx
+++ b/web/src/components/CliCommand.tsx
@@ -33,11 +33,11 @@ export function CliCommand({ title, command, docs, onCopied }: CliCommandProps) 
         <code className="cli-command-code">{command}</code>
         <button
           type="button"
-          className="btn ghost cli-copy"
+          className="copybtn cli-copy"
           aria-label={`Copy command: ${command}`}
           onClick={handleCopy}
         >
-          Copy
+          ⧉ Copy
         </button>
       </div>
     </div>

--- a/web/src/components/CliCommand.tsx
+++ b/web/src/components/CliCommand.tsx
@@ -25,7 +25,7 @@ export function CliCommand({ title, command, docs, onCopied }: CliCommandProps) 
             rel="noopener noreferrer"
             aria-label={`${title} — Dapr CLI docs`}
           >
-            ↗
+            <span className="ext">↗</span>
           </a>
         )}
       </div>

--- a/web/src/components/CliCommand.tsx
+++ b/web/src/components/CliCommand.tsx
@@ -36,7 +36,9 @@ export function CliCommand({ title, command, docs, onCopied }: CliCommandProps) 
           className="btn ghost cli-copy"
           aria-label={`Copy command: ${command}`}
           onClick={handleCopy}
-        />
+        >
+          Copy
+        </button>
       </div>
     </div>
   )

--- a/web/src/components/CliDrawer.test.tsx
+++ b/web/src/components/CliDrawer.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CliDrawer } from './CliDrawer'
+import { copyText } from '../lib/clipboard'
+
+vi.mock('../lib/clipboard', () => ({ copyText: vi.fn() }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+})
+
+describe('CliDrawer', () => {
+  it('renders nothing for a context with no content', () => {
+    const { container } = render(<CliDrawer context="Logs" values={{}} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when context is undefined', () => {
+    const { container } = render(<CliDrawer context={undefined} values={{}} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows the CLI tab and resolves values into commands on AppDetail', () => {
+    render(<CliDrawer context="AppDetail" values={{ appId: 'order' }} />)
+    expect(screen.getByRole('button', { name: 'CLI commands' })).toBeInTheDocument()
+    expect(screen.getByText('dapr stop --app-id order')).toBeInTheDocument()
+  })
+
+  it('starts collapsed and toggles open/closed via the tab', () => {
+    render(<CliDrawer context="AppDetail" values={{ appId: 'order' }} />)
+    const drawer = document.querySelector('.cli-drawer')!
+    expect(drawer.className).not.toContain('open')
+    fireEvent.click(screen.getByRole('button', { name: 'CLI commands' }))
+    expect(document.querySelector('.cli-drawer')!.className).toContain('open')
+  })
+
+  it('persists the open state to localStorage', () => {
+    render(<CliDrawer context="AppDetail" values={{ appId: 'order' }} />)
+    fireEvent.click(screen.getByRole('button', { name: 'CLI commands' }))
+    expect(localStorage.getItem('devdash.cliDrawerOpen')).toBe('true')
+  })
+
+  it('opens collapsed=false initially when localStorage says open', () => {
+    localStorage.setItem('devdash.cliDrawerOpen', 'true')
+    render(<CliDrawer context="AppDetail" values={{ appId: 'order' }} />)
+    expect(document.querySelector('.cli-drawer')!.className).toContain('open')
+  })
+
+  it('falls back to a literal <app-id> when appId is absent', () => {
+    render(<CliDrawer context="Workflows" values={{}} />)
+    expect(screen.getByText('dapr workflow list --app-id <app-id>')).toBeInTheDocument()
+  })
+
+  it('copies the resolved command and shows a Copied toast', () => {
+    render(<CliDrawer context="AppDetail" values={{ appId: 'order' }} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy command: dapr stop --app-id order' }))
+    expect(copyText).toHaveBeenCalledWith('dapr stop --app-id order')
+    expect(screen.getByText('Copied')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/CliDrawer.test.tsx
+++ b/web/src/components/CliDrawer.test.tsx
@@ -54,6 +54,7 @@ describe('CliDrawer', () => {
 
   it('copies the resolved command and shows a Copied toast', () => {
     render(<CliDrawer context="AppDetail" values={{ appId: 'order' }} />)
+    fireEvent.click(screen.getByRole('button', { name: 'CLI commands' }))
     fireEvent.click(screen.getByRole('button', { name: 'Copy command: dapr stop --app-id order' }))
     expect(copyText).toHaveBeenCalledWith('dapr stop --app-id order')
     expect(screen.getByText('Copied')).toBeInTheDocument()

--- a/web/src/components/CliDrawer.tsx
+++ b/web/src/components/CliDrawer.tsx
@@ -23,6 +23,8 @@ export function CliDrawer({ context, values }: CliDrawerProps) {
   const toolIds = Object.keys(content.tools)
   const tool = content.tools[toolIds[0]]
 
+  if (!tool) return null
+
   function toggle() {
     setOpen((prev) => {
       const next = !prev
@@ -42,7 +44,7 @@ export function CliDrawer({ context, values }: CliDrawerProps) {
       >
         CLI
       </button>
-      <aside className="cli-panel" aria-hidden={!open} aria-label="CLI commands panel">
+      <aside className="cli-panel" inert={!open} aria-hidden={!open} aria-label="CLI commands panel">
         <div className="cli-panel-head">
           <h2>CLI</h2>
           <button type="button" className="cli-close" aria-label="Close CLI drawer" onClick={toggle}>

--- a/web/src/components/CliDrawer.tsx
+++ b/web/src/components/CliDrawer.tsx
@@ -46,7 +46,7 @@ export function CliDrawer({ context, values }: CliDrawerProps) {
       </button>
       <aside className="cli-panel" inert={!open} aria-hidden={!open} aria-label="CLI commands panel">
         <div className="cli-panel-head">
-          <h2>CLI</h2>
+          <h2>Dapr CLI</h2>
           <button type="button" className="cli-close" aria-label="Close CLI drawer" onClick={toggle}>
             ✕
           </button>

--- a/web/src/components/CliDrawer.tsx
+++ b/web/src/components/CliDrawer.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+import { getCliContent, resolvePlaceholders } from '../lib/cli'
+import { CliCommand } from './CliCommand'
+import { useToast } from '../lib/toast'
+import { safeGet, safeSet } from '../lib/safeStorage'
+
+const OPEN_KEY = 'devdash.cliDrawerOpen'
+
+interface CliDrawerProps {
+  context?: string
+  values: Record<string, string | undefined>
+}
+
+export function CliDrawer({ context, values }: CliDrawerProps) {
+  const content = getCliContent(context)
+  const { toast, toastNode } = useToast()
+  const [open, setOpen] = useState(() => safeGet(OPEN_KEY) === 'true')
+
+  if (!content) return null
+
+  // Single tool for now (Dapr). The tools map is keyed for a future second
+  // tool; a tab bar is intentionally not rendered while only one exists.
+  const toolIds = Object.keys(content.tools)
+  const tool = content.tools[toolIds[0]]
+
+  function toggle() {
+    setOpen((prev) => {
+      const next = !prev
+      safeSet(OPEN_KEY, String(next))
+      return next
+    })
+  }
+
+  return (
+    <div className={`cli-drawer${open ? ' open' : ''}`}>
+      <button
+        type="button"
+        className="cli-tab"
+        aria-expanded={open}
+        aria-label="CLI commands"
+        onClick={toggle}
+      >
+        CLI
+      </button>
+      <aside className="cli-panel" aria-label="CLI commands panel">
+        <div className="cli-panel-head">
+          <h2>CLI</h2>
+          <button type="button" className="cli-close" aria-label="Close CLI drawer" onClick={toggle}>
+            ✕
+          </button>
+        </div>
+        <div className="cli-commands">
+          {tool.commands.map((c) => (
+            <CliCommand
+              key={c.title}
+              title={c.title}
+              command={resolvePlaceholders(c.command, values)}
+              docs={c.docs}
+              onCopied={() => toast.show('Copied')}
+            />
+          ))}
+        </div>
+      </aside>
+      {toastNode}
+    </div>
+  )
+}

--- a/web/src/components/CliDrawer.tsx
+++ b/web/src/components/CliDrawer.tsx
@@ -42,7 +42,7 @@ export function CliDrawer({ context, values }: CliDrawerProps) {
       >
         CLI
       </button>
-      <aside className="cli-panel" aria-label="CLI commands panel">
+      <aside className="cli-panel" aria-hidden={!open} aria-label="CLI commands panel">
         <div className="cli-panel-head">
           <h2>CLI</h2>
           <button type="button" className="cli-close" aria-label="Close CLI drawer" onClick={toggle}>

--- a/web/src/components/CliDrawer.tsx
+++ b/web/src/components/CliDrawer.tsx
@@ -42,7 +42,7 @@ export function CliDrawer({ context, values }: CliDrawerProps) {
         aria-label="CLI commands"
         onClick={toggle}
       >
-        CLI
+        <span className="cli-vtext">CLI</span>
       </button>
       <aside className="cli-panel" inert={!open} aria-hidden={!open} aria-label="CLI commands panel">
         <div className="cli-panel-head">

--- a/web/src/content/cli/actors.yaml
+++ b/web/src/content/cli/actors.yaml
@@ -1,0 +1,11 @@
+context: Actors
+tools:
+  dapr:
+    label: Dapr
+    commands:
+      - title: List scheduled jobs and reminders
+        command: dapr scheduler list
+        docs: https://docs.dapr.io/reference/cli/dapr-scheduler/
+      - title: Get an actor reminder
+        command: dapr scheduler get actor/<actor-type>/<actor-id>/<reminder-name> -o yaml
+        docs: https://docs.dapr.io/reference/cli/dapr-scheduler/

--- a/web/src/content/cli/app-detail.yaml
+++ b/web/src/content/cli/app-detail.yaml
@@ -1,0 +1,11 @@
+context: AppDetail
+tools:
+  dapr:
+    label: Dapr
+    commands:
+      - title: Stop this app
+        command: dapr stop --app-id {{appId}}
+        docs: https://docs.dapr.io/reference/cli/dapr-stop/
+      - title: Invoke a method on this app
+        command: dapr invoke --app-id {{appId}} --method <method> --data '{"key":"value"}'
+        docs: https://docs.dapr.io/reference/cli/dapr-invoke/

--- a/web/src/content/cli/applications.yaml
+++ b/web/src/content/cli/applications.yaml
@@ -1,0 +1,11 @@
+# CLI commands shown in the drawer on the Applications overview page.
+# Edit wording/commands here — no code changes needed.
+# Constraint: self-hosted only, never a `-k` / `--kubernetes` command.
+context: Applications
+tools:
+  dapr:
+    label: Dapr
+    commands:
+      - title: List running Dapr apps
+        command: dapr list
+        docs: https://docs.dapr.io/reference/cli/dapr-list/

--- a/web/src/content/cli/subscriptions.yaml
+++ b/web/src/content/cli/subscriptions.yaml
@@ -1,0 +1,8 @@
+context: Subscriptions
+tools:
+  dapr:
+    label: Dapr
+    commands:
+      - title: Publish a test event
+        command: dapr publish --publish-app-id <app-id> --pubsub <pubsub> --topic <topic> --data '{"key":"value"}'
+        docs: https://docs.dapr.io/reference/cli/dapr-publish/

--- a/web/src/content/cli/workflow-detail.yaml
+++ b/web/src/content/cli/workflow-detail.yaml
@@ -1,0 +1,23 @@
+context: WorkflowDetail
+tools:
+  dapr:
+    label: Dapr
+    commands:
+      - title: View execution history
+        command: dapr workflow history {{instanceId}} --app-id {{appId}}
+        docs: https://docs.dapr.io/reference/cli/dapr-workflow/
+      - title: Terminate this instance
+        command: dapr workflow terminate {{instanceId}} --app-id {{appId}}
+        docs: https://docs.dapr.io/reference/cli/dapr-workflow/
+      - title: Pause (suspend) this instance
+        command: dapr workflow suspend {{instanceId}} --app-id {{appId}}
+        docs: https://docs.dapr.io/reference/cli/dapr-workflow/
+      - title: Resume this instance
+        command: dapr workflow resume {{instanceId}} --app-id {{appId}}
+        docs: https://docs.dapr.io/reference/cli/dapr-workflow/
+      - title: Purge this instance
+        command: dapr workflow purge {{instanceId}} --app-id {{appId}}
+        docs: https://docs.dapr.io/reference/cli/dapr-workflow/
+      - title: Inspect this instance's scheduler reminder
+        command: dapr scheduler get workflow/{{appId}}/{{instanceId}}/<reminder-name> -o yaml
+        docs: https://docs.dapr.io/reference/cli/dapr-scheduler/

--- a/web/src/content/cli/workflows.yaml
+++ b/web/src/content/cli/workflows.yaml
@@ -1,0 +1,14 @@
+context: Workflows
+tools:
+  dapr:
+    label: Dapr
+    commands:
+      - title: List workflows for this app
+        command: dapr workflow list --app-id {{appId}}
+        docs: https://docs.dapr.io/reference/cli/dapr-workflow/
+      - title: List running workflows
+        command: dapr workflow list --app-id {{appId}} --filter-status RUNNING
+        docs: https://docs.dapr.io/reference/cli/dapr-workflow/
+      - title: List scheduled jobs
+        command: dapr scheduler list
+        docs: https://docs.dapr.io/reference/cli/dapr-scheduler/

--- a/web/src/lib/cli.test.ts
+++ b/web/src/lib/cli.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { getCliContent, resolvePlaceholders } from './cli'
+
+const CONTEXTS = ['Applications', 'AppDetail', 'Workflows', 'WorkflowDetail', 'Actors', 'Subscriptions']
+
+describe('getCliContent', () => {
+  it('loads content for every supported context with a dapr tool and commands', () => {
+    for (const ctx of CONTEXTS) {
+      const content = getCliContent(ctx)
+      expect(content, ctx).toBeDefined()
+      expect(content!.context).toBe(ctx)
+      expect(content!.tools.dapr.label).toBe('Dapr')
+      expect(content!.tools.dapr.commands.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('returns undefined for unknown or missing contexts', () => {
+    expect(getCliContent('Logs')).toBeUndefined()
+    expect(getCliContent(undefined)).toBeUndefined()
+  })
+
+  it('ships no Kubernetes-only commands', () => {
+    for (const ctx of CONTEXTS) {
+      for (const c of getCliContent(ctx)!.tools.dapr.commands) {
+        expect(c.command, c.command).not.toMatch(/(^|\s)(-k|--kubernetes)(\s|$)/)
+      }
+    }
+  })
+
+  it('exposes the expected app-detail commands', () => {
+    const cmds = getCliContent('AppDetail')!.tools.dapr.commands.map((c) => c.command)
+    expect(cmds).toContain('dapr stop --app-id {{appId}}')
+  })
+})
+
+describe('resolvePlaceholders', () => {
+  it('substitutes present values', () => {
+    expect(resolvePlaceholders('dapr stop --app-id {{appId}}', { appId: 'order' })).toBe(
+      'dapr stop --app-id order',
+    )
+    expect(
+      resolvePlaceholders('dapr workflow history {{instanceId}} --app-id {{appId}}', {
+        appId: 'order',
+        instanceId: 'abc-123',
+      }),
+    ).toBe('dapr workflow history abc-123 --app-id order')
+  })
+
+  it('falls back to kebab-cased <token> literals for missing/empty values', () => {
+    expect(resolvePlaceholders('dapr workflow list --app-id {{appId}}', {})).toBe(
+      'dapr workflow list --app-id <app-id>',
+    )
+    expect(resolvePlaceholders('history {{instanceId}}', { instanceId: '' })).toBe(
+      'history <instance-id>',
+    )
+  })
+
+  it('leaves literal <...> placeholders untouched', () => {
+    const cmd = 'dapr invoke --app-id {{appId}} --method <method>'
+    expect(resolvePlaceholders(cmd, { appId: 'order' })).toBe(
+      'dapr invoke --app-id order --method <method>',
+    )
+  })
+})

--- a/web/src/lib/cli.ts
+++ b/web/src/lib/cli.ts
@@ -1,0 +1,62 @@
+import { load } from 'js-yaml'
+import applicationsRaw from '../content/cli/applications.yaml?raw'
+import appDetailRaw from '../content/cli/app-detail.yaml?raw'
+import workflowsRaw from '../content/cli/workflows.yaml?raw'
+import workflowDetailRaw from '../content/cli/workflow-detail.yaml?raw'
+import actorsRaw from '../content/cli/actors.yaml?raw'
+import subscriptionsRaw from '../content/cli/subscriptions.yaml?raw'
+
+export interface CliCommandDef {
+  title: string
+  command: string
+  docs?: string
+}
+
+export interface CliTool {
+  label: string
+  commands: CliCommandDef[]
+}
+
+export interface CliContent {
+  context: string
+  tools: Record<string, CliTool>
+}
+
+const rawByContext: Record<string, string> = {
+  Applications: applicationsRaw,
+  AppDetail: appDetailRaw,
+  Workflows: workflowsRaw,
+  WorkflowDetail: workflowDetailRaw,
+  Actors: actorsRaw,
+  Subscriptions: subscriptionsRaw,
+}
+
+const contentByContext: Record<string, CliContent> = Object.fromEntries(
+  Object.entries(rawByContext).map(([ctx, raw]) => [ctx, load(raw) as CliContent]),
+)
+
+/** Returns drawer content for a route context (rumView), or undefined if none. */
+export function getCliContent(context: string | undefined): CliContent | undefined {
+  if (!context) return undefined
+  return contentByContext[context]
+}
+
+/** camelCase token -> kebab-case literal placeholder, e.g. appId -> <app-id>. */
+function tokenToLiteral(token: string): string {
+  return `<${token.replace(/([A-Z])/g, '-$1').toLowerCase()}>`
+}
+
+/**
+ * Substitutes {{token}} placeholders from `values`. Missing/empty values fall
+ * back to a readable <kebab-token> literal so the command stays copyable.
+ * Literal <...> placeholders in the source command are left untouched.
+ */
+export function resolvePlaceholders(
+  command: string,
+  values: Record<string, string | undefined>,
+): string {
+  return command.replace(/\{\{(\w+)\}\}/g, (_match, token: string) => {
+    const value = values[token]
+    return value != null && value !== '' ? value : tokenToLiteral(token)
+  })
+}

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -520,3 +520,34 @@ pre.stacktrace { white-space: pre-wrap; overflow-wrap: anywhere; }
 .share-intro { color: var(--muted); font-size: 13px; margin: 0 0 12px; }
 .share-preview { width: 100%; box-sizing: border-box; font: inherit; font-size: 12.5px; line-height: 1.5; color: var(--text); background: var(--surface-2); border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; resize: vertical; }
 .share-actions { flex-wrap: wrap; justify-content: flex-start; }
+
+/* ---------- CLI drawer ---------- */
+.cli-drawer { position: fixed; inset: 0; pointer-events: none; z-index: 40; }
+.cli-tab {
+  pointer-events: auto; position: fixed; right: 0; top: calc(var(--topbar-h, 46px) + 40px);
+  z-index: 41; writing-mode: vertical-rl; transform: rotate(180deg);
+  background: var(--surface-2); color: var(--text); border: 1px solid var(--line);
+  border-radius: 8px 0 0 8px; padding: 14px 6px; font-size: 12px; font-weight: 600;
+  letter-spacing: .1em; cursor: pointer; box-shadow: var(--shadow);
+  transition: right .18s ease;
+}
+.cli-drawer.open .cli-tab { right: min(33vw, 33%); }
+.cli-panel {
+  pointer-events: auto; position: fixed; top: var(--topbar-h, 46px); right: 0; bottom: 0;
+  width: min(33vw, 33%); z-index: 40; background: var(--surface);
+  border-left: 1px solid var(--line); box-shadow: var(--shadow);
+  transform: translateX(100%); transition: transform .18s ease;
+  display: flex; flex-direction: column; overflow-y: auto;
+}
+.cli-drawer.open .cli-panel { transform: translateX(0); }
+.cli-panel-head { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid var(--line); }
+.cli-panel-head h2 { margin: 0; font-size: 13px; font-weight: 700; letter-spacing: .04em; }
+.cli-close { background: none; border: none; color: var(--text); font-size: 15px; line-height: 1; cursor: pointer; padding: 4px; }
+.cli-commands { padding: 14px 16px; display: flex; flex-direction: column; gap: 16px; }
+.cli-command-head { display: flex; align-items: center; gap: 6px; margin-bottom: 6px; }
+.cli-command-title { font-size: 12.5px; font-weight: 600; }
+.cli-command-docs { text-decoration: none; opacity: .7; }
+.cli-command-docs:hover { opacity: 1; }
+.cli-command-row { display: flex; align-items: stretch; gap: 8px; }
+.cli-command-code { flex: 1; min-width: 0; background: var(--surface-2); border: 1px solid var(--line); border-radius: 6px; padding: 8px 10px; font-size: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; word-break: break-all; }
+.cli-copy { white-space: nowrap; align-self: flex-start; }

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -526,10 +526,14 @@ pre.stacktrace { white-space: pre-wrap; overflow-wrap: anywhere; }
 .cli-tab {
   pointer-events: auto; position: fixed; right: 0; top: calc(var(--topbar-h, 46px) + 40px);
   z-index: 41; writing-mode: vertical-rl;
-  background: var(--surface-2); color: var(--text); border: 1px solid var(--line);
-  border-radius: 8px 0 0 8px; padding: 14px 6px; font-size: 12px; font-weight: 600;
-  letter-spacing: .1em; cursor: pointer; box-shadow: var(--shadow);
+  background: var(--surface-2); border: 1px solid var(--line);
+  border-radius: 8px 0 0 8px; padding: 14px 6px; cursor: pointer; box-shadow: var(--shadow);
   transition: right .18s ease;
+}
+.cli-tab .cli-vtext {
+  display: inline-block; transform: rotate(180deg);
+  font-family: var(--mono); font-size: 11px; letter-spacing: .18em;
+  text-transform: uppercase; color: var(--muted);
 }
 .cli-drawer.open .cli-tab { right: min(33vw, 33%); }
 .cli-panel {
@@ -546,10 +550,8 @@ pre.stacktrace { white-space: pre-wrap; overflow-wrap: anywhere; }
 .cli-commands { padding: 14px 16px; display: flex; flex-direction: column; gap: 16px; }
 .cli-command-head { display: flex; align-items: center; gap: 6px; margin-bottom: 6px; }
 .cli-command-title { font-size: 12.5px; font-weight: 600; }
-.cli-command-docs { margin-left: auto; text-decoration: none; }
-.cli-command-docs .ext { color: var(--faint); font-size: 11px; opacity: 0; }
-.cli-command:hover .cli-command-docs .ext,
-.cli-command-docs:focus-visible .ext { opacity: 1; }
+.cli-command-docs { text-decoration: none; display: inline-flex; align-items: center; }
+.cli-command-docs .ext { color: var(--faint); font-size: 11px; }
 .cli-command-row { display: flex; align-items: stretch; gap: 8px; }
 .cli-command-code { flex: 1; min-width: 0; background: var(--surface-2); border: 1px solid var(--line); border-radius: 6px; padding: 8px 10px; font-size: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; word-break: break-all; }
 .cli-copy { white-space: nowrap; align-self: flex-start; }

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -525,7 +525,7 @@ pre.stacktrace { white-space: pre-wrap; overflow-wrap: anywhere; }
 .cli-drawer { position: fixed; inset: 0; pointer-events: none; z-index: 40; }
 .cli-tab {
   pointer-events: auto; position: fixed; right: 0; top: calc(var(--topbar-h, 46px) + 40px);
-  z-index: 41; writing-mode: vertical-rl; transform: rotate(180deg);
+  z-index: 41; writing-mode: vertical-rl;
   background: var(--surface-2); color: var(--text); border: 1px solid var(--line);
   border-radius: 8px 0 0 8px; padding: 14px 6px; font-size: 12px; font-weight: 600;
   letter-spacing: .1em; cursor: pointer; box-shadow: var(--shadow);
@@ -546,8 +546,10 @@ pre.stacktrace { white-space: pre-wrap; overflow-wrap: anywhere; }
 .cli-commands { padding: 14px 16px; display: flex; flex-direction: column; gap: 16px; }
 .cli-command-head { display: flex; align-items: center; gap: 6px; margin-bottom: 6px; }
 .cli-command-title { font-size: 12.5px; font-weight: 600; }
-.cli-command-docs { text-decoration: none; opacity: .7; }
-.cli-command-docs:hover { opacity: 1; }
+.cli-command-docs { margin-left: auto; text-decoration: none; }
+.cli-command-docs .ext { color: var(--faint); font-size: 11px; opacity: 0; }
+.cli-command:hover .cli-command-docs .ext,
+.cli-command-docs:focus-visible .ext { opacity: 1; }
 .cli-command-row { display: flex; align-items: stretch; gap: 8px; }
 .cli-command-code { flex: 1; min-width: 0; background: var(--surface-2); border: 1px solid var(--line); border-radius: 6px; padding: 8px 10px; font-size: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; word-break: break-all; }
 .cli-copy { white-space: nowrap; align-self: flex-start; }


### PR DESCRIPTION
## Summary

Adds a right-side collapsible **CLI drawer** that surfaces context-sensitive, self-hosted Dapr CLI commands for the current page, each with a copy button. A slim vertical "CLI" tab on the right edge slides an overlay panel over page content (fixed positioning, ≤ 1/3 width, **no layout shift**). Content is context-sensitive per page and populates `{{appId}}` / `{{instanceId}}` from the current route.

Design spec and plan: `docs/superpowers/specs/2026-07-16-cli-drawer-design.md`, `docs/superpowers/plans/2026-07-16-cli-drawer.md`.

## What's included

- **Content layer** (`web/src/lib/cli.ts` + `web/src/content/cli/*.yaml`): one editable YAML file per page context (Applications, AppDetail, Workflows, WorkflowDetail, Actors, Subscriptions). `{{token}}` placeholders resolve from the route; literal `<...>` placeholders pass through. Schema keyed by tool id so a future Diagrid Catalyst tool slots in (no tab bar while only Dapr exists).
- **`CliCommand`**: one command row — title, optional docs "↗" link, command in `<code>`, and a Copy button (`copyText` + "Copied" toast, matching ShareDialog).
- **`CliDrawer`**: pure component (props `context` + `values`); vertical edge tab + overlay panel; open state persisted to `localStorage` (`devdash.cliDrawerOpen`), collapsed by default; closed panel is `inert` for keyboard/AT safety.
- **App shell wiring** (`App.tsx`): derives context from the route `rumView` and values from the leaf match params + `?app=` search param — no page components changed. CSS added to `theme.css` using existing tokens.

## Commands surfaced (self-hosted only)

- Applications: `dapr list`
- App detail: `dapr stop --app-id <id>`, `dapr invoke ...`
- Workflows: `dapr workflow list --app-id <id>` (+ `--filter-status RUNNING`), `dapr scheduler list`
- Workflow detail: `dapr workflow history/terminate/suspend/resume/purge <instanceId> --app-id <id>`, `dapr scheduler get workflow/<id>/<instanceId>/...`
- Actors: `dapr scheduler list` / `get actor/...`
- Subscriptions: `dapr publish ...`

**No Kubernetes commands.** `dapr components`, `dapr configurations`, `dapr status`, and `dapr logs` are `-k`-only and are deliberately excluded, so Components/Configurations/ControlPlane/Logs/Resiliency pages show no drawer. A test guards against `-k`/`--kubernetes` regressions.

## Testing

- 754/754 web tests passing; `npm run build` (tsc + vite) clean.
- New unit tests for `cli.ts` (content loads for all 6 contexts, placeholder resolution + fallback, no-k8s guard), `CliCommand`, `CliDrawer` (visibility, toggle, persistence, resolution), and `App.tsx` integration (tab appears with resolved appId on AppDetail; absent on a no-content context).
- Built via TDD with per-task and whole-branch review; the review found and fixed an `aria-hidden`/focus a11y issue (closed panel now `inert`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)