### PR TITLE
Limit Restart & Start to Docker Compose apps

### DIFF
--- a/docs/superpowers/plans/2026-07-17-limit-restart-start-to-compose.md
+++ b/docs/superpowers/plans/2026-07-17-limit-restart-start-to-compose.md
@@ -121,7 +121,7 @@ Keep `fakeStarter` (still used by `TestStandaloneStartRestartRejected`). Keep al
 
 - [ ] **Step 6: Run the full lifecycle package tests**
 
-Run: `go test ./pkg/lifecycle/... ./pkg/server/...`
+Run: `make test-go` (server tests sit behind the `//go:build unit` tag, so `make test-go` / `go test -tags unit ./...` is required; a plain `go test ./pkg/server/...` silently reports "no test files").
 Expected: PASS. (`pkg/server/apps_test.go` already maps `ErrUnsupported` → HTTP 400 via a `fakeLifecycle` double, so no server test changes are needed.)
 
 - [ ] **Step 7: Build the Go module**

--- a/docs/superpowers/plans/2026-07-17-limit-restart-start-to-compose.md
+++ b/docs/superpowers/plans/2026-07-17-limit-restart-start-to-compose.md
@@ -1,0 +1,359 @@
+# Limit Restart & Start to Compose mode — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restrict the Restart and Start lifecycle actions to Docker Compose apps only, in both the backend Manager and the Application detail UI, while leaving Stop available for every mode where it works today.
+
+**Architecture:** A single policy guard in `lifecycle.doStandalone` rejects any non-stop action with `ErrUnsupported`; the existing `standaloneStart` machinery stays in place, dormant behind the gate. In `AppDetail.tsx`, the Restart/Start buttons (header and per-panel) gain an `isCompose` gate, and a hint explains the absence for running dapr-run apps. Stop, Remove-from-list, the registry stop-snapshot, and stopped-instance visibility are untouched.
+
+**Tech Stack:** Go (backend `pkg/lifecycle`), React + TypeScript + Vitest + MSW (frontend `web/src`).
+
+## Global Constraints
+
+- Stop must remain available for Compose, Dapr run (standalone), Aspire, and orphaned sidecars — only Restart and Start are being restricted.
+- Compose (`doCompose`) and Testcontainers behavior is unchanged.
+- `RecordStop` and stopped-instance registry visibility must stay intact so stopped dapr-run apps still render as *stopped* and offer **Remove from list**.
+- Real dapr-run apps always arrive with `source: 'standalone'` (the server normalizes empty source to `standalone` in `pkg/discovery/service.go:220`).
+- Vitest does NOT typecheck — run `cd web && npx tsc -b` (or `make build`) after any `.tsx` change, test files included.
+- Commit message trailer: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Backend — gate start/restart to Compose in the lifecycle Manager
+
+**Files:**
+- Modify: `pkg/lifecycle/manager.go:136-163` (`doStandalone`)
+- Test: `pkg/lifecycle/manager_test.go` (replace the standalone start/restart success cases)
+
+**Interfaces:**
+- Consumes: existing `manager.Do` → `doStandalone(ctx, in, target, action)`, sentinel `ErrUnsupported`, `ActionStop`/`ActionStart`/`ActionRestart`, `TargetAll`/`TargetApp`/`TargetDaprd`.
+- Produces: no new exported symbols. Behavior change only: `Do` on a standalone (non-compose, non-testcontainers) instance returns `ErrUnsupported` for any action other than `ActionStop`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to `pkg/lifecycle/manager_test.go` (e.g. right after `TestStandaloneStopSingleTargetEscalatesToKill`, near line 224):
+
+```go
+// Start and restart are Compose-only: dapr-run (standalone) instances reject
+// both with ErrUnsupported and touch no process or starter, even when a stop
+// snapshot exists that could tempt a re-run. Stop stays supported (covered by
+// the standalone stop tests).
+func TestStandaloneStartRestartRejected(t *testing.T) {
+	proc := newFakeProc()
+	proc.snaps[100] = ProcSnapshot{PID: 100, Argv: []string{"go", "run", "."}, Dir: "/src"}
+	proc.alive[100] = true
+	st := &fakeStarter{}
+	reg := NewRegistry()
+	reg.RecordStop(standaloneInst(), map[Target]ProcSnapshot{
+		TargetAll: {PID: 300, Argv: []string{"dapr", "run", "--app-id", "orders"}, Dir: "/src"},
+	})
+	m := New(fakeApps{items: map[string]discovery.Instance{"orders": standaloneInst()}}, reg, nil, proc, st)
+
+	cases := []struct {
+		target Target
+		action Action
+	}{
+		{TargetAll, ActionStart},
+		{TargetApp, ActionStart},
+		{TargetAll, ActionRestart},
+		{TargetDaprd, ActionRestart},
+	}
+	for _, tc := range cases {
+		require.ErrorIs(t, m.Do(context.Background(), "orders", tc.target, tc.action), ErrUnsupported)
+	}
+	require.Empty(t, st.started, "standalone start machinery must not run")
+	require.Empty(t, proc.terminated, "restart must not signal any process")
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./pkg/lifecycle/ -run TestStandaloneStartRestartRejected -v`
+Expected: FAIL — start/restart currently succeed, so `require.ErrorIs(... ErrUnsupported)` fails (and `st.started`/`proc.terminated` are non-empty).
+
+- [ ] **Step 3: Add the policy guard in `doStandalone`**
+
+In `pkg/lifecycle/manager.go`, insert the guard after the orphaned-sidecar check and before the `switch action` block. The surrounding code becomes:
+
+```go
+	if in.SidecarOrphaned && action != ActionStop {
+		return fmt.Errorf("%w: orphaned sidecar — only stop is supported", ErrUnsupported)
+	}
+	// Restart and start only work reliably for Docker Compose apps, where the
+	// container runtime restarts containers cleanly. For dapr-run instances the
+	// re-run-from-snapshot path is unreliable, so only stop is offered. The
+	// standaloneStart machinery below stays in place, dormant behind this gate,
+	// for when standalone start becomes reliable.
+	if action != ActionStop {
+		return fmt.Errorf("%w: restart and start are only supported for Docker Compose apps", ErrUnsupported)
+	}
+	switch action {
+	case ActionStop:
+		return m.standaloneStop(ctx, in, target)
+	case ActionStart:
+		return m.standaloneStart(ctx, in, target)
+	default: // restart
+		if err := m.standaloneStop(ctx, in, target); err != nil {
+			return err
+		}
+		return m.standaloneStart(ctx, in, target)
+	}
+```
+
+Leave the `switch` intact — its start/restart arms are now unreachable but keep `standaloneStart` referenced (dormant machinery, no dead-code removal). Leave the Aspire and orphan guards above it as-is so they keep their specific messages.
+
+- [ ] **Step 4: Run the new test to verify it passes**
+
+Run: `go test ./pkg/lifecycle/ -run TestStandaloneStartRestartRejected -v`
+Expected: PASS.
+
+- [ ] **Step 5: Remove the now-superseded standalone start/restart success tests**
+
+Delete these four tests from `pkg/lifecycle/manager_test.go` (they assert start/restart success, which no longer holds):
+- `TestStandaloneStartAllRerunsCLICommand`
+- `TestStandaloneStartSingleTarget`
+- `TestStandaloneRestartStopsThenStarts`
+- `TestStandaloneStartAllWithoutCLISnapshotStartsHalvesInOrder`
+
+Also delete `TestStandaloneStartWithoutSnapshotRejected` — it still passes but for a now-misleading reason (the new blanket guard, not the missing snapshot); the consolidated test covers rejection.
+
+Keep `fakeStarter` (still used by `TestStandaloneStartRestartRejected`). Keep all stop tests, `TestAspireStartRejectedStopAllowed`, `TestOrphanedSidecarOnlyStopAllowed`, and the compose tests unchanged.
+
+- [ ] **Step 6: Run the full lifecycle package tests**
+
+Run: `go test ./pkg/lifecycle/... ./pkg/server/...`
+Expected: PASS. (`pkg/server/apps_test.go` already maps `ErrUnsupported` → HTTP 400 via a `fakeLifecycle` double, so no server test changes are needed.)
+
+- [ ] **Step 7: Build the Go module**
+
+Run: `go build ./...`
+Expected: no errors (`standaloneStart` remains referenced by the switch, so no unused-symbol issues).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pkg/lifecycle/manager.go pkg/lifecycle/manager_test.go
+git commit -m "feat(lifecycle): restrict start/restart to Docker Compose apps
+
+Dapr-run start/restart via process-snapshot re-run is unreliable; gate
+doStandalone to stop-only. standaloneStart machinery kept dormant behind
+the gate. Consolidate the standalone start/restart tests into a rejection test.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Frontend — gate Restart/Start to Compose and add the dapr-run hint
+
+**Files:**
+- Modify: `web/src/pages/AppDetail.tsx` (`panelActions`, page header buttons, hints block)
+- Test: `web/src/pages/AppDetail.test.tsx`
+
+**Interfaces:**
+- Consumes: existing `isCompose = app.source === 'compose'`, `isTestcontainers`, `orphaned = !!app.sidecarOrphaned`, `anyRunning`, `allStopped`, `caps.lifecycle`, `runAction(target, action, what)`.
+- Produces: no new exports. UI change: Restart/Start buttons render only when `isCompose`; a `.hint` renders for running standalone apps.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `web/src/pages/AppDetail.test.tsx`, add three new tests inside the `describe('AppDetail', …)` block (place near the other lifecycle tests, e.g. after `'funnels sidecar stop to the whole instance for dapr run apps'`):
+
+```tsx
+it('hides Restart and Start for a running dapr run app but keeps Stop and shows a hint', async () => {
+  server.use(http.get('/api/apps/order', () => HttpResponse.json({ ...runningApp, source: 'standalone' })))
+  renderDetail()
+  await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+  expect(screen.queryByRole('button', { name: 'Restart' })).not.toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: 'Start' })).not.toBeInTheDocument()
+  expect(screen.getAllByRole('button', { name: 'Stop' }).length).toBeGreaterThan(0)
+  expect(screen.getByText(/restart and start it from your terminal/i)).toBeInTheDocument()
+})
+
+it('keeps Restart for a running compose app', async () => {
+  server.use(http.get('/api/apps/order', () => HttpResponse.json({ ...runningApp, source: 'compose' })))
+  renderDetail()
+  await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+  expect(screen.getAllByRole('button', { name: 'Restart' }).length).toBeGreaterThan(0)
+  // Nothing is stopped, so no Start button; and no dapr-run hint for compose.
+  expect(screen.queryByText(/restart and start it from your terminal/i)).not.toBeInTheDocument()
+})
+
+it('hides Start for a fully stopped dapr run app, offering Remove instead', async () => {
+  server.use(
+    http.get('/api/apps/order', () =>
+      HttpResponse.json({
+        ...runningApp,
+        source: 'standalone',
+        health: 'unknown',
+        appStatus: 'stopped',
+        daprdStatus: 'stopped',
+        appPid: 0,
+        daprdPid: 0,
+      }),
+    ),
+  )
+  renderDetail()
+  await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+  expect(screen.queryByRole('button', { name: 'Start' })).not.toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Remove from list' })).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `cd web && npx vitest run src/pages/AppDetail.test.tsx -t "dapr run"`
+Expected: FAIL — the running dapr-run app currently shows Restart/Start and no hint; the fully-stopped dapr-run app currently shows a whole-instance Start.
+
+- [ ] **Step 3: Gate the per-panel Restart/Start on `isCompose`**
+
+In `web/src/pages/AppDetail.tsx`, update `panelActions` (currently around lines 121-147). Replace the `!app.isAspire && !orphaned` Restart gate with `isCompose`, and replace the Start condition with a plain `isCompose` gate. The block becomes:
+
+```tsx
+  const panelActions = (target: AppTarget, status: string | undefined, what: string) => {
+    if (!caps.lifecycle || isTestcontainers) return null
+    return (
+      <span style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}>
+        {status === 'running' && (
+          <>
+            {isCompose && (
+              <button className="btn ghost" disabled={busy} onClick={() => runAction(target, 'restart', what)}>
+                Restart
+              </button>
+            )}
+            <button className="btn danger" disabled={busy} onClick={() => runAction(target, 'stop', what)}>
+              Stop
+            </button>
+          </>
+        )}
+        {/* Restart and Start are Compose-only: they only work reliably for
+            containers driven by the runtime. dapr-run/Aspire panels show Stop
+            only. */}
+        {status === 'stopped' && isCompose && (
+          <button className="btn ghost" disabled={busy} onClick={() => runAction(target, 'start', what)}>
+            Start
+          </button>
+        )}
+      </span>
+    )
+  }
+```
+
+- [ ] **Step 4: Gate the header Restart/Start on `isCompose`**
+
+In the page header (currently lines 182-216), gate the header Restart on `isCompose` and the header Start on `caps.lifecycle && isCompose && allStopped`. The Stop button and Remove-from-list button are unchanged. The block becomes:
+
+```tsx
+        <div style={{ display: 'flex', gap: 8 }}>
+          {caps.lifecycle && !isTestcontainers && anyRunning && (
+            <>
+              {isCompose && (
+                <button
+                  className="btn ghost"
+                  disabled={busy}
+                  onClick={() => runAction('all', 'restart', `"${app.appId}" (app + sidecar)`)}
+                >
+                  Restart
+                </button>
+              )}
+              <button
+                className="btn danger"
+                disabled={busy}
+                onClick={() => runAction('all', 'stop', `"${app.appId}" (app + sidecar)`)}
+              >
+                Stop
+              </button>
+            </>
+          )}
+          {caps.lifecycle && removable && (
+            <button className="btn ghost" disabled={busy || forget.isPending} onClick={removeFromList}>
+              Remove from list
+            </button>
+          )}
+          {caps.lifecycle && isCompose && allStopped && (
+            <button
+              className="btn ghost"
+              disabled={busy}
+              onClick={() => runAction('all', 'start', `"${app.appId}" (app + sidecar)`)}
+            >
+              Start
+            </button>
+          )}
+          <button className="tbtn" onClick={() => navigate('/')}>← Back</button>
+          {caps.logs && (
+            <Link className="tbtn" to={`/logs?app=${key}&source=daprd`}>View logs</Link>
+          )}
+        </div>
+```
+
+- [ ] **Step 5: Add the dapr-run hint**
+
+In the hints region (after the Aspire hint block, currently around lines 233-240), add a hint for a running standalone app. Insert:
+
+```tsx
+      {caps.lifecycle && app.source === 'standalone' && !app.isAspire && !orphaned && anyRunning && (
+        <div className="hint">
+          Started with <span className="mono">dapr run</span> — restart and start it from your terminal.
+        </div>
+      )}
+```
+
+- [ ] **Step 6: Update the two existing tests broken by the change**
+
+In `web/src/pages/AppDetail.test.tsx`:
+
+Replace the test `'offers per-panel Start for a stopped non-Aspire target'` (currently ~line 104) with a compose variant:
+
+```tsx
+it('offers per-panel Start for a stopped compose target', async () => {
+  server.use(
+    http.get('/api/apps/order', () =>
+      HttpResponse.json({ ...runningApp, source: 'compose', daprdStatus: 'stopped' }),
+    ),
+  )
+  renderDetail()
+  await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+  expect(screen.getAllByRole('button', { name: 'Start' }).length).toBeGreaterThan(0)
+})
+```
+
+Delete the test `'offers a single whole-instance Start when a dapr run app is fully stopped'` (currently ~line 545) — its premise (dapr-run fully stopped → one Start) is exactly the behavior being removed, and the new `'hides Start for a fully stopped dapr run app…'` test covers the replacement.
+
+- [ ] **Step 7: Run the AppDetail tests to verify they pass**
+
+Run: `cd web && npx vitest run src/pages/AppDetail.test.tsx`
+Expected: PASS (all tests, including the three new ones and the compose per-panel Start test).
+
+- [ ] **Step 8: Typecheck the web app (Vitest does not typecheck)**
+
+Run: `cd web && npx tsc -b`
+Expected: no type errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/src/pages/AppDetail.tsx web/src/pages/AppDetail.test.tsx
+git commit -m "feat(app-detail): limit Restart & Start to Compose apps
+
+Gate the header and per-panel Restart/Start buttons on isCompose; keep Stop
+for all modes. Add a hint for running dapr-run apps pointing to the terminal.
+Fully stopped dapr-run apps offer Remove from list instead of Start.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Restart/Start Compose-only in UI → Task 2 Steps 3-4. ✓
+- Stop unchanged for all modes → preserved in both tasks (Stop buttons untouched; backend `ActionStop` still routed). ✓
+- Running dapr-run hint → Task 2 Step 5 + test Step 1. ✓
+- Backend guard in `doStandalone` → Task 1 Step 3. ✓
+- `RecordStop`/stopped visibility/Remove-from-list intact → untouched; verified by Task 2 Step 6 fully-stopped test asserting Remove is offered. ✓
+- Aspire already stop-only, Testcontainers already blocked → unchanged; existing tests retained. ✓
+- Test updates (both packages) → Task 1 Steps 1/5, Task 2 Steps 1/6. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"; every code step shows full code. ✓
+
+**Type/name consistency:** `isCompose`, `orphaned`, `anyRunning`, `allStopped`, `caps.lifecycle`, `runAction`, `ErrUnsupported`, `ActionStop`, `TargetAll/App/Daprd`, `fakeStarter`, `standaloneInst`, `newFakeProc` all match the current source. `app.source === 'standalone'` matches the wire type union in `web/src/types/api.ts`. ✓

--- a/docs/superpowers/specs/2026-07-17-limit-restart-start-to-compose-design.md
+++ b/docs/superpowers/specs/2026-07-17-limit-restart-start-to-compose-design.md
@@ -1,0 +1,85 @@
+# Limit Restart & Start to Compose mode
+
+**Date:** 2026-07-17
+**Status:** Approved — ready for implementation plan
+
+## Problem
+
+The Application detail view (`web/src/pages/AppDetail.tsx`) offers Restart, Start,
+and Stop lifecycle controls for discovered app instances. In practice, Restart and
+Start only work **reliably** for apps started via Docker Compose, where the container
+runtime restarts/starts containers cleanly. For Dapr-run (standalone) apps the
+start/restart path depends on re-running a process snapshot captured at stop time,
+which is unreliable. Offering those buttons sets a false expectation.
+
+## Goal
+
+Limit **Restart** and **Start** to Compose mode only. Keep **Stop** available for
+every mode where it works today. Make the reliability boundary explicit in both the
+UI and the backend API.
+
+## Behavior
+
+Restart and Start become Compose-only. Stop is unchanged.
+
+| Mode | Before | After |
+|------|--------|-------|
+| Compose | Restart / Start / Stop | *(unchanged)* Restart / Start / Stop |
+| Dapr run (standalone) | Restart / Start / Stop | **Stop only** |
+| Aspire | Stop only | *(unchanged)* Stop only |
+| Testcontainers | none | *(unchanged)* none |
+
+After stopping a Dapr-run app, it still appears as *stopped* and offers **Remove from
+list** via the existing `removable = !isCompose && appStopped && daprdStopped` path,
+so the flow does not dead-end.
+
+## Frontend — `web/src/pages/AppDetail.tsx`
+
+- Add an `isCompose` gate to:
+  - the header **Restart** button (target `all`),
+  - the header **Start** button (target `all`),
+  - the per-panel **Restart** and **Start** in `panelActions`.
+- Stop buttons (header and panels) are untouched — all current stop conditions remain.
+- Simplify now-redundant conditions:
+  - the panel Start's `(isCompose || !allStopped)` clause collapses to `isCompose`,
+  - the header Start's non-compose reachability collapses to `isCompose && allStopped`.
+- Add a hint for a **running standalone** app (source `standalone`, not Aspire, not
+  orphaned): *"Started with `dapr run` — restart and start it from your terminal."*
+  Styled like the existing Aspire hint (`className="hint"`). It complements, and does
+  not replace, the existing Aspire/orphan/unreachable hints.
+
+Aspire (`isCompose` is false) already had Restart/Start hidden, so there is no
+regression there.
+
+## Backend — `pkg/lifecycle/manager.go`
+
+- Add a single policy guard at the top of `doStandalone`: any `action` other than
+  `ActionStop` returns `ErrUnsupported` with a clear message, e.g.
+  *"restart/start is only supported for Docker Compose apps"*. This subsumes the
+  existing Aspire and orphaned-sidecar start/restart guards (which can be simplified
+  or left in place — the earlier general guard wins first).
+- `standaloneStop`, `RecordStop`, `terminateWithEscalation`, and the registry/overlay
+  stopped-instance visibility are **unchanged** — stopped Dapr-run apps must still be
+  remembered so they render as *stopped* and can be removed from the list.
+- `standaloneStart` and the injected `Starter` wiring stay in place as **dormant
+  machinery** behind the gate. Nothing is removed, so start can be re-enabled when it
+  becomes reliable.
+
+Compose (`doCompose`) and Testcontainers handling in `Do` are unchanged.
+
+## Tests
+
+- `pkg/lifecycle/manager_test.go`: convert the standalone start/restart success cases
+  (~lines 260–347) into assertions that start and restart now return `ErrUnsupported`.
+  Stop cases stay green. Compose start/restart/stop cases stay green.
+- `web/src/pages/AppDetail.test.tsx`:
+  - standalone running app: assert Restart and Start are absent, Stop is present,
+    and the new `dapr run` hint renders;
+  - compose app: assert Restart/Start/Stop all still present;
+  - standalone stopped app: assert **Remove from list** still offered.
+
+## Out of scope
+
+- The Control Plane view (`ControlPlane.tsx`) placement/scheduler restart — unrelated.
+- Making standalone start/restart reliable — deferred; the machinery is retained for
+  that future work.

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -149,6 +149,14 @@ func (m *manager) doStandalone(ctx context.Context, in discovery.Instance, targe
 	if in.SidecarOrphaned && action != ActionStop {
 		return fmt.Errorf("%w: orphaned sidecar — only stop is supported", ErrUnsupported)
 	}
+	// Restart and start only work reliably for Docker Compose apps, where the
+	// container runtime restarts containers cleanly. For dapr-run instances the
+	// re-run-from-snapshot path is unreliable, so only stop is offered. The
+	// standaloneStart machinery below stays in place, dormant behind this gate,
+	// for when standalone start becomes reliable.
+	if action != ActionStop {
+		return fmt.Errorf("%w: restart and start are only supported for Docker Compose apps", ErrUnsupported)
+	}
 	switch action {
 	case ActionStop:
 		return m.standaloneStop(ctx, in, target)

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -223,6 +223,37 @@ func (s *stubbornProc) Terminate(pid int) error {
 }
 func (s *stubbornProc) Kill(pid int) error { return s.fakeProc.Kill(pid) }
 
+// Start and restart are Compose-only: dapr-run (standalone) instances reject
+// both with ErrUnsupported and touch no process or starter, even when a stop
+// snapshot exists that could tempt a re-run. Stop stays supported (covered by
+// the standalone stop tests).
+func TestStandaloneStartRestartRejected(t *testing.T) {
+	proc := newFakeProc()
+	proc.snaps[100] = ProcSnapshot{PID: 100, Argv: []string{"go", "run", "."}, Dir: "/src"}
+	proc.alive[100] = true
+	st := &fakeStarter{}
+	reg := NewRegistry()
+	reg.RecordStop(standaloneInst(), map[Target]ProcSnapshot{
+		TargetAll: {PID: 300, Argv: []string{"dapr", "run", "--app-id", "orders"}, Dir: "/src"},
+	})
+	m := New(fakeApps{items: map[string]discovery.Instance{"orders": standaloneInst()}}, reg, nil, proc, st)
+
+	cases := []struct {
+		target Target
+		action Action
+	}{
+		{TargetAll, ActionStart},
+		{TargetApp, ActionStart},
+		{TargetAll, ActionRestart},
+		{TargetDaprd, ActionRestart},
+	}
+	for _, tc := range cases {
+		require.ErrorIs(t, m.Do(context.Background(), "orders", tc.target, tc.action), ErrUnsupported)
+	}
+	require.Empty(t, st.started, "standalone start machinery must not run")
+	require.Empty(t, proc.terminated, "restart must not signal any process")
+}
+
 func TestAspireStartRejectedStopAllowed(t *testing.T) {
 	in := standaloneInst()
 	in.IsAspire = true
@@ -255,59 +286,6 @@ func (f *fakeStarter) Start(argv []string, dir, logPath string) error {
 	return nil
 }
 
-func TestStandaloneStartAllRerunsCLICommand(t *testing.T) {
-	reg := NewRegistry()
-	reg.RecordStop(standaloneInst(), map[Target]ProcSnapshot{
-		TargetAll:   {PID: 300, Argv: []string{"dapr", "run", "--app-id", "orders"}, Dir: "/src"},
-		TargetApp:   {PID: 100, Argv: []string{"go", "run", "."}, Dir: "/src"},
-		TargetDaprd: {PID: 200, Argv: []string{"daprd", "--app-id", "orders"}, Dir: "/src"},
-	})
-	st := &fakeStarter{}
-	m := New(fakeApps{items: map[string]discovery.Instance{"orders": standaloneInst()}}, reg, nil, newFakeProc(), st)
-
-	require.NoError(t, m.Do(context.Background(), "orders", TargetAll, ActionStart))
-	require.Equal(t, [][]string{{"dapr", "run", "--app-id", "orders"}}, st.started)
-	require.Equal(t, []string{"/src"}, st.dirs)
-	_, ok := reg.Get("orders")
-	require.True(t, ok, "entry survives start; the overlay drops it once discovery sees the instance live")
-}
-
-func TestStandaloneStartSingleTarget(t *testing.T) {
-	reg := NewRegistry()
-	reg.RecordStop(standaloneInst(), map[Target]ProcSnapshot{
-		TargetApp:   {PID: 100, Argv: []string{"go", "run", "."}, Dir: "/src", LogPath: "/tmp/app.log"},
-		TargetDaprd: {PID: 200, Argv: []string{"daprd", "--app-id", "orders"}},
-	})
-	st := &fakeStarter{}
-	m := New(fakeApps{items: map[string]discovery.Instance{"orders": standaloneInst()}}, reg, nil, newFakeProc(), st)
-
-	require.NoError(t, m.Do(context.Background(), "orders", TargetApp, ActionStart))
-	require.Equal(t, [][]string{{"go", "run", "."}}, st.started)
-	e, ok := reg.Get("orders")
-	require.True(t, ok, "entry survives start; live reconciliation cleans it up")
-	require.Len(t, e.Procs, 2)
-}
-
-func TestStandaloneStartWithoutSnapshotRejected(t *testing.T) {
-	m := New(fakeApps{items: map[string]discovery.Instance{"orders": standaloneInst()}},
-		NewRegistry(), nil, newFakeProc(), &fakeStarter{})
-	require.ErrorIs(t, m.Do(context.Background(), "orders", TargetApp, ActionStart), ErrUnsupported)
-}
-
-func TestStandaloneRestartStopsThenStarts(t *testing.T) {
-	proc := newFakeProc()
-	proc.snaps[100] = ProcSnapshot{PID: 100, Argv: []string{"go", "run", "."}, Dir: "/src"}
-	proc.alive[100] = true
-	st := &fakeStarter{}
-	reg := NewRegistry()
-	m := New(fakeApps{items: map[string]discovery.Instance{"orders": standaloneInst()}}, reg, nil, proc, st).(*manager)
-	m.grace = 10 * time.Millisecond
-
-	require.NoError(t, m.Do(context.Background(), "orders", TargetApp, ActionRestart))
-	require.Equal(t, []int{100}, proc.terminated)
-	require.Equal(t, [][]string{{"go", "run", "."}}, st.started)
-}
-
 func TestStandaloneDaprdTargetFunnelsToAll(t *testing.T) {
 	proc := newFakeProc()
 	proc.snaps[100] = ProcSnapshot{PID: 100, Argv: []string{"go", "run", "."}, Dir: "/src"}
@@ -337,25 +315,6 @@ func TestAspireDaprdStopNotFunneled(t *testing.T) {
 
 	require.NoError(t, m.Do(context.Background(), "orders", TargetDaprd, ActionStop))
 	require.Equal(t, []int{200}, proc.terminated, "Aspire keeps per-PID daprd stop")
-}
-
-// Pins the TargetAll start fallback: with no CLI snapshot (e.g. the CLI was
-// never captured), the halves start individually, sidecar first, and each
-// started target leaves the registry.
-func TestStandaloneStartAllWithoutCLISnapshotStartsHalvesInOrder(t *testing.T) {
-	reg := NewRegistry()
-	reg.RecordStop(standaloneInst(), map[Target]ProcSnapshot{
-		TargetDaprd: {PID: 200, Argv: []string{"daprd", "--app-id", "orders"}, Dir: "/src"},
-		TargetApp:   {PID: 100, Argv: []string{"go", "run", "."}, Dir: "/src"},
-	})
-	st := &fakeStarter{}
-	m := New(fakeApps{items: map[string]discovery.Instance{"orders": standaloneInst()}}, reg, nil, newFakeProc(), st)
-
-	require.NoError(t, m.Do(context.Background(), "orders", TargetAll, ActionStart))
-	require.Equal(t, [][]string{{"daprd", "--app-id", "orders"}, {"go", "run", "."}}, st.started, "sidecar starts before the app")
-	e, ok := reg.Get("orders")
-	require.True(t, ok, "entry survives start; live reconciliation cleans it up")
-	require.Len(t, e.Procs, 2)
 }
 
 // An orphaned sidecar (no supervising CLI, app gone) supports only stop:

--- a/web/src/pages/AppDetail.test.tsx
+++ b/web/src/pages/AppDetail.test.tsx
@@ -89,7 +89,7 @@ describe('AppDetail', () => {
     expect(posted).toBe(false)
   })
 
-  it('offers Start for a stopped target and hides Start for Aspire', async () => {
+  it('hides Start for a fully stopped Aspire app', async () => {
     server.use(
       http.get('/api/apps/order', () =>
         HttpResponse.json({ ...runningApp, appStatus: 'stopped', daprdStatus: 'stopped', isAspire: true }),

--- a/web/src/pages/AppDetail.test.tsx
+++ b/web/src/pages/AppDetail.test.tsx
@@ -101,10 +101,10 @@ describe('AppDetail', () => {
     expect(screen.getByText(/Managed by Aspire/)).toBeInTheDocument()
   })
 
-  it('offers per-panel Start for a stopped non-Aspire target', async () => {
+  it('offers per-panel Start for a stopped compose target', async () => {
     server.use(
       http.get('/api/apps/order', () =>
-        HttpResponse.json({ ...runningApp, daprdStatus: 'stopped' }),
+        HttpResponse.json({ ...runningApp, source: 'compose', daprdStatus: 'stopped' }),
       ),
     )
     renderDetail()
@@ -410,6 +410,45 @@ describe('AppDetail', () => {
     await waitFor(() => expect(posted).toBe('all/stop'))
   })
 
+  it('hides Restart and Start for a running dapr run app but keeps Stop and shows a hint', async () => {
+    server.use(http.get('/api/apps/order', () => HttpResponse.json({ ...runningApp, source: 'standalone' })))
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: 'Restart' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Start' })).not.toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Stop' }).length).toBeGreaterThan(0)
+    expect(screen.getByText(/restart and start it from your terminal/i)).toBeInTheDocument()
+  })
+
+  it('keeps Restart for a running compose app', async () => {
+    server.use(http.get('/api/apps/order', () => HttpResponse.json({ ...runningApp, source: 'compose' })))
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    expect(screen.getAllByRole('button', { name: 'Restart' }).length).toBeGreaterThan(0)
+    // Nothing is stopped, so no Start button; and no dapr-run hint for compose.
+    expect(screen.queryByText(/restart and start it from your terminal/i)).not.toBeInTheDocument()
+  })
+
+  it('hides Start for a fully stopped dapr run app, offering Remove instead', async () => {
+    server.use(
+      http.get('/api/apps/order', () =>
+        HttpResponse.json({
+          ...runningApp,
+          source: 'standalone',
+          health: 'unknown',
+          appStatus: 'stopped',
+          daprdStatus: 'stopped',
+          appPid: 0,
+          daprdPid: 0,
+        }),
+      ),
+    )
+    renderDetail()
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: 'Start' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove from list' })).toBeInTheDocument()
+  })
+
   it('renders app protocol when reported', async () => {
     server.use(
       http.get('/api/apps/order', () => HttpResponse.json({ ...runningApp, appProtocol: 'http' })),
@@ -539,27 +578,6 @@ describe('AppDetail', () => {
     // The stopped orphan vanishes from discovery; the page must not dead-end
     // on "App not found" but return to the overview.
     await waitFor(() => expect(screen.getByText('Applications index')).toBeInTheDocument())
-  })
-
-
-  it('offers a single whole-instance Start when a dapr run app is fully stopped', async () => {
-    server.use(
-      http.get('/api/apps/order', () =>
-        HttpResponse.json({
-          ...runningApp,
-          health: 'unknown',
-          appStatus: 'stopped',
-          daprdStatus: 'stopped',
-          appPid: 0,
-          daprdPid: 0,
-        }),
-      ),
-    )
-    renderDetail()
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
-    // Per-panel Starts are hidden: a bare app or bare daprd restart is not
-    // discoverable/useful — the header whole-instance Start is the affordance.
-    expect(screen.getAllByRole('button', { name: 'Start' })).toHaveLength(1)
   })
 
   it('removes a fully stopped instance from the list and returns to the overview', async () => {

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -124,7 +124,7 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
       <span style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}>
         {status === 'running' && (
           <>
-            {!app.isAspire && !orphaned && (
+            {isCompose && (
               <button className="btn ghost" disabled={busy} onClick={() => runAction(target, 'restart', what)}>
                 Restart
               </button>
@@ -134,10 +134,10 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
             </button>
           </>
         )}
-        {/* Per-panel Start is hidden for fully-stopped dapr run apps: a bare
-            half-restart is not discoverable — the header's whole-instance Start
-            is the affordance. Compose keeps per-container starts. */}
-        {status === 'stopped' && !app.isAspire && !orphaned && (isCompose || !allStopped) && (
+        {/* Restart and Start are Compose-only: they only work reliably for
+            containers driven by the runtime. dapr-run/Aspire panels show Stop
+            only. */}
+        {status === 'stopped' && isCompose && (
           <button className="btn ghost" disabled={busy} onClick={() => runAction(target, 'start', what)}>
             Start
           </button>
@@ -182,7 +182,7 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
         <div style={{ display: 'flex', gap: 8 }}>
           {caps.lifecycle && !isTestcontainers && anyRunning && (
             <>
-              {!app.isAspire && !orphaned && (
+              {isCompose && (
                 <button
                   className="btn ghost"
                   disabled={busy}
@@ -205,7 +205,7 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
               Remove from list
             </button>
           )}
-          {caps.lifecycle && !isTestcontainers && allStopped && !app.isAspire && !orphaned && (
+          {caps.lifecycle && isCompose && allStopped && (
             <button
               className="btn ghost"
               disabled={busy}
@@ -236,6 +236,11 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
       {app.sidecarOrphaned && (
         <div className="hint">
           Orphaned sidecar — this daprd has no supervising dapr CLI and its app is gone. Stopping it is safe.
+        </div>
+      )}
+      {caps.lifecycle && app.source === 'standalone' && !app.isAspire && !orphaned && anyRunning && (
+        <div className="hint">
+          Started with <span className="mono">dapr run</span> — restart and start it from your terminal.
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Restart and Start now work reliably only for Docker Compose apps, so this limits both actions to Compose mode in the Application detail view and enforces it in the backend. **Stop is unchanged** — it stays available for every mode where it worked before (Compose, Dapr run, Aspire, orphaned sidecars).

Rationale: for `dapr run` (standalone) apps, start/restart depended on re-running a process snapshot captured at stop time, which is unreliable. Offering those buttons set a false expectation.

### Behavior per mode

| Mode | Before | After |
|------|--------|-------|
| Compose | Restart / Start / Stop | *(unchanged)* Restart / Start / Stop |
| Dapr run (standalone) | Restart / Start / Stop | **Stop only** |
| Aspire | Stop only | *(unchanged)* Stop only |
| Testcontainers | none | *(unchanged)* none |

A stopped Dapr-run app still appears as *stopped* and offers **Remove from list**, so nothing dead-ends. A running Dapr-run app shows a hint: *"Started with `dapr run` — restart and start it from your terminal."*

## Changes

- **Backend** (`pkg/lifecycle/manager.go`): one policy guard in `doStandalone` rejecting any non-stop action with `ErrUnsupported`. `RecordStop`, stop logic, and the Aspire/orphan-specific guards are untouched; `standaloneStart` is kept dormant behind the gate for when standalone start becomes reliable.
- **Frontend** (`web/src/pages/AppDetail.tsx`): header + per-panel Restart/Start gated on `isCompose`; new hint for running standalone apps.

## Testing

- `make test-go` — all packages pass (server tests via `//go:build unit`)
- `web`: 764/764 vitest tests pass; `tsc -b` clean
- Consolidated the standalone start/restart tests into a rejection test; updated the frontend tests to cover compose-vs-standalone gating and the new hint.

Design + plan: `docs/superpowers/specs/2026-07-17-limit-restart-start-to-compose-design.md`, `docs/superpowers/plans/2026-07-17-limit-restart-start-to-compose.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)