### PR TITLE
Simplify Logs page filters: one Target dropdown + daprd|app toggle

### DIFF
--- a/docs/superpowers/plans/2026-07-17-logs-filter-simplification.md
+++ b/docs/superpowers/plans/2026-07-17-logs-filter-simplification.md
@@ -1,0 +1,450 @@
+# Logs Filter Simplification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce the Logs page from three peer dropdowns (App, Source, Control plane) to a single grouped **Target** dropdown plus a `daprd | app` **segmented source toggle** shown only in app view.
+
+**Architecture:** The App and Control-plane dropdowns collapse into one `<select>` with `Applications` / `Control plane` `optgroup`s, whose option values are kind-prefixed (`app:<key>` / `cp:<name>`) so `onChange` routes to the correct URL param. The Source `<select>` becomes two `.lvchip`-styled toggle buttons that derive their pressed state from the `?source` param and enforce an at-least-one-on invariant. All state stays URL-derived; deep links are unchanged.
+
+**Tech Stack:** React 19 + TypeScript, react-router-dom v6 (`useSearchParams`), Vitest + Testing Library, CSS in `web/src/styles/theme.css`.
+
+## Global Constraints
+
+- **Deep links unchanged.** `?app=<key>&source=<daprd|app|both>` and `?cp=<name>` must keep working with zero edits to their call sites (`AppDetail.tsx:219`, `PublishMessageDialog.tsx:70`, `ControlPlane.tsx:169`).
+- **`?source` validation.** Always parse via `parseEnum(searchParams.get('source'), LOG_SOURCES, 'both')` — an invalid value falls back to `both`, never leaks into the UI.
+- **2-click app→CP switch preserved.** Selecting a control-plane target must remain: open Target → pick service (selecting it auto-clears `?app`).
+- **At-least-one source on.** The source toggle can express `both` / `daprd` / `app` but never an empty set; clicking the sole active chip is a no-op.
+- **Reuse existing styling.** Source chips use the existing `.lvchip` / `.lvchips` classes (`theme.css:292–294`). No new visual primitives.
+- **Vitest does not typecheck.** After any `.ts`/`.tsx` change (test files included), run `cd web && npm run build` (`tsc -b && vite build`) — vitest alone will miss type errors.
+- **Follow `web/STYLEGUIDE.md`** for select/chip/link styling and readability.
+
+---
+
+### Task 1: Merge App + Control-plane into one Target dropdown
+
+Replace the two separate `<select>`s (App at `Logs.tsx:505–518`, Control plane at `Logs.tsx:533–550`) with one grouped Target select. Fold in the empty-state copy change.
+
+**Files:**
+- Modify: `web/src/pages/Logs.tsx` (the `Logs` component: selects at 505–550, the `onAppChange`/`onCpChange`/`clearCp` handlers at 405–440, and the empty-state text at 603–605)
+- Test: `web/src/pages/Logs.test.tsx`
+
+**Interfaces:**
+- Consumes (existing, unchanged): `appOptions: { key: string; label: string }[]`, `cpNames: string[]`, `appId: string`, `cp: string`, `source: LogSource`, `setSearchParams`.
+- Produces: `onTargetChange(value: string): void` — `value` is `''`, `app:<key>`, or `cp:<name>`. `''` deletes both `app` and `cp`; `app:<key>` sets `app` + deletes `cp`; `cp:<name>` sets `cp` + deletes `app`. `?source` is left untouched. Also `targetValue: string` — the derived current selection (`cp ? \`cp:${cp}\` : appId ? \`app:${appId}\` : ''`).
+
+- [ ] **Step 1: Write the failing test — Target select renders grouped options and the App/Control-plane selects are gone**
+
+Add to `web/src/pages/Logs.test.tsx` inside the `describe('Logs', …)` block. Replace the existing `it('renders app and source selects in .logbar', …)` test body's app/CP portion by adding this new test (leave the source assertions for Task 2):
+
+```tsx
+it('renders a single grouped Target select (no separate App/CP selects)', async () => {
+  server.use(
+    http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+    http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+    http.get('/api/controlplane', () => HttpResponse.json(CP_LIST_BASE)),
+  )
+
+  renderAt()
+
+  const target = (await screen.findByRole('combobox', { name: /Target/i })) as HTMLSelectElement
+  expect(target).toBeInTheDocument()
+  // Old peer selects are gone
+  expect(screen.queryByRole('combobox', { name: /^App$/i })).toBeNull()
+  expect(screen.queryByRole('combobox', { name: /Control Plane/i })).toBeNull()
+  // Grouped: an Applications optgroup with the app, a Control plane optgroup with a dapr_* service
+  expect(target.querySelector('optgroup[label="Applications"]')).not.toBeNull()
+  expect(target.querySelector('optgroup[label="Control plane"]')).not.toBeNull()
+  expect(screen.getByRole('option', { name: 'order' })).toBeInTheDocument()
+  expect(screen.getByRole('option', { name: 'dapr_scheduler' })).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/pages/Logs.test.tsx -t "single grouped Target select"`
+Expected: FAIL — no combobox named "Target" (still named "App").
+
+- [ ] **Step 3: Replace the handlers**
+
+In `web/src/pages/Logs.tsx`, delete `onAppChange`, `onCpChange`, and `clearCp` (lines 405–440) and replace with a single handler plus a derived value. Keep `onSourceChange` as-is:
+
+```tsx
+const targetValue = cp ? `cp:${cp}` : appId ? `app:${appId}` : ''
+
+function onTargetChange(value: string) {
+  setSearchParams(prev => {
+    const next = new URLSearchParams(prev)
+    const sep = value.indexOf(':')
+    const kind = sep === -1 ? '' : value.slice(0, sep)
+    const name = sep === -1 ? '' : value.slice(sep + 1)
+    if (kind === 'app') {
+      next.set('app', name)
+      next.delete('cp')
+    } else if (kind === 'cp') {
+      next.set('cp', name)
+      next.delete('app')
+    } else {
+      next.delete('app')
+      next.delete('cp')
+    }
+    return next
+  })
+}
+```
+
+- [ ] **Step 4: Replace the two selects with one grouped Target select**
+
+In `web/src/pages/Logs.tsx`, replace the App `<select>` (505–518) AND the Control-plane `<select>` (532–550) with this single control (leave the Source `<select>` at 520–530 untouched for now):
+
+```tsx
+<select
+  className="select"
+  data-cy="log-target"
+  value={targetValue}
+  onChange={e => onTargetChange(e.target.value)}
+  aria-label="Target"
+>
+  <option value="">— select target —</option>
+  {appOptions.length > 0 && (
+    <optgroup label="Applications">
+      {appOptions.map(o => (
+        <option key={`app:${o.key}`} value={`app:${o.key}`}>
+          {o.label}
+        </option>
+      ))}
+    </optgroup>
+  )}
+  {cpNames.length > 0 && (
+    <optgroup label="Control plane">
+      {cpNames.map(name => (
+        <option key={`cp:${name}`} value={`cp:${name}`}>
+          {name}
+        </option>
+      ))}
+    </optgroup>
+  )}
+</select>
+```
+
+- [ ] **Step 5: Update the empty-state copy**
+
+In `web/src/pages/Logs.tsx`, change the empty-state text (line 604) from `Select an app to view logs.` to:
+
+```tsx
+<p className="muted">Select a target to view logs.</p>
+```
+
+- [ ] **Step 6: Update the F1 control-count test**
+
+In `web/src/pages/Logs.test.tsx`, the `F1 — renders exactly ONE .logbar containing all five controls` test asserts `bar.querySelector('[aria-label="App"]')`. Change that one line to the Target select (leave the `[aria-label="Source"]` line for Task 2):
+
+```tsx
+    // target select
+    expect(bar.querySelector('[aria-label="Target"]')).not.toBeNull()
+```
+
+- [ ] **Step 7: Add the deep-link + switch tests**
+
+Add these to `web/src/pages/Logs.test.tsx`:
+
+```tsx
+it('reflects a ?app deep link as the selected Target', async () => {
+  server.use(
+    http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+    http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+  )
+  renderAt('/logs?app=order&source=daprd')
+  const target = (await screen.findByRole('combobox', { name: /Target/i })) as HTMLSelectElement
+  await waitFor(() => expect(target.value).toBe('app:order'))
+})
+
+it('reflects a ?cp deep link as the selected Target and clears app on switch', async () => {
+  server.use(
+    http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+    http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+    http.get('/api/controlplane', () => HttpResponse.json(CP_LIST_BASE)),
+  )
+  renderAt('/logs?cp=dapr_scheduler')
+  const target = (await screen.findByRole('combobox', { name: /Target/i })) as HTMLSelectElement
+  await waitFor(() => expect(target.value).toBe('cp:dapr_scheduler'))
+})
+```
+
+- [ ] **Step 8: Run the Logs test suite**
+
+Run: `cd web && npx vitest run src/pages/Logs.test.tsx`
+Expected: PASS (the Task 1 tests pass; the source-select tests still pass because that select is untouched).
+
+- [ ] **Step 9: Typecheck + build**
+
+Run: `cd web && npm run build`
+Expected: `tsc -b` and `vite build` succeed with no type errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add web/src/pages/Logs.tsx web/src/pages/Logs.test.tsx
+git commit -m "feat(logs): merge App + Control-plane filters into one Target select
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Replace the Source dropdown with a segmented daprd|app toggle
+
+Replace the Source `<select>` (`Logs.tsx:520–530`) with two `.lvchip` toggles shown only in app view.
+
+**Files:**
+- Modify: `web/src/pages/Logs.tsx` (Source select at 520–530; add the toggle handler near `onSourceChange`)
+- Modify: `web/src/styles/theme.css` (add `.srcchips` wrapper if the `.lvchips` gap/layout needs a distinct label; see Step 5)
+- Test: `web/src/pages/Logs.test.tsx`
+
+**Interfaces:**
+- Consumes: `source: LogSource` and `onSourceChange(s: LogSource): void` from Task 1's file; `appId`, `isCpView` (existing, `Logs.tsx:459`).
+- Produces: `toggleSource(stream: 'daprd' | 'app'): void` — flips one stream in the active set derived from `source`, enforces the at-least-one-on invariant, and writes the resulting `LogSource` via `onSourceChange`.
+
+- [ ] **Step 1: Write the failing tests — chips reflect ?source and toggle it**
+
+Replace the existing `it('falls back to "both" for an invalid ?source= URL param', …)` test's select-value assertions and add toggle/visibility tests. First, add these new tests to `web/src/pages/Logs.test.tsx`:
+
+```tsx
+it('renders daprd|app source chips reflecting ?source=daprd (no Source select)', async () => {
+  server.use(
+    http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+    http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+  )
+  renderAt('/logs?app=order&source=daprd')
+  // Source is now chips, not a combobox
+  expect(screen.queryByRole('combobox', { name: /Source/i })).toBeNull()
+  const daprd = await screen.findByRole('button', { name: 'daprd' })
+  const app = screen.getByRole('button', { name: 'app' })
+  expect(daprd).toHaveAttribute('aria-pressed', 'true')
+  expect(app).toHaveAttribute('aria-pressed', 'false')
+})
+
+it('toggling the app chip while on daprd yields source=both (adds the stream)', async () => {
+  const user = userEvent.setup()
+  server.use(
+    http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+    http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+  )
+  renderAt('/logs?app=order&source=daprd')
+  const app = await screen.findByRole('button', { name: 'app' })
+  await user.click(app)
+  await waitFor(() => expect(app).toHaveAttribute('aria-pressed', 'true'))
+  expect(screen.getByRole('button', { name: 'daprd' })).toHaveAttribute('aria-pressed', 'true')
+})
+
+it('clicking the only active source chip is a no-op (at-least-one invariant)', async () => {
+  const user = userEvent.setup()
+  server.use(
+    http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+    http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+  )
+  renderAt('/logs?app=order&source=daprd')
+  const daprd = await screen.findByRole('button', { name: 'daprd' })
+  await user.click(daprd)
+  // still pressed — cannot turn off the last active stream
+  expect(daprd).toHaveAttribute('aria-pressed', 'true')
+})
+
+it('hides the source chips in control-plane view', async () => {
+  server.use(
+    http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+    http.get('/api/controlplane', () => HttpResponse.json(CP_LIST_BASE)),
+  )
+  renderAt('/logs?cp=dapr_scheduler')
+  await screen.findByRole('combobox', { name: /Target/i })
+  expect(screen.queryByRole('button', { name: 'daprd' })).toBeNull()
+  expect(screen.queryByRole('button', { name: 'app' })).toBeNull()
+})
+```
+
+Then update the invalid-`?source` test: replace its `sourceSelect` lines (`Logs.test.tsx:433–435`) with chip-state assertions (keep the subtitle + `--lsrc-w` assertions):
+
+```tsx
+    // An unknown source falls back to "both": both chips pressed.
+    const daprd = (await screen.findByRole('button', { name: 'daprd' }))
+    const app = screen.getByRole('button', { name: 'app' })
+    await waitFor(() => expect(daprd).toHaveAttribute('aria-pressed', 'true'))
+    expect(app).toHaveAttribute('aria-pressed', 'true')
+```
+
+Ensure `import userEvent from '@testing-library/user-event'` is present at the top of the test file (add it if missing).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd web && npx vitest run src/pages/Logs.test.tsx -t "source chip"`
+Expected: FAIL — no `button` named `daprd`/`app` (source is still a `<select>`).
+
+- [ ] **Step 3: Add the toggle handler**
+
+In `web/src/pages/Logs.tsx`, add next to `onSourceChange`:
+
+```tsx
+function toggleSource(stream: 'daprd' | 'app') {
+  const active = new Set<'daprd' | 'app'>(
+    source === 'both' ? ['daprd', 'app'] : [source],
+  )
+  if (active.has(stream)) {
+    if (active.size === 1) return // at-least-one-on invariant
+    active.delete(stream)
+  } else {
+    active.add(stream)
+  }
+  const next: LogSource = active.size === 2 ? 'both' : active.has('daprd') ? 'daprd' : 'app'
+  onSourceChange(next)
+}
+```
+
+- [ ] **Step 4: Replace the Source select with chips**
+
+In `web/src/pages/Logs.tsx`, replace the Source `<select>` (520–530) with this block. It renders only in app view:
+
+```tsx
+{!isCpView && appId && (
+  <div className="lvchips srcchips" role="group" aria-label="Source">
+    {(['daprd', 'app'] as const).map(stream => {
+      const active = source === 'both' || source === stream
+      return (
+        <button
+          key={stream}
+          className="lvchip"
+          data-cy={`log-source-${stream}`}
+          aria-pressed={active}
+          onClick={() => toggleSource(stream)}
+        >
+          {stream}
+        </button>
+      )
+    })}
+  </div>
+)}
+```
+
+Note: `isCpView` is defined at `Logs.tsx:459` — this JSX is above that declaration in source order, but both live inside the same component body and `isCpView` is a `const` evaluated before render returns, so it is in scope in the returned JSX. If lint/TS flags use-before-declaration for the `const`, move the `const isCpView = cp !== ''` line up to sit beside the other derived values (near `targetValue`).
+
+- [ ] **Step 5: Add the `.srcchips` style if needed**
+
+The chips already inherit `.lvchips` (`display: inline-flex; gap: 5px`) and `.lvchip`. Add a marginal separation from the Target select so the group reads as a distinct sub-control. In `web/src/styles/theme.css`, after the `.lvchip[aria-pressed="true"]` rule (line 294):
+
+```css
+.srcchips { margin-right: 2px; }
+```
+
+- [ ] **Step 6: Fix the F1 source assertion**
+
+In `web/src/pages/Logs.test.tsx`, the `F1 — renders exactly ONE .logbar` test still asserts `bar.querySelector('[aria-label="Source"]')` expecting a select. It now resolves to the chip group (same `aria-label="Source"` on the `div[role="group"]`), so the assertion still holds. Confirm the `.lvchips` assertion in that test now matches TWO groups (levels + source) — change it to assert at least one and that the Source group exists:
+
+```tsx
+    // source chip group (role=group, aria-label Source)
+    expect(bar.querySelector('[aria-label="Source"]')).not.toBeNull()
+    // level chips group still present
+    expect(bar.querySelector('.lvchips[aria-label="Levels"]')).not.toBeNull()
+```
+
+- [ ] **Step 7: Run the full Logs test suite**
+
+Run: `cd web && npx vitest run src/pages/Logs.test.tsx`
+Expected: PASS — all source-chip, toggle, invariant, CP-hidden, deep-link, and subtitle tests green.
+
+- [ ] **Step 8: Typecheck + build**
+
+Run: `cd web && npm run build`
+Expected: `tsc -b` and `vite build` succeed with no type errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/src/pages/Logs.tsx web/src/pages/Logs.test.tsx web/src/styles/theme.css
+git commit -m "feat(logs): replace Source dropdown with daprd|app segmented toggle
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: End-to-end verification against real deep links
+
+Confirm the two remaining deep-link generators and the running app behave correctly, and run the whole web suite.
+
+**Files:**
+- Read only: `web/src/pages/AppDetail.tsx:219`, `web/src/components/PublishMessageDialog.tsx:70`, `web/src/pages/ControlPlane.tsx:169`
+- Test: `web/src/pages/Logs.test.tsx` (already covers param handling; this task adds a source-column regression check for `?source=app`)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–2. Produces nothing new.
+
+- [ ] **Step 1: Add a `?source=app` chip-state regression test**
+
+Add to `web/src/pages/Logs.test.tsx`:
+
+```tsx
+it('reflects ?source=app as only the app chip pressed', async () => {
+  server.use(
+    http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+    http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+  )
+  renderAt('/logs?app=order&source=app')
+  const daprd = await screen.findByRole('button', { name: 'daprd' })
+  const app = screen.getByRole('button', { name: 'app' })
+  await waitFor(() => expect(app).toHaveAttribute('aria-pressed', 'true'))
+  expect(daprd).toHaveAttribute('aria-pressed', 'false')
+})
+```
+
+- [ ] **Step 2: Run the whole web test suite**
+
+Run: `cd web && npm test`
+Expected: PASS — the full Vitest suite is green.
+
+- [ ] **Step 3: Typecheck + build**
+
+Run: `cd web && npm run build`
+Expected: no type errors, build succeeds.
+
+- [ ] **Step 4: Verify the deep links in the running app**
+
+Invoke the `verify` (or `/run`) skill to launch the dashboard, then exercise each generator's link and confirm the controls reflect it:
+
+- From an App detail page click **View logs** → URL `/logs?app=<key>&source=daprd`; Target shows that app, only the **daprd** chip is pressed.
+- From the Publish message dialog click **Open … logs** → `/logs?app=<id>&source=app`; only the **app** chip pressed.
+- From the Control plane page click a service chip → `/logs?cp=<name>`; Target shows that service, **no source chips** visible.
+- Switch from an app target to a control-plane target in the Target dropdown in **2 interactions** (open, pick) and confirm the app clears.
+
+Record the observed behavior. Expected: all four behave as described.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/pages/Logs.test.tsx
+git commit -m "test(logs): source-column regression for ?source=app deep link
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Target selector (merged, grouped, prefixed values, URL-derived, empty groups omitted, `cpPending` preserved) → Task 1. `cpPending` logic is untouched (not modified by any task), so it is preserved by omission.
+- Source segmented control (chips, pressed-state mapping, toggle semantics, at-least-one-on, app-view-only visibility, parity on stream availability) → Task 2.
+- Deep-link contract unchanged (3 generators, `parseEnum` fallback) → verified in Tasks 1–3; no generator files are modified.
+- Layout / `.logbar` ordering + `.srcchips` → Task 2 Steps 4–5.
+- Empty-state copy "Select a target" → Task 1 Step 5.
+- Testing (selector rename, chip toggle, invariant, CP-hidden, deep links) → Tasks 1–3.
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every test step shows the assertion and the run command with expected result.
+
+**Type consistency:** `onTargetChange(value: string)`, `targetValue: string`, `toggleSource(stream: 'daprd' | 'app')`, `onSourceChange(s: LogSource)`, `LogSource` / `LOG_SOURCES`, `isCpView` — names are consistent across Tasks 1–3 and match the existing symbols in `Logs.tsx`.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-17-logs-filter-simplification.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — execute tasks in this session with checkpoints for review.
+
+Which approach?

--- a/docs/superpowers/specs/2026-07-17-logs-filter-simplification-design.md
+++ b/docs/superpowers/specs/2026-07-17-logs-filter-simplification-design.md
@@ -1,0 +1,145 @@
+# Logs Filter Simplification — Design
+
+**Date:** 2026-07-17
+**Status:** Design — awaiting review
+**Area:** `web/src/pages/Logs.tsx`, `web/src/styles/theme.css`, `web/src/pages/Logs.test.tsx`
+
+## Problem
+
+The Logs page presents **three equal-looking `<select>` dropdowns**:
+
+1. **App** — pick an application
+2. **Source** — `daprd + app` / `daprd only` / `app only`
+3. **Control plane** — pick a control-plane service (`dapr_scheduler`, `dapr_placement`, compose-managed containers)
+
+Nothing in the UI communicates the relationships that actually govern them:
+
+- **App and Control plane are mutually exclusive.** `onAppChange` clears `?cp`; `onCpChange` clears `?app` (`Logs.tsx:405–432`). You are always tailing *either* an app *or* a control-plane service — the two dropdowns encode a single decision: **"what am I tailing?"**
+- **Source only applies to apps.** `daprd/app/both` is meaningless when a control-plane service is selected, yet the dropdown sits there fully interactive in CP view.
+
+So there are conceptually **two** decisions (target, then which stream within an app), presented as three peer controls with no visible coupling.
+
+## Goals
+
+- Reduce the three controls to their two real decisions.
+- Make the app-vs-control-plane choice a single obvious control.
+- Remove the Source control from view when it does not apply (control-plane view).
+- **Preserve the 2-click "app → control-plane" switch** (open target, pick service).
+- **Preserve every existing deep link with zero changes to their call sites.**
+
+## Non-goals
+
+- Changing the log streaming, merging, sorting, or level/search filtering logic.
+- Changing the deep-link URL contract (`?app=`, `?cp=`, `?source=`).
+- Adding new capabilities to the Logs page.
+
+## Chosen approach (Option C)
+
+Merge **App + Control plane** into one grouped **Target** dropdown, and replace the **Source** dropdown with a **segmented toggle** (`daprd` | `app`) that reuses the existing level-chip styling and only appears in app view.
+
+Two other approaches were considered and rejected:
+
+- **Keep three dropdowns, disable the inactive ones.** Disabling the *target* pair (App/CP) turns the 2-click app→CP switch into 4 clicks (clear app, then open CP), regressing the primary flow. Disabling is only safe for the Source control, which alone does not justify keeping three peers.
+- **Merged Target + Source dropdown retained.** Cleaner than today but leaves Source as a dropdown that is visually identical to (and easily confused with) the Target dropdown. The segmented control reads as a sub-choice, not a peer selector.
+
+### Target selector
+
+A single `<select data-cy="log-target">` replaces the two dropdowns, using `optgroup`s:
+
+```
+Target ▾
+  — select target —
+  ── Applications ──
+    order-processor
+    checkout (compose:checkout)
+  ── Control plane ──
+    dapr_scheduler
+    dapr_placement
+```
+
+- **Option value encoding.** Each option carries a kind-prefixed value: `app:<appKey>` for applications, `cp:<name>` for control-plane services. The prefix disambiguates the (theoretical) case where an app and a CP service share a name, and lets `onChange` route to the correct URL param without ambiguity. The empty placeholder value is `''`.
+- **Applications** group reuses the existing `appOptions` label logic (`appId (key)` when the key differs from the appId).
+- **Control plane** group reuses the existing `cpNames` derivation (static `dapr_*` fallback per mode + actionable services reported by `/api/controlplane`, deduped).
+- **Empty groups are omitted.** In compose / test-containers modes with no CP services, the Control-plane `optgroup` is not rendered. Likewise the Applications group is omitted when no apps are discovered.
+- **Selected value is derived from the URL**, not stored separately:
+  - `?cp=<name>` set and valid → `cp:<name>`
+  - else `?app=<key>` set → `app:<key>`
+  - else `''`
+- **onChange** parses the prefix and writes params in one `setSearchParams`:
+  - `app:<key>` → set `app`, delete `cp` (leave `source` untouched)
+  - `cp:<name>` → set `cp`, delete `app`
+  - `''` → delete both `app` and `cp`
+- The existing **`cpPending`** behavior is preserved: a `?cp=` deep link for a compose service not yet returned by `/api/controlplane` still shows "Loading…" rather than "Select a target", and lights up the dropdown once the fetch settles.
+
+The **2-click app→CP switch** is preserved: open Target (1) → pick a service under the Control plane group (1).
+
+### Source segmented control
+
+The Source `<select>` is replaced by a two-chip toggle group styled with the existing `.lvchips` / `.lvchip` classes (the same visual language as the level filter):
+
+```
+( daprd | app )
+```
+
+- **Pressed state derives from `source`:**
+  - `both` → both chips pressed
+  - `daprd` → only `daprd` pressed
+  - `app` → only `app` pressed
+- **Toggle semantics.** Clicking a chip flips that stream in/out of the active set, and the new `source` is derived from the result:
+  - `{daprd, app}` → `both`
+  - `{daprd}` → `daprd`
+  - `{app}` → `app`
+  - `{}` → **disallowed.** Clicking the only-active chip is a no-op; at least one stream must stay selected. (This is the one behavioral difference from the level chips, which permit an all-off empty view — an all-off source has no meaning.)
+- **Visibility.** The source control renders **only in app view** (`appId` set, not CP view, target chosen). It is entirely absent in control-plane view and before a target is chosen. This removes the "why is this dropdown here?" confusion in CP view.
+- **Stream availability.** For parity with today, both chips are always shown regardless of `canStreamDaprd` / `canStreamApp`; the existing "no captured log file" card still handles the unstreamable case. (Disabling a chip when its stream is unavailable is noted as a future enhancement, out of scope here.)
+
+### Layout
+
+The `.logbar` order becomes:
+
+```
+[ Target ▾ ]   ( daprd | app )   [ debug info warn error ]   [ 🔍 Search… ]   [ Follow ]
+                 └ app view only
+```
+
+`.logbar` already wraps (`flex-wrap: wrap`), so no layout-engine changes are needed. The source chip group needs its own small wrapper (e.g. `.srcchips`, or reuse `.lvchips` with an `aria-label="Source"`).
+
+## Deep-link contract (unchanged)
+
+All existing generators keep working with **no edits**:
+
+| Source | Link | Result |
+|---|---|---|
+| `AppDetail.tsx:219` | `/logs?app=<key>&source=daprd` | Target = that app; source chips show `daprd` only |
+| `PublishMessageDialog.tsx:70` | `/logs?app=<id>&source=app` | Target = that app; source chips show `app` only |
+| `ControlPlane.tsx:169` | `/logs?cp=<name>` | Target = that CP service; source chips hidden |
+
+`?source=` continues to be parsed via `parseEnum` against `LOG_SOURCES` with a `both` fallback (an invalid value must not blank the control). The chips render the parsed value; they never read the raw param.
+
+## Data flow
+
+No change to state ownership. `source`, `app`, and `cp` remain URL-derived; `activeLevels`, `search`, and `following` remain local component state. The Target dropdown and source chips are pure reflections of URL params, mutated only through the existing `setSearchParams` helpers (renamed/merged as needed):
+
+- `onAppChange` / `onCpChange` / `clearCp` collapse into a single `onTargetChange(value: string)` that parses the `app:` / `cp:` / `''` prefix.
+- `onSourceChange` is kept but now invoked by the chip toggle handler, which computes the next `source` from the active set.
+
+## Error handling
+
+Unchanged. The existing content-area branches (`cpPending` "Loading…", "Select an app…" → reworded "Select a target to view logs.", "no captured log file" card, per-view loading) are preserved. Only the empty-state copy that says "Select an app" is updated to "Select a target" since the control now covers both.
+
+## Testing
+
+`web/src/pages/Logs.test.tsx` — most tests assert on URL params and `EventSource` URLs, which are unchanged, so they keep passing. The tests that touch the DOM controls need updates:
+
+- **Selector rename.** Tests referencing `log-app` and `log-cp` selects now drive the single `log-target` select (selecting `app:<key>` / `cp:<name>` values). "renders app and source selects in .logbar" becomes "renders target select and source chips in .logbar".
+- **Source control.** The invalid-`?source=` fallback test (currently asserts the select value) now asserts chip pressed-state (`both` → both pressed). Add: toggling a chip updates `?source`; the at-least-one-on invariant (clicking the sole active chip is a no-op); source chips are absent in CP view.
+- **Deep links.** Add/confirm: `?app=…&source=daprd` selects the app in Target and shows only the `daprd` chip pressed; `?cp=…` selects the CP service and hides the source chips.
+
+New behavior is TDD'd: write the failing test for each new interaction (target routing, chip toggle, invariant, CP-view hiding) before implementing.
+
+## Files touched
+
+- `web/src/pages/Logs.tsx` — merge the two selects into the Target `<select>` with optgroups + prefixed values; replace the Source `<select>` with the chip toggle; collapse `onAppChange`/`onCpChange`/`clearCp` into `onTargetChange`; gate source chips to app view; reword the empty state.
+- `web/src/styles/theme.css` — add a `.srcchips` wrapper if not reusing `.lvchips` verbatim; no new visual primitives.
+- `web/src/pages/Logs.test.tsx` — update selectors and add the new interaction tests above.
+- Follow `web/STYLEGUIDE.md` for chip/select styling and link/readability rules.

--- a/web/src/pages/Logs.test.tsx
+++ b/web/src/pages/Logs.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { http, HttpResponse, delay } from 'msw'
 import { describe, it, expect, beforeEach } from 'vitest'
@@ -219,10 +220,10 @@ describe('Logs', () => {
 
     // target select
     expect(bar.querySelector('[aria-label="Target"]')).not.toBeNull()
-    // source select
+    // source chip group (role=group, aria-label Source)
     expect(bar.querySelector('[aria-label="Source"]')).not.toBeNull()
-    // .lvchips group
-    expect(bar.querySelector('.lvchips')).not.toBeNull()
+    // level chips group still present
+    expect(bar.querySelector('.lvchips[aria-label="Levels"]')).not.toBeNull()
     // search input
     expect(bar.querySelector('input[aria-label="Filter logs"]')).not.toBeNull()
     // follow button
@@ -400,7 +401,7 @@ describe('Logs', () => {
     expect(FakeES.instances).toHaveLength(0)
   })
 
-  it('renders source select in .logbar', async () => {
+  it('renders daprd|app source chips in .logbar', async () => {
     server.use(
       http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
       http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
@@ -410,13 +411,13 @@ describe('Logs', () => {
 
     await waitFor(() => expect(FakeES.instances.length).toBeGreaterThanOrEqual(1))
 
-    const sourceSelect = screen.getByRole('combobox', { name: /Source/i })
-    expect(sourceSelect).toBeInTheDocument()
-
-    // Source options match mock
-    expect(screen.getByRole('option', { name: 'daprd + app' })).toBeInTheDocument()
-    expect(screen.getByRole('option', { name: 'daprd only' })).toBeInTheDocument()
-    expect(screen.getByRole('option', { name: 'app only' })).toBeInTheDocument()
+    // Source is now a chip toggle group, not a combobox.
+    // renderAt()'s default URL is `?source=daprd`, so only the daprd chip is pressed.
+    expect(screen.queryByRole('combobox', { name: /Source/i })).toBeNull()
+    const daprd = screen.getByRole('button', { name: 'daprd' })
+    const app = screen.getByRole('button', { name: 'app' })
+    expect(daprd).toHaveAttribute('aria-pressed', 'true')
+    expect(app).toHaveAttribute('aria-pressed', 'false')
   })
 
   it('renders a single grouped Target select (no separate App/CP selects)', async () => {
@@ -463,6 +464,57 @@ describe('Logs', () => {
     await waitFor(() => expect(target.value).toBe('cp:dapr_scheduler'))
   })
 
+  it('renders daprd|app source chips reflecting ?source=daprd (no Source select)', async () => {
+    server.use(
+      http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+      http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+    )
+    renderAt('/logs?app=order&source=daprd')
+    // Source is now chips, not a combobox
+    expect(screen.queryByRole('combobox', { name: /Source/i })).toBeNull()
+    const daprd = await screen.findByRole('button', { name: 'daprd' })
+    const app = screen.getByRole('button', { name: 'app' })
+    expect(daprd).toHaveAttribute('aria-pressed', 'true')
+    expect(app).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('toggling the app chip while on daprd yields source=both (adds the stream)', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+      http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+    )
+    renderAt('/logs?app=order&source=daprd')
+    const app = await screen.findByRole('button', { name: 'app' })
+    await user.click(app)
+    await waitFor(() => expect(app).toHaveAttribute('aria-pressed', 'true'))
+    expect(screen.getByRole('button', { name: 'daprd' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('clicking the only active source chip is a no-op (at-least-one invariant)', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+      http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+    )
+    renderAt('/logs?app=order&source=daprd')
+    const daprd = await screen.findByRole('button', { name: 'daprd' })
+    await user.click(daprd)
+    // still pressed — cannot turn off the last active stream
+    expect(daprd).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('hides the source chips in control-plane view', async () => {
+    server.use(
+      http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+      http.get('/api/controlplane', () => HttpResponse.json(CP_LIST_BASE)),
+    )
+    renderAt('/logs?cp=dapr_scheduler')
+    await screen.findByRole('combobox', { name: /Target/i })
+    expect(screen.queryByRole('button', { name: 'daprd' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'app' })).toBeNull()
+  })
+
   it('falls back to "both" for an invalid ?source= URL param', async () => {
     server.use(
       http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
@@ -471,9 +523,11 @@ describe('Logs', () => {
 
     const { container } = renderAt('/logs?app=order&source=garbage')
 
-    const sourceSelect = (await screen.findByRole('combobox', { name: /Source/i })) as HTMLSelectElement
-    // An unknown source must not leave the select blank — it falls back to "both".
-    await waitFor(() => expect(sourceSelect.value).toBe('both'))
+    // An unknown source falls back to "both": both chips pressed.
+    const daprd = (await screen.findByRole('button', { name: 'daprd' }))
+    const app = screen.getByRole('button', { name: 'app' })
+    await waitFor(() => expect(daprd).toHaveAttribute('aria-pressed', 'true'))
+    expect(app).toHaveAttribute('aria-pressed', 'true')
     // Subtitle reflects the fallback, not the garbage value.
     expect(screen.getByText(/daprd \+ application/)).toBeInTheDocument()
     // The raw URL value must not leak into rendering: the source-column width is

--- a/web/src/pages/Logs.test.tsx
+++ b/web/src/pages/Logs.test.tsx
@@ -217,8 +217,8 @@ describe('Logs', () => {
 
     const bar = logbars[0]
 
-    // app select
-    expect(bar.querySelector('[aria-label="App"]')).not.toBeNull()
+    // target select
+    expect(bar.querySelector('[aria-label="Target"]')).not.toBeNull()
     // source select
     expect(bar.querySelector('[aria-label="Source"]')).not.toBeNull()
     // .lvchips group
@@ -396,11 +396,11 @@ describe('Logs', () => {
 
     await waitFor(() => expect(screen.getByRole('heading', { name: 'Logs' })).toBeInTheDocument())
 
-    expect(screen.getByText(/Select an app/)).toBeInTheDocument()
+    expect(screen.getByText(/Select a target/)).toBeInTheDocument()
     expect(FakeES.instances).toHaveLength(0)
   })
 
-  it('renders app and source selects in .logbar', async () => {
+  it('renders source select in .logbar', async () => {
     server.use(
       http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
       http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
@@ -410,9 +410,6 @@ describe('Logs', () => {
 
     await waitFor(() => expect(FakeES.instances.length).toBeGreaterThanOrEqual(1))
 
-    const appSelect = screen.getByRole('combobox', { name: /App/i })
-    expect(appSelect).toBeInTheDocument()
-
     const sourceSelect = screen.getByRole('combobox', { name: /Source/i })
     expect(sourceSelect).toBeInTheDocument()
 
@@ -420,6 +417,50 @@ describe('Logs', () => {
     expect(screen.getByRole('option', { name: 'daprd + app' })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: 'daprd only' })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: 'app only' })).toBeInTheDocument()
+  })
+
+  it('renders a single grouped Target select (no separate App/CP selects)', async () => {
+    server.use(
+      http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+      http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+      http.get('/api/controlplane', () => HttpResponse.json(CP_LIST_BASE)),
+    )
+
+    renderAt()
+
+    const target = (await screen.findByRole('combobox', { name: /Target/i })) as HTMLSelectElement
+    expect(target).toBeInTheDocument()
+    // Old peer selects are gone
+    expect(screen.queryByRole('combobox', { name: /^App$/i })).toBeNull()
+    expect(screen.queryByRole('combobox', { name: /Control Plane/i })).toBeNull()
+    // Grouped: an Applications optgroup with the app, a Control plane optgroup with a dapr_* service.
+    // Wait for the async /api/apps + /api/controlplane fetches to populate the options —
+    // the select itself renders synchronously with zero options.
+    await screen.findByRole('option', { name: 'order' })
+    expect(target.querySelector('optgroup[label="Applications"]')).not.toBeNull()
+    expect(target.querySelector('optgroup[label="Control plane"]')).not.toBeNull()
+    expect(screen.getByRole('option', { name: 'dapr_scheduler' })).toBeInTheDocument()
+  })
+
+  it('reflects a ?app deep link as the selected Target', async () => {
+    server.use(
+      http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+      http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+    )
+    renderAt('/logs?app=order&source=daprd')
+    const target = (await screen.findByRole('combobox', { name: /Target/i })) as HTMLSelectElement
+    await waitFor(() => expect(target.value).toBe('app:order'))
+  })
+
+  it('reflects a ?cp deep link as the selected Target and clears app on switch', async () => {
+    server.use(
+      http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+      http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+      http.get('/api/controlplane', () => HttpResponse.json(CP_LIST_BASE)),
+    )
+    renderAt('/logs?cp=dapr_scheduler')
+    const target = (await screen.findByRole('combobox', { name: /Target/i })) as HTMLSelectElement
+    await waitFor(() => expect(target.value).toBe('cp:dapr_scheduler'))
   })
 
   it('falls back to "both" for an invalid ?source= URL param', async () => {
@@ -901,8 +942,8 @@ describe('Logs', () => {
     expect(screen.getByRole('option', { name: 'dapr_placement' })).toBeInTheDocument()
 
     // Statics must not be duplicated by the fetched list.
-    const cpSelect = screen.getByRole('combobox', { name: /Control Plane/i })
-    const names = Array.from(cpSelect.querySelectorAll('option')).map(o => o.textContent)
+    const target = screen.getByRole('combobox', { name: /Target/i })
+    const names = Array.from(target.querySelectorAll('option')).map(o => o.textContent)
     expect(names.filter(n => n === 'dapr_placement')).toHaveLength(1)
   })
 
@@ -959,7 +1000,7 @@ describe('Logs', () => {
     expect(await screen.findByText(/placement raft leader/)).toBeInTheDocument()
   })
 
-  it('CP — while the CP list is still loading, a ?cp= deep link shows loading, not "Select an app"', async () => {
+  it('CP — while the CP list is still loading, a ?cp= deep link shows loading, not "Select a target"', async () => {
     server.use(
       http.get('/api/apps', () => HttpResponse.json([])),
       http.get('/api/controlplane', async () => {
@@ -974,8 +1015,8 @@ describe('Logs', () => {
       expect(screen.getByRole('heading', { name: 'Logs' })).toBeInTheDocument(),
     )
     // The compose name can't be validated until the fetch lands — but the page
-    // must not claim "Select an app" while a cp target is pending.
-    expect(screen.queryByText(/Select an app/)).toBeNull()
+    // must not claim "Select a target" while a cp target is pending.
+    expect(screen.queryByText(/Select a target/)).toBeNull()
 
     // Once the list arrives the CP stream mounts.
     await waitFor(() => expect(FakeES.instances.length).toBeGreaterThanOrEqual(1))
@@ -995,9 +1036,9 @@ describe('Logs', () => {
       expect(screen.getByRole('option', { name: 'saga-placement-1' })).toBeInTheDocument(),
     )
     expect(FakeES.instances).toHaveLength(0)
-    const cpSelect = screen.getByRole('combobox', { name: /Control Plane/i }) as HTMLSelectElement
-    expect(cpSelect.value).toBe('')
-    expect(screen.getByText(/Select an app/)).toBeInTheDocument()
+    const target = screen.getByRole('combobox', { name: /Target/i }) as HTMLSelectElement
+    expect(target.value).toBe('')
+    expect(screen.getByText(/Select a target/)).toBeInTheDocument()
   })
 
   // F5: logfoot tail size
@@ -1032,11 +1073,11 @@ describe('Logs', () => {
       ),
     )
     renderAt('/logs?app=daprmq-host-1&source=daprd')
-    const select = await screen.findByLabelText('App')
+    const select = await screen.findByLabelText('Target')
     await waitFor(() => {
       const values = Array.from(select.querySelectorAll('option')).map(o => o.value)
-      expect(values).toContain('daprmq-host-1')
-      expect(values).toContain('daprmq-host-2')
+      expect(values).toContain('app:daprmq-host-1')
+      expect(values).toContain('app:daprmq-host-2')
     })
     // Labels disambiguate: app id + container name.
     expect(screen.getByRole('option', { name: 'daprmq-service (daprmq-host-1)' })).toBeInTheDocument()

--- a/web/src/pages/Logs.test.tsx
+++ b/web/src/pages/Logs.test.tsx
@@ -478,6 +478,18 @@ describe('Logs', () => {
     expect(app).toHaveAttribute('aria-pressed', 'false')
   })
 
+  it('reflects ?source=app as only the app chip pressed', async () => {
+    server.use(
+      http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+      http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+    )
+    renderAt('/logs?app=order&source=app')
+    const daprd = await screen.findByRole('button', { name: 'daprd' })
+    const app = screen.getByRole('button', { name: 'app' })
+    await waitFor(() => expect(app).toHaveAttribute('aria-pressed', 'true'))
+    expect(daprd).toHaveAttribute('aria-pressed', 'false')
+  })
+
   it('toggling the app chip while on daprd yields source=both (adds the stream)', async () => {
     const user = userEvent.setup()
     server.use(

--- a/web/src/pages/Logs.test.tsx
+++ b/web/src/pages/Logs.test.tsx
@@ -453,7 +453,7 @@ describe('Logs', () => {
     await waitFor(() => expect(target.value).toBe('app:order'))
   })
 
-  it('reflects a ?cp deep link as the selected Target and clears app on switch', async () => {
+  it('reflects a ?cp deep link as the selected Target', async () => {
     server.use(
       http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
       http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
@@ -462,6 +462,23 @@ describe('Logs', () => {
     renderAt('/logs?cp=dapr_scheduler')
     const target = (await screen.findByRole('combobox', { name: /Target/i })) as HTMLSelectElement
     await waitFor(() => expect(target.value).toBe('cp:dapr_scheduler'))
+  })
+
+  it('switching Target from an app to a control-plane service clears ?app', async () => {
+    server.use(
+      http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+      http.get('/api/apps/order', () => HttpResponse.json(ORDER_DETAIL)),
+      http.get('/api/controlplane', () => HttpResponse.json(CP_LIST_BASE)),
+    )
+    renderAt('/logs?app=order&source=daprd')
+    const target = (await screen.findByRole('combobox', { name: /Target/i })) as HTMLSelectElement
+
+    fireEvent.change(target, { target: { value: 'cp:dapr_scheduler' } })
+
+    await waitFor(() => expect(target.value).toBe('cp:dapr_scheduler'))
+    // App cleared → CP view, so the source chips (app-only UI) disappear.
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'daprd' })).toBeNull())
+    expect(screen.queryByRole('button', { name: 'app' })).toBeNull()
   })
 
   it('renders daprd|app source chips reflecting ?source=daprd (no Source select)', async () => {
@@ -514,6 +531,9 @@ describe('Logs', () => {
     await user.click(daprd)
     // still pressed — cannot turn off the last active stream
     expect(daprd).toHaveAttribute('aria-pressed', 'true')
+    // and the state must not have been silently promoted to "both" (which would
+    // also show daprd pressed) — app must remain unpressed.
+    expect(screen.getByRole('button', { name: 'app' })).toHaveAttribute('aria-pressed', 'false')
   })
 
   it('hides the source chips in control-plane view', async () => {
@@ -522,6 +542,16 @@ describe('Logs', () => {
       http.get('/api/controlplane', () => HttpResponse.json(CP_LIST_BASE)),
     )
     renderAt('/logs?cp=dapr_scheduler')
+    await screen.findByRole('combobox', { name: /Target/i })
+    expect(screen.queryByRole('button', { name: 'daprd' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'app' })).toBeNull()
+  })
+
+  it('hides the source chips before any target is chosen', async () => {
+    server.use(
+      http.get('/api/apps', () => HttpResponse.json([ORDER_SUMMARY])),
+    )
+    renderAt('/logs')
     await screen.findByRole('combobox', { name: /Target/i })
     expect(screen.queryByRole('button', { name: 'daprd' })).toBeNull()
     expect(screen.queryByRole('button', { name: 'app' })).toBeNull()
@@ -1129,7 +1159,7 @@ describe('Logs', () => {
     expect(logfoot?.textContent).toMatch(/tail \d+ KB/)
   })
 
-  it('app dropdown lists duplicate-app-id compose instances as distinct options keyed by instanceKey', async () => {
+  it('Target dropdown lists duplicate-app-id compose instances as distinct options keyed by instanceKey', async () => {
     const host1 = { ...COMPOSE_SUMMARY, appId: 'daprmq-service', instanceKey: 'daprmq-host-1' }
     const host2 = { ...COMPOSE_SUMMARY, appId: 'daprmq-service', instanceKey: 'daprmq-host-2' }
     server.use(

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -432,6 +432,20 @@ export function Logs() {
     })
   }
 
+  function toggleSource(stream: 'daprd' | 'app') {
+    const active = new Set<'daprd' | 'app'>(
+      source === 'both' ? ['daprd', 'app'] : [source],
+    )
+    if (active.has(stream)) {
+      if (active.size === 1) return // at-least-one-on invariant
+      active.delete(stream)
+    } else {
+      active.add(stream)
+    }
+    const next: LogSource = active.size === 2 ? 'both' : active.has('daprd') ? 'daprd' : 'app'
+    onSourceChange(next)
+  }
+
   function toggleLevel(level: LogLevel) {
     setActiveLevels(prev => {
       const next = new Set(prev)
@@ -493,7 +507,7 @@ export function Logs() {
         </div>
       </div>
 
-      {/* Single unified logbar: target select · source select · lvchips · search · followbtn */}
+      {/* Single unified logbar: target select · source chips · lvchips · search · followbtn */}
       <div className="logbar">
         <select
           className="select"
@@ -523,17 +537,24 @@ export function Logs() {
           )}
         </select>
 
-        <select
-          className="select"
-          data-cy="log-source"
-          value={source}
-          onChange={e => onSourceChange(e.target.value as LogSource)}
-          aria-label="Source"
-        >
-          <option value="both">daprd + app</option>
-          <option value="daprd">daprd only</option>
-          <option value="app">app only</option>
-        </select>
+        {!isCpView && appId && (
+          <div className="lvchips srcchips" role="group" aria-label="Source">
+            {(['daprd', 'app'] as const).map(stream => {
+              const active = source === 'both' || source === stream
+              return (
+                <button
+                  key={stream}
+                  className="lvchip"
+                  data-cy={`log-source-${stream}`}
+                  aria-pressed={active}
+                  onClick={() => toggleSource(stream)}
+                >
+                  {stream}
+                </button>
+              )
+            })}
+          </div>
+        )}
 
         <div className="lvchips" role="group" aria-label="Levels">
           {ALL_LEVELS.map(level => (

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -387,7 +387,7 @@ export function Logs() {
   const cp = cpNames.includes(cpParam) ? cpParam : ''
   // A cp target that isn't (yet) in the list is pending until the fetch
   // settles — /api/controlplane shells out to docker and can take seconds, and
-  // we must not claim "Select an app" for a valid compose deep link meanwhile.
+  // we must not claim "Select a target" for a valid compose deep link meanwhile.
   const cpPending = cpParam !== '' && cp === '' && cpList === undefined && !cpListError
 
   const [activeLevels, setActiveLevels] = useState<Set<LogLevel>>(new Set(ALL_LEVELS))
@@ -402,13 +402,24 @@ export function Logs() {
 
   const { data: app, isLoading } = useApp(appId)
 
-  function onAppChange(id: string) {
+  const targetValue = cp ? `cp:${cp}` : appId ? `app:${appId}` : ''
+
+  function onTargetChange(value: string) {
     setSearchParams(prev => {
       const next = new URLSearchParams(prev)
-      if (id) next.set('app', id)
-      else next.delete('app')
-      // Clear cp when switching to an app
-      next.delete('cp')
+      const sep = value.indexOf(':')
+      const kind = sep === -1 ? '' : value.slice(0, sep)
+      const name = sep === -1 ? '' : value.slice(sep + 1)
+      if (kind === 'app') {
+        next.set('app', name)
+        next.delete('cp')
+      } else if (kind === 'cp') {
+        next.set('cp', name)
+        next.delete('app')
+      } else {
+        next.delete('app')
+        next.delete('cp')
+      }
       return next
     })
   }
@@ -417,24 +428,6 @@ export function Logs() {
     setSearchParams(prev => {
       const next = new URLSearchParams(prev)
       next.set('source', s)
-      return next
-    })
-  }
-
-  function onCpChange(name: string) {
-    setSearchParams(prev => {
-      const next = new URLSearchParams(prev)
-      next.set('cp', name)
-      // Clear app selection when switching to control-plane view
-      next.delete('app')
-      return next
-    })
-  }
-
-  function clearCp() {
-    setSearchParams(prev => {
-      const next = new URLSearchParams(prev)
-      next.delete('cp')
       return next
     })
   }
@@ -500,21 +493,34 @@ export function Logs() {
         </div>
       </div>
 
-      {/* Single unified logbar: app select · source select · lvchips · search · followbtn */}
+      {/* Single unified logbar: target select · source select · lvchips · search · followbtn */}
       <div className="logbar">
         <select
           className="select"
-          data-cy="log-app"
-          value={appId}
-          onChange={e => onAppChange(e.target.value)}
-          aria-label="App"
+          data-cy="log-target"
+          value={targetValue}
+          onChange={e => onTargetChange(e.target.value)}
+          aria-label="Target"
         >
-          <option value="">— select app —</option>
-          {appOptions.map(o => (
-            <option key={o.key} value={o.key}>
-              {o.label}
-            </option>
-          ))}
+          <option value="">— select target —</option>
+          {appOptions.length > 0 && (
+            <optgroup label="Applications">
+              {appOptions.map(o => (
+                <option key={`app:${o.key}`} value={`app:${o.key}`}>
+                  {o.label}
+                </option>
+              ))}
+            </optgroup>
+          )}
+          {cpNames.length > 0 && (
+            <optgroup label="Control plane">
+              {cpNames.map(name => (
+                <option key={`cp:${name}`} value={`cp:${name}`}>
+                  {name}
+                </option>
+              ))}
+            </optgroup>
+          )}
         </select>
 
         <select
@@ -527,26 +533,6 @@ export function Logs() {
           <option value="both">daprd + app</option>
           <option value="daprd">daprd only</option>
           <option value="app">app only</option>
-        </select>
-
-        {/* Control-plane service selector — slots alongside the existing source selector */}
-        <select
-          className="select"
-          data-cy="log-cp"
-          value={cp}
-          onChange={e => {
-            const val = e.target.value
-            if (val === '') clearCp()
-            else onCpChange(val)
-          }}
-          aria-label="Control Plane"
-        >
-          <option value="">— control plane —</option>
-          {cpNames.map(name => (
-            <option key={name} value={name}>
-              {name}
-            </option>
-          ))}
         </select>
 
         <div className="lvchips" role="group" aria-label="Levels">
@@ -601,7 +587,7 @@ export function Logs() {
       )}
 
       {!isCpView && !appId && !cpPending && (
-        <p className="muted">Select an app to view logs.</p>
+        <p className="muted">Select a target to view logs.</p>
       )}
 
       {!isCpView && appId && isLoading && (

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -292,6 +292,7 @@ pre.code { margin: 0; padding: 14px; font-family: var(--mono); font-size: 12px; 
 .lvchips { display: inline-flex; gap: 5px; }
 .lvchip { font: inherit; font-family: var(--mono); font-size: 10.5px; padding: 6px 9px; border-radius: 7px; border: 1px solid var(--line); background: var(--surface); color: var(--muted); cursor: pointer; text-transform: uppercase; letter-spacing: .05em; }
 .lvchip[aria-pressed="true"] { color: var(--text); border-color: var(--faint); background: var(--surface-2); }
+.srcchips { margin-right: 2px; }
 .followbtn { font: inherit; font-size: 12.5px; border: 1px solid var(--line); background: var(--surface); color: var(--muted); border-radius: 9px; padding: 7px 12px; cursor: pointer; display: inline-flex; align-items: center; gap: 7px; }
 .followbtn .d { width: 8px; height: 8px; border-radius: 50%; background: var(--done-fg); animation: beat 2.4s ease-out infinite; }
 .followbtn.on { color: var(--text); border-color: color-mix(in srgb, var(--done-fg) 45%, transparent); }

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -292,7 +292,7 @@ pre.code { margin: 0; padding: 14px; font-family: var(--mono); font-size: 12px; 
 .lvchips { display: inline-flex; gap: 5px; }
 .lvchip { font: inherit; font-family: var(--mono); font-size: 10.5px; padding: 6px 9px; border-radius: 7px; border: 1px solid var(--line); background: var(--surface); color: var(--muted); cursor: pointer; text-transform: uppercase; letter-spacing: .05em; }
 .lvchip[aria-pressed="true"] { color: var(--text); border-color: var(--faint); background: var(--surface-2); }
-.srcchips { margin-right: 2px; }
+.srcchips { margin-left: 2px; }
 .followbtn { font: inherit; font-size: 12.5px; border: 1px solid var(--line); background: var(--surface); color: var(--muted); border-radius: 9px; padding: 7px 12px; cursor: pointer; display: inline-flex; align-items: center; gap: 7px; }
 .followbtn .d { width: 8px; height: 8px; border-radius: 50%; background: var(--done-fg); animation: beat 2.4s ease-out infinite; }
 .followbtn.on { color: var(--text); border-color: color-mix(in srgb, var(--done-fg) 45%, transparent); }


### PR DESCRIPTION
## Why

The Logs page had **three peer dropdowns** — App, Source (daprd+app / daprd / app), and Control plane — with no visible indication of how they relate. In fact there were only ever **two** real decisions:

- **App and Control plane are mutually exclusive** (selecting one already cleared the other), so they were really one question: *what am I tailing?*
- **Source only applies to apps** — it was meaningless yet fully interactive when viewing a control-plane service.

## What changed

- **Merged App + Control plane into one grouped `Target` dropdown** (`Applications` / `Control plane` optgroups, kind-prefixed option values `app:<key>` / `cp:<name>`). Empty groups are omitted per discovery mode.
- **Replaced the Source dropdown with a `daprd | app` segmented toggle** (reuses the existing `.lvchip` styling) that appears **only in app view** and is hidden for control-plane targets. Both lit = `both`; an at-least-one-on invariant prevents an empty selection.
- Reworded the empty state to "Select a target to view logs."

## Preserved

- **All deep links unchanged** — `?app=<key>&source=<daprd|app|both>` and `?cp=<name>` keep working with zero edits to their generators (`AppDetail`, `PublishMessageDialog`, `ControlPlane`).
- **2-click app→control-plane switch** kept (open Target → pick service; app auto-clears).
- `?source` still validated via `parseEnum(..., 'both')`.

## Testing

- Frontend-only change; full web suite **772/772 green**, `tsc -b` + `vite build` clean.
- Component tests drive the real `<Logs>` through all three deep-link URL shapes and assert control state, the at-least-one-on invariant, CP-view chip hiding, and the app→CP switch clearing `?app`.
- Verified live against a running dashboard with a real discovered Dapr app + control plane.

Design + implementation plan: `docs/superpowers/specs/2026-07-17-logs-filter-simplification-design.md`, `docs/superpowers/plans/2026-07-17-logs-filter-simplification.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)