### PR TITLE
feat: clear inactive applications (global + per-row, non-destructive)

### DIFF
--- a/docs/superpowers/plans/2026-07-27-clear-inactive-apps.md
+++ b/docs/superpowers/plans/2026-07-27-clear-inactive-apps.md
@@ -1,0 +1,959 @@
+# Clear Inactive Applications Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give users one global, coherent action to remove all fully-stopped ("inactive") scan-detected applications from the dashboard, plus a per-row remove on the Applications list — without deleting anything from Docker.
+
+**Architecture:** All retained inactive state flows through the lifecycle overlay (`pkg/lifecycle/overlay.go`), which decorates the stateless discovery service. We add an in-memory **suppression set** to the shared `lifecycle.Registry`. A unified `Manager.Dismiss(key)` drops any registry "ghost" and suppresses the `InstanceKey`; the overlay filters out suppressed instances while they are fully stopped and auto-un-suppresses any that reappear running. `Manager.ClearInactive` dismisses every fully-stopped instance at once. The frontend gets a global "Clear inactive · N" button in the Applications page header and a per-row remove; because components/subscriptions/actors/resources all re-derive from the app list, suppression is coherent across every page for free.
+
+**Tech Stack:** Go (chi router, testify), React 19 + TypeScript, TanStack Query, Vitest + Testing Library + msw.
+
+## Global Constraints
+
+- **Non-destructive:** never run `docker rm` or delete real Docker/container state. "Remove" means suppress from the dashboard view only.
+- **Fully-stopped predicate:** eligible = `AppStatus == "stopped" && DaprdStatus == "stopped"` (backend `discovery.StatusStopped`; frontend `isStopped`). Nothing else is removable.
+- **Ephemeral:** suppression lives in backend process memory only; it resets on dashboard restart (same lifetime as the existing registry). No disk persistence.
+- **Auto-un-hide:** a suppressed instance seen running again reappears and is pruned from the suppression set.
+- **Copy rule:** user-facing text says "Remove from dashboard" and "reappear if it runs again or when the dashboard restarts". Never "delete", "remove container", or "docker rm".
+- **Verification:** run `make build` (which runs `tsc -b`) after any `.ts(x)` change — Vitest alone does not typecheck. Go tests run with `-tags unit`.
+
+---
+
+### Task 1: Registry suppression set
+
+**Files:**
+- Modify: `pkg/lifecycle/registry.go`
+- Test: `pkg/lifecycle/registry_test.go`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `(*Registry).Suppress(key string)`, `(*Registry).Unsuppress(key string)`, `(*Registry).IsSuppressed(key string) bool`. `NewRegistry()` now also initializes the suppression set.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `pkg/lifecycle/registry_test.go` (package `lifecycle`, no build tag — matches the existing file):
+
+```go
+func TestRegistrySuppression(t *testing.T) {
+	r := NewRegistry()
+	require.False(t, r.IsSuppressed("orders"))
+
+	r.Suppress("orders")
+	require.True(t, r.IsSuppressed("orders"))
+
+	// Idempotent.
+	r.Suppress("orders")
+	require.True(t, r.IsSuppressed("orders"))
+
+	r.Unsuppress("orders")
+	require.False(t, r.IsSuppressed("orders"))
+
+	// Unsuppressing an unknown key is a no-op.
+	r.Unsuppress("never")
+	require.False(t, r.IsSuppressed("never"))
+}
+```
+
+If `registry_test.go` does not already import testify, add `"github.com/stretchr/testify/require"` and `"testing"` to its imports.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -tags unit ./pkg/lifecycle/ -run TestRegistrySuppression`
+Expected: FAIL — `r.Suppress undefined (type *Registry has no field or method Suppress)`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `pkg/lifecycle/registry.go`, add a `suppressed` field to the struct and initialize it in `NewRegistry`:
+
+```go
+type Registry struct {
+	mu         sync.Mutex
+	entries    map[string]*Entry   // keyed by InstanceKey
+	suppressed map[string]struct{} // InstanceKeys the user cleared; hidden while stopped
+}
+
+func NewRegistry() *Registry {
+	return &Registry{entries: map[string]*Entry{}, suppressed: map[string]struct{}{}}
+}
+```
+
+Then add the three methods (e.g. just below `Drop`):
+
+```go
+// Suppress hides an InstanceKey from the overlay while it remains fully
+// stopped. It is cleared automatically when the instance is seen running
+// again (see overlay.List) or on dashboard restart (the set is not persisted).
+func (r *Registry) Suppress(key string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.suppressed[key] = struct{}{}
+}
+
+// Unsuppress removes a key from the suppression set.
+func (r *Registry) Unsuppress(key string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.suppressed, key)
+}
+
+// IsSuppressed reports whether key is currently suppressed.
+func (r *Registry) IsSuppressed(key string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.suppressed[key]
+	return ok
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -tags unit ./pkg/lifecycle/ -run TestRegistrySuppression`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/lifecycle/registry.go pkg/lifecycle/registry_test.go
+git commit -m "feat(lifecycle): add suppression set to Registry"
+```
+
+---
+
+### Task 2: Overlay hides suppressed stopped instances
+
+**Files:**
+- Modify: `pkg/lifecycle/overlay.go`
+- Test: `pkg/lifecycle/overlay_test.go`
+
+**Interfaces:**
+- Consumes: `(*Registry).IsSuppressed`, `(*Registry).Unsuppress` (Task 1).
+- Produces: package-level helper `fullyStopped(in discovery.Instance) bool` (reused by Task 3). `overlay.List` now filters suppressed instances.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `pkg/lifecycle/overlay_test.go`:
+
+```go
+func TestOverlayHidesSuppressedStoppedInstance(t *testing.T) {
+	reg := NewRegistry()
+	stopped := standaloneInst()
+	stopped.AppStatus, stopped.DaprdStatus = discovery.StatusStopped, discovery.StatusStopped
+	reg.Suppress(stopped.InstanceKey)
+
+	svc := Overlay(fakeApps{items: map[string]discovery.Instance{"orders": stopped}}, reg, newFakeProc())
+
+	items, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, items) // suppressed + fully stopped -> hidden
+}
+
+func TestOverlayUnsuppressesReactivatedInstance(t *testing.T) {
+	reg := NewRegistry()
+	live := standaloneInst()
+	live.AppStatus, live.DaprdStatus = discovery.StatusRunning, discovery.StatusRunning
+	reg.Suppress(live.InstanceKey)
+
+	svc := Overlay(fakeApps{items: map[string]discovery.Instance{"orders": live}}, reg, newFakeProc())
+
+	items, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, items, 1) // running again -> shown
+	require.False(t, reg.IsSuppressed(live.InstanceKey)) // and pruned
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -tags unit ./pkg/lifecycle/ -run 'TestOverlayHidesSuppressedStoppedInstance|TestOverlayUnsuppressesReactivatedInstance'`
+Expected: FAIL — `TestOverlayHidesSuppressedStoppedInstance` returns 1 item (filter not implemented yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `pkg/lifecycle/overlay.go`, add the helper (e.g. just above `synthesize`):
+
+```go
+// fullyStopped reports whether both halves of an instance are stopped — the
+// predicate the dashboard uses to treat an instance as inactive/removable.
+func fullyStopped(in discovery.Instance) bool {
+	return in.AppStatus == discovery.StatusStopped && in.DaprdStatus == discovery.StatusStopped
+}
+```
+
+Then insert a suppression filter pass into `List`, immediately before the
+`sort.SliceStable(...)` call:
+
+```go
+	// Suppression: instances the user cleared stay hidden while still stopped;
+	// once one is seen running again it reappears and its suppression is pruned.
+	out := items[:0]
+	for _, in := range items {
+		if o.reg.IsSuppressed(in.InstanceKey) {
+			if fullyStopped(in) {
+				continue
+			}
+			o.reg.Unsuppress(in.InstanceKey)
+		}
+		out = append(out, in)
+	}
+	items = out
+```
+
+(`items[:0]` reuses the backing array safely: the write index never passes the read index.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -tags unit ./pkg/lifecycle/ -run Overlay`
+Expected: PASS (new tests plus all existing `Overlay*` tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/lifecycle/overlay.go pkg/lifecycle/overlay_test.go
+git commit -m "feat(lifecycle): overlay filters suppressed stopped instances"
+```
+
+---
+
+### Task 3: Manager Dismiss + ClearInactive
+
+**Files:**
+- Modify: `pkg/lifecycle/manager.go`
+- Test: `pkg/lifecycle/manager_test.go`
+
+**Interfaces:**
+- Consumes: `(*Registry).Drop`, `(*Registry).Suppress`, `(*Registry).Get` (Tasks 1 & existing); `fullyStopped` (Task 2); `manager.apps discovery.Service` (existing field, wired to the overlay in `cmd/root.go`).
+- Produces: `Manager.Dismiss(ctx, key) error` (replaces `Forget`) and `Manager.ClearInactive(ctx) (int, error)`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `pkg/lifecycle/manager_test.go`, replace any existing `Forget` test with these (if there is no existing `Forget` test in this file, just add them):
+
+```go
+func TestDismissSuppressesAndDropsGhost(t *testing.T) {
+	reg := NewRegistry()
+	ghost := standaloneInst() // InstanceKey "orders"
+	reg.RecordStop(ghost, map[Target]ProcSnapshot{TargetAll: {PID: 300}})
+	m := New(fakeApps{items: map[string]discovery.Instance{}}, reg, nil, newFakeProc(), nil)
+
+	require.NoError(t, m.Dismiss(context.Background(), "orders"))
+
+	_, ok := reg.Get("orders")
+	require.False(t, ok) // ghost dropped
+	require.True(t, reg.IsSuppressed("orders"))
+}
+
+func TestDismissSuppressesComposeKeyWithoutGhost(t *testing.T) {
+	reg := NewRegistry()
+	m := New(fakeApps{items: map[string]discovery.Instance{}}, reg, nil, newFakeProc(), nil)
+
+	require.NoError(t, m.Dismiss(context.Background(), "shop-checkout-app-1"))
+
+	require.True(t, reg.IsSuppressed("shop-checkout-app-1"))
+}
+
+func TestClearInactiveDismissesEveryStoppedInstance(t *testing.T) {
+	reg := NewRegistry()
+	stopped1 := standaloneInst() // "orders"
+	stopped1.AppStatus, stopped1.DaprdStatus = discovery.StatusStopped, discovery.StatusStopped
+	stopped2 := composeInst() // "shop-checkout-app-1"
+	stopped2.AppStatus, stopped2.DaprdStatus = discovery.StatusStopped, discovery.StatusStopped
+	running := standaloneInst()
+	running.InstanceKey, running.AppID = "live", "live"
+	running.AppStatus, running.DaprdStatus = discovery.StatusRunning, discovery.StatusRunning
+
+	m := New(fakeApps{items: map[string]discovery.Instance{
+		"orders":              stopped1,
+		"shop-checkout-app-1": stopped2,
+		"live":                running,
+	}}, reg, nil, newFakeProc(), nil)
+
+	n, err := m.ClearInactive(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+	require.True(t, reg.IsSuppressed("orders"))
+	require.True(t, reg.IsSuppressed("shop-checkout-app-1"))
+	require.False(t, reg.IsSuppressed("live"))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -tags unit ./pkg/lifecycle/ -run 'Dismiss|ClearInactive'`
+Expected: FAIL — `m.Dismiss undefined` / `m.ClearInactive undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `pkg/lifecycle/manager.go`, update the `Manager` interface: remove `Forget` and add `Dismiss` + `ClearInactive`:
+
+```go
+// Manager starts, stops and restarts discovered app instances.
+type Manager interface {
+	Do(ctx context.Context, key string, target Target, action Action) error
+	// Dismiss hides an inactive instance from the dashboard: it drops any
+	// registry ghost and suppresses the InstanceKey so a natively-scanned
+	// stopped instance (e.g. a stopped compose container) stops appearing.
+	// The suppression auto-clears when the instance is seen running again.
+	// It always succeeds and never touches Docker.
+	Dismiss(ctx context.Context, key string) error
+	// ClearInactive dismisses every currently fully-stopped instance and
+	// returns how many distinct instances were dismissed.
+	ClearInactive(ctx context.Context) (int, error)
+}
+```
+
+Replace the existing `Forget` method with `Dismiss`, and add `ClearInactive`:
+
+```go
+// Dismiss resolves key to its canonical InstanceKey when a registry ghost
+// exists (so suppression matches the key the scanner reports), drops that
+// ghost, then suppresses the key. Suppressing a still-running instance is
+// harmless: the overlay un-suppresses it on the next scan.
+func (m *manager) Dismiss(ctx context.Context, key string) error {
+	ik := key
+	if e, ok := m.reg.Get(key); ok {
+		ik = e.Instance.InstanceKey
+	}
+	logger().Info("dismissing inactive instance", "key", ik)
+	m.reg.Drop(ik)
+	m.reg.Suppress(ik)
+	return nil
+}
+
+// ClearInactive lists the instances the dashboard currently serves (the
+// manager's apps service is the overlay, so this includes synthesized ghosts
+// and stopped compose containers) and dismisses each fully-stopped one.
+func (m *manager) ClearInactive(ctx context.Context) (int, error) {
+	items, err := m.apps.List(ctx)
+	if err != nil {
+		return 0, err
+	}
+	seen := map[string]bool{}
+	for _, in := range items {
+		if !fullyStopped(in) || seen[in.InstanceKey] {
+			continue
+		}
+		seen[in.InstanceKey] = true
+		m.reg.Drop(in.InstanceKey)
+		m.reg.Suppress(in.InstanceKey)
+	}
+	return len(seen), nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -tags unit ./pkg/lifecycle/ -run 'Dismiss|ClearInactive'`
+Expected: PASS. (The server package won't compile yet — that's Task 4.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/lifecycle/manager.go pkg/lifecycle/manager_test.go
+git commit -m "feat(lifecycle): replace Forget with Dismiss + add ClearInactive"
+```
+
+---
+
+### Task 4: Server routes — generalized DELETE + clear-inactive
+
+**Files:**
+- Modify: `pkg/server/apps.go:78-92` (DELETE handler) and add a new route
+- Test: `pkg/server/apps_test.go`
+
+**Interfaces:**
+- Consumes: `Manager.Dismiss`, `Manager.ClearInactive` (Task 3).
+- Produces: `DELETE /api/apps/{appId}` → `Dismiss` (204 always, 503 if no manager); `POST /api/apps/clear-inactive` → `{"cleared": N}` (503 if no manager).
+
+- [ ] **Step 1: Write the failing test**
+
+In `pkg/server/apps_test.go`, update the `fakeLifecycle` double (rename `forgetErr`→`dismissErr`, rename the method, add clear fields + method):
+
+```go
+// fakeLifecycle is a test double for lifecycle.Manager.
+type fakeLifecycle struct {
+	err        error
+	dismissErr error
+	clearErr   error
+	cleared    int
+	gotKey     string
+	gotTgt     lifecycle.Target
+	gotAct     lifecycle.Action
+}
+
+func (f *fakeLifecycle) Do(ctx context.Context, key string, target lifecycle.Target, action lifecycle.Action) error {
+	f.gotKey, f.gotTgt, f.gotAct = key, target, action
+	return f.err
+}
+
+func (f *fakeLifecycle) Dismiss(ctx context.Context, key string) error {
+	f.gotKey = key
+	return f.dismissErr
+}
+
+func (f *fakeLifecycle) ClearInactive(ctx context.Context) (int, error) {
+	return f.cleared, f.clearErr
+}
+```
+
+Replace `TestAppsForgetRoute` with:
+
+```go
+func TestAppsDismissRoute(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    error
+		status int
+	}{
+		{"ok", nil, http.StatusNoContent},
+		{"exec failure", errors.New("boom"), http.StatusBadGateway},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			life := &fakeLifecycle{dismissErr: tc.err}
+			h := appsRouter(newFakeApps(), nil, life, FullCapabilities())
+			req := httptest.NewRequest(http.MethodDelete, "/orders", nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			require.Equal(t, tc.status, rec.Code)
+			if tc.err == nil {
+				require.Equal(t, "orders", life.gotKey)
+			}
+		})
+	}
+}
+
+func TestAppsClearInactiveRoute(t *testing.T) {
+	life := &fakeLifecycle{cleared: 3}
+	h := appsRouter(newFakeApps(), nil, life, FullCapabilities())
+	req := httptest.NewRequest(http.MethodPost, "/clear-inactive", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Cleared int `json:"cleared"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, 3, body.Cleared)
+}
+
+func TestAppsClearInactiveRouteError(t *testing.T) {
+	life := &fakeLifecycle{clearErr: errors.New("boom")}
+	h := appsRouter(newFakeApps(), nil, life, FullCapabilities())
+	req := httptest.NewRequest(http.MethodPost, "/clear-inactive", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+func TestAppsClearInactiveRouteNilManager(t *testing.T) {
+	h := appsRouter(newFakeApps(), nil, nil, FullCapabilities())
+	req := httptest.NewRequest(http.MethodPost, "/clear-inactive", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+```
+
+Keep the existing `TestAppsForgetRouteNilManager` but rename it to
+`TestAppsDismissRouteNilManager` (its body is unchanged — DELETE `/orders`
+with a nil manager still expects 503).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -tags unit ./pkg/server/ -run 'TestAppsDismissRoute|TestAppsClearInactive'`
+Expected: FAIL — compile error (`life.ClearInactive` route not handled / no `/clear-inactive` route returns 404).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `pkg/server/apps.go`, replace the existing `r.Delete("/{appId}", ...)` block (lines 78-92) with a Dismiss-based handler, and add the clear-inactive route right after it:
+
+```go
+	r.Delete("/{appId}", func(w http.ResponseWriter, req *http.Request) {
+		if life == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "lifecycle actions unavailable"})
+			return
+		}
+		if err := life.Dismiss(req.Context(), chi.URLParam(req, "appId")); err != nil {
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	r.Post("/clear-inactive", func(w http.ResponseWriter, req *http.Request) {
+		if life == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "lifecycle actions unavailable"})
+			return
+		}
+		n, err := life.ClearInactive(req.Context())
+		if err != nil {
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]int{"cleared": n})
+	})
+```
+
+(`/clear-inactive` is a single static POST segment; there is no `POST /{appId}` route, so chi routes it without collision.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -tags unit ./pkg/server/ ./pkg/lifecycle/`
+Expected: PASS (whole server + lifecycle packages green).
+
+- [ ] **Step 5: Verify the binary still builds (interface rename reaches cmd)**
+
+Run: `go build ./...`
+Expected: no errors. (`cmd/root.go` uses the `Manager` interface only via `lifecycle.New`; no call sites reference `Forget`. If the compiler flags a stray `Forget` reference anywhere, rename it to `Dismiss`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/server/apps.go pkg/server/apps_test.go
+git commit -m "feat(server): DELETE dismisses (incl. compose) + POST /apps/clear-inactive"
+```
+
+---
+
+### Task 5: Frontend hook — useClearInactive
+
+**Files:**
+- Modify: `web/src/hooks/useAppAction.ts`
+- Test: `web/src/hooks/useAppAction.test.tsx`
+
+**Interfaces:**
+- Consumes: `apiUrl` (existing), `throwIfNotOK` (existing, module-private).
+- Produces: `useClearInactive(): UseMutationResult<ClearInactiveResult, Error, void>` where `ClearInactiveResult = { cleared: number }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web/src/hooks/useAppAction.test.tsx` (extend the import to include `useClearInactive`):
+
+```tsx
+describe('useClearInactive', () => {
+  it('POSTs to /apps/clear-inactive and returns the cleared count', async () => {
+    let hit = false
+    server.use(
+      http.post('/api/apps/clear-inactive', () => {
+        hit = true
+        return HttpResponse.json({ cleared: 2 })
+      }),
+    )
+    const { result } = renderHook(() => useClearInactive(), { wrapper })
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(hit).toBe(true)
+    expect(result.current.data?.cleared).toBe(2)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/hooks/useAppAction.test.tsx`
+Expected: FAIL — `useClearInactive` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `web/src/hooks/useAppAction.ts`:
+
+```ts
+export interface ClearInactiveResult {
+  cleared: number
+}
+
+async function sendClearInactive(): Promise<ClearInactiveResult> {
+  const res = await fetch(apiUrl('/apps/clear-inactive'), { method: 'POST' })
+  await throwIfNotOK(res)
+  return (await res.json()) as ClearInactiveResult
+}
+
+/**
+ * Removes every fully-stopped instance from the dashboard via
+ * POST /api/apps/clear-inactive. Invalidates all app queries on success.
+ */
+export function useClearInactive() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => sendClearInactive(),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['apps'] }),
+  })
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && npx vitest run src/hooks/useAppAction.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/hooks/useAppAction.ts web/src/hooks/useAppAction.test.tsx
+git commit -m "feat(web): add useClearInactive hook"
+```
+
+---
+
+### Task 6: Applications page — global Clear inactive button + per-row remove
+
+**Files:**
+- Modify: `web/src/pages/Applications.tsx`
+- Test: `web/src/pages/Applications.test.tsx`
+
+**Interfaces:**
+- Consumes: `useClearInactive` (Task 5), `useAppForget` (existing), `ConfirmDialog` (existing), `useToast` (existing `../lib/toast`), `getCapabilities` (existing), `trackAction` (existing `../lib/telemetry`), module-level `isStopped` and `appKey` (existing in file).
+- Produces: UI only.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web/src/pages/Applications.test.tsx`. The file already has `renderAt`, `mockApps`, and `baseApp`. Add a stopped fixture and tests (import `userEvent` and `within` if not already imported — `import userEvent from '@testing-library/user-event'` and add `within` to the `@testing-library/react` import):
+
+```tsx
+const stoppedApp = {
+  ...baseApp,
+  appId: 'orders',
+  appStatus: 'stopped',
+  daprdStatus: 'stopped',
+  daprdPid: 0,
+  appPid: 0,
+}
+
+it('shows the global Clear inactive button with the stopped count', async () => {
+  mockApps([{ ...baseApp }, stoppedApp])
+  renderAt()
+  expect(await screen.findByRole('button', { name: /clear inactive · 1/i })).toBeInTheDocument()
+})
+
+it('hides the Clear inactive button when nothing is stopped', async () => {
+  mockApps([{ ...baseApp }])
+  renderAt()
+  await screen.findByText('order') // list rendered
+  expect(screen.queryByRole('button', { name: /clear inactive/i })).not.toBeInTheDocument()
+})
+
+it('confirms then POSTs clear-inactive', async () => {
+  mockApps([{ ...baseApp }, stoppedApp])
+  let hit = false
+  server.use(
+    http.post('/api/apps/clear-inactive', () => {
+      hit = true
+      return HttpResponse.json({ cleared: 1 })
+    }),
+  )
+  renderAt()
+  await userEvent.click(await screen.findByRole('button', { name: /clear inactive · 1/i }))
+  // ConfirmDialog confirm button
+  await userEvent.click(await screen.findByRole('button', { name: /^clear inactive$/i }))
+  await waitFor(() => expect(hit).toBe(true))
+})
+
+it('shows a per-row Remove only for stopped rows and DELETEs it', async () => {
+  mockApps([{ ...baseApp }, stoppedApp])
+  let deleted = ''
+  server.use(
+    http.delete('/api/apps/:key', ({ params }) => {
+      deleted = String(params.key)
+      return new HttpResponse(null, { status: 204 })
+    }),
+  )
+  renderAt()
+  const rows = await screen.findAllByRole('row')
+  // Exactly one row (the stopped one) exposes a Remove button.
+  const removeButtons = screen.getAllByRole('button', { name: /^remove$/i })
+  expect(removeButtons).toHaveLength(1)
+  await userEvent.click(removeButtons[0])
+  await userEvent.click(await screen.findByRole('button', { name: /^remove$/i, hidden: false }))
+  await waitFor(() => expect(deleted).toBe('orders'))
+  expect(rows.length).toBeGreaterThan(0)
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/pages/Applications.test.tsx`
+Expected: FAIL — no "Clear inactive" button / no per-row Remove button.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Edit `web/src/pages/Applications.tsx`.
+
+3a. Extend the imports at the top of the file:
+
+```tsx
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useApps } from '../hooks/useApps'
+import { useClearInactive, useAppForget } from '../hooks/useAppAction'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
+import { runtimeSwatch } from '../lib/runtimeSwatch'
+import { appKey } from '../lib/appKey'
+import { appDisplayState } from '../lib/appDisplayState'
+import { modeLabel } from '../lib/modeLabel'
+import { getCapabilities } from '../lib/capabilities'
+import { trackAction } from '../lib/telemetry'
+import { useToast } from '../lib/toast'
+import { ConfirmDialog } from '../components/ConfirmDialog'
+import type { AppSummary } from '../types/api'
+```
+
+3b. In `Applications()`, declare the new hooks BEFORE the loading/empty early
+returns (hooks must run unconditionally). Replace the top of the function:
+
+```tsx
+export function Applications() {
+  const navigate = useNavigate()
+  const { data: apps, isLoading } = useApps()
+  const caps = getCapabilities()
+  const { toast, toastNode } = useToast()
+  const clearInactive = useClearInactive()
+  const [confirmClear, setConfirmClear] = useState(false)
+
+  useDocumentTitle('Applications')
+```
+
+(The existing `if (isLoading)` and `if (!apps || apps.length === 0)` early
+returns stay unchanged — they render `PAGE_HEADER`, which has no button; the
+count is zero there anyway.)
+
+3c. In the main `return`, replace `{PAGE_HEADER}` with a header that includes
+the global button, and add the confirm dialog + toast node. Compute the
+inactive list just above the `return` (after the existing stats calculations):
+
+```tsx
+  const inactive = apps.filter(isStopped)
+```
+
+Then the header + dialog:
+
+```tsx
+  return (
+    <div className="page">
+      <div className="phead">
+        <div>
+          <h1>Applications</h1>
+          <div className="sub">Dapr apps &amp; sidecars discovered on this machine</div>
+        </div>
+        {caps.lifecycle && inactive.length > 0 && (
+          <button
+            className="btn ghost"
+            disabled={clearInactive.isPending}
+            onClick={() => setConfirmClear(true)}
+          >
+            Clear inactive · {inactive.length}
+          </button>
+        )}
+      </div>
+      <ConfirmDialog
+        open={confirmClear}
+        title={`Remove ${inactive.length} stopped application${inactive.length === 1 ? '' : 's'} from the dashboard?`}
+        confirmLabel="Clear inactive"
+        onCancel={() => setConfirmClear(false)}
+        onConfirm={() => {
+          trackAction('clear_inactive', { count: inactive.length })
+          clearInactive.mutate(undefined, {
+            onError: (e) => toast.show(e instanceof Error ? e.message : 'Clear failed'),
+          })
+          setConfirmClear(false)
+        }}
+      >
+        <p className="muted">
+          They&rsquo;ll reappear if they run again or when the dashboard restarts. Nothing is deleted from Docker.
+        </p>
+      </ConfirmDialog>
+      {/* ...existing <div className="stats"> ... </div> and card/table stay unchanged... */}
+      {toastNode}
+    </div>
+  )
+```
+
+Keep everything between the stats block and the closing `</div>` exactly as it
+is; only the header, the dialog, and `{toastNode}` are added.
+
+3d. Add the per-row Remove control in `AppRow`. Update `AppRow` to declare its
+own hooks and replace the trailing kebab cell:
+
+```tsx
+function AppRow({ app, onOpen }: { app: AppSummary; onOpen: () => void }) {
+  const caps = getCapabilities()
+  const forget = useAppForget(appKey(app))
+  const [confirmRemove, setConfirmRemove] = useState(false)
+  const removable = caps.lifecycle && isStopped(app)
+  const num = (v: number) =>
+    v ? <td className="mono tabnum">{v}</td> : <td className="mono tabnum faint">—</td>
+  // ...existing state/secondary/etc. unchanged...
+```
+
+Replace the final `<td className="kebab">⋯</td>` with:
+
+```tsx
+      <td className="kebab" onClick={(e) => e.stopPropagation()}>
+        {removable ? (
+          <button
+            className="tbtn"
+            disabled={forget.isPending}
+            aria-label={`Remove ${app.appId} from the dashboard`}
+            onClick={() => setConfirmRemove(true)}
+          >
+            Remove
+          </button>
+        ) : (
+          '⋯'
+        )}
+        <ConfirmDialog
+          open={confirmRemove}
+          title={`Remove "${app.appId}" from the dashboard?`}
+          confirmLabel="Remove"
+          onCancel={() => setConfirmRemove(false)}
+          onConfirm={() => {
+            forget.mutate()
+            setConfirmRemove(false)
+          }}
+        >
+          <p className="muted">It&rsquo;ll reappear if it runs again or when the dashboard restarts.</p>
+        </ConfirmDialog>
+      </td>
+```
+
+- [ ] **Step 4: Run test + typecheck**
+
+Run: `cd web && npx vitest run src/pages/Applications.test.tsx && npm run build`
+Expected: tests PASS and `tsc -b` reports no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/pages/Applications.tsx web/src/pages/Applications.test.tsx
+git commit -m "feat(web): global Clear inactive button + per-row remove on Applications"
+```
+
+---
+
+### Task 7: AppDetail — allow removing stopped compose apps
+
+**Files:**
+- Modify: `web/src/pages/AppDetail.tsx:84` (and the confirm body copy)
+- Test: `web/src/pages/AppDetail.test.tsx`
+
+**Interfaces:**
+- Consumes: existing `useAppForget`, `removable` gate.
+- Produces: UI behavior change only.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web/src/pages/AppDetail.test.tsx` a test that a fully-stopped **compose**
+app shows the "Remove from list" button. Mirror the existing render helper in
+that file (it already mounts `AppDetail` with a mocked `/api/apps/:appId`). Use
+the file's existing fixture shape; the key fields are `source: 'compose'`,
+`appStatus: 'stopped'`, `daprdStatus: 'stopped'`:
+
+```tsx
+it('offers Remove from list for a fully-stopped compose app', async () => {
+  // renderDetail is this file's existing helper; match its fixture shape.
+  renderDetail({
+    appId: 'checkout',
+    instanceKey: 'shop-checkout-app-1',
+    source: 'compose',
+    appStatus: 'stopped',
+    daprdStatus: 'stopped',
+    health: 'unknown',
+    runtime: 'go',
+  })
+  expect(await screen.findByRole('button', { name: /remove from list/i })).toBeInTheDocument()
+})
+```
+
+If `AppDetail.test.tsx` has no reusable `renderDetail` helper, follow the
+exact render pattern already used by the other tests in that file (mock
+`GET /api/apps/checkout` via `server.use(http.get(...))` and render at
+`/apps/checkout`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/pages/AppDetail.test.tsx`
+Expected: FAIL — button absent because the current `removable` gate excludes compose (`!isCompose`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `web/src/pages/AppDetail.tsx`, change line 84 to drop the `!isCompose` term:
+
+```tsx
+  // Fully stopped instances exist only as suppressible dashboard state; offer
+  // removing them from the list (compose included — nothing is deleted from Docker).
+  const removable = appStopped && daprdStopped
+```
+
+And update the confirm body copy in `removeFromList` (the `body` field) to the
+non-destructive wording:
+
+```tsx
+      body: 'It will be hidden until it runs again or the dashboard restarts. Nothing is deleted from Docker.',
+```
+
+- [ ] **Step 4: Run test + typecheck**
+
+Run: `cd web && npx vitest run src/pages/AppDetail.test.tsx && npm run build`
+Expected: PASS, no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/pages/AppDetail.tsx web/src/pages/AppDetail.test.tsx
+git commit -m "feat(web): allow removing fully-stopped compose apps from AppDetail"
+```
+
+---
+
+### Task 8: Full verification gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Go — format, vet, unit tests with race**
+
+Run: `gofmt -l pkg/ cmd/ && go vet -tags unit ./... && go test -tags unit -race ./...`
+Expected: `gofmt -l` prints nothing; vet clean; all packages `ok`.
+
+- [ ] **Step 2: Web — lint, tests, typecheck build**
+
+Run: `cd web && npm run lint && npm test && npm run build`
+Expected: lint clean; all Vitest files pass; `tsc -b && vite build` succeeds.
+
+- [ ] **Step 3: Full build (embeds web into the binary)**
+
+Run: `make build`
+Expected: builds `bin/diagrid-dev-dashboard` with no errors.
+
+- [ ] **Step 4: Manual smoke (documented, run if a live environment is available)**
+
+With compose apps running, stop one container (`docker stop <name>`); confirm
+it shows as stopped, click its row Remove → it disappears; restart it
+(`docker start <name>`) → it reappears within one refresh (auto-un-hide). Then
+with several stopped instances, click "Clear inactive · N" → all clear at once
+and the button disappears.
+
+- [ ] **Step 5: Commit any formatting fixups**
+
+```bash
+git add -A && git commit -m "chore: verification fixups for clear-inactive" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Core mechanism (unified Dismiss + suppression filter + auto-un-hide): Tasks 1, 2, 3. ✓
+- Fully-stopped predicate (`fullyStopped` / `isStopped`): Task 2 (backend), reused frontend Task 6. ✓
+- Backend, in-memory, until-restart lifetime: Task 1 (set lives on `Registry`, not persisted). ✓
+- Generalized `DELETE /apps/{appId}` + new `POST /apps/clear-inactive`: Task 4. ✓
+- Global button in Applications header + per-row remove: Task 6. ✓
+- AppDetail `!isCompose` gate removed: Task 7. ✓
+- Non-destructive copy: Tasks 6 & 7 (bodies), constraint restated in header. ✓
+- Telemetry `clear_inactive`: Task 6 (`trackAction`). ✓
+- Tests for overlay filter/auto-un-hide, manager, handlers, hook, pages: Tasks 1-7. ✓
+- Edge cases (zero inactive → button hidden + `{cleared:0}`; dismiss unknown key harmless; concurrency via mutex): covered by Task 1 mutex, Task 3 `ClearInactive` count, Task 6 hidden-button test. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows real code and exact commands. ✓
+
+**Type consistency:** `Dismiss(ctx, key) error` and `ClearInactive(ctx) (int,error)` are defined identically in the interface (Task 3), the impl (Task 3), and the `fakeLifecycle` double (Task 4). `ClearInactiveResult = { cleared: number }` defined in Task 5, consumed in Task 6. `fullyStopped` defined in Task 2, used in Tasks 2 & 3. `isStopped`/`appKey` are pre-existing module-level exports reused in Task 6. ✓

--- a/docs/superpowers/specs/2026-07-27-clear-inactive-apps-design.md
+++ b/docs/superpowers/specs/2026-07-27-clear-inactive-apps-design.md
@@ -1,0 +1,197 @@
+# Clear Inactive Applications — Design
+
+Date: 2026-07-27
+Status: Approved design, pending implementation plan
+
+## Problem
+
+The dashboard shows entities discovered by **scanning** the local machine (Dapr
+apps + sidecars, and — derived from them — components, subscriptions, actors,
+resources). Some of these entities go **inactive** (the process stops, the
+container exits) but continue to appear in the dashboard. Today the only way to
+remove a stale entry is a single "Remove from list" button buried on the
+**App detail** page, gated to fully-stopped **non-compose** apps. There is no
+coherent, global way to clear inactive data — the user has to visit each app's
+detail page, and compose apps cannot be removed at all.
+
+We want an **easy, global, coherent** way to remove data related to inactive
+applications — one action that clears everything, rather than per-page,
+per-entity cleanup.
+
+## Findings: where retained "inactive" state actually lives
+
+Investigation of the codebase established that there is far less retained state
+than the UI suggests, and it comes from exactly two backend sources:
+
+1. **The discovery/scanning layer is stateless.** `pkg/discovery/service.go`
+   re-scans on every `/api/apps` request. Nothing accumulates there, nothing is
+   persisted to disk. Components, subscriptions, actors, and resources are all
+   **derived** from the live app scan (`pkg/server/subscriptions.go`,
+   `actors.go`, `resources.go` re-derive from `apps.List`), so they are not
+   independently retained — their retention is a side effect of app retention.
+
+2. **The frontend retains nothing.** React Query is in-memory only
+   (`web/src/lib/query.tsx` has no persister); `localStorage` holds only prefs
+   (refresh interval, news-seen), never entities. On reload the UI shows exactly
+   what the backend returns.
+
+The only genuinely retained inactive state is therefore backend-side:
+
+| Source | Retains | Keyed by | Removed today |
+|---|---|---|---|
+| `lifecycle.Registry` (`pkg/lifecycle/registry.go`) | Standalone/Aspire instances **the dashboard itself stopped** (synthesized "ghost" rows). Lost on dashboard restart. | `InstanceKey` | `DELETE /api/apps/{appId}` → `Manager.Forget` → `reg.Drop`. |
+| Docker/Podman itself | Stopped compose containers — the compose scanner runs `ps -aq` (`scan_compose.go`), so it reflects stopped containers until `docker rm`. | container name | **No path exists** — `Forget` cannot touch these (not registry-backed). |
+
+Externally-stopped standalone apps already vanish from the scan, so there is
+nothing to remove for those.
+
+## Decisions (from brainstorming)
+
+1. **Dashboard-state only, non-destructive.** Never run `docker rm`. Removing a
+   stopped compose container means **suppressing it from the dashboard's view**,
+   not deleting it from Docker.
+2. **Fully-stopped only.** Eligible = `AppStatus == stopped && DaprdStatus ==
+   stopped` (the existing `isStopped` predicate). Half-running / orphaned states
+   stay visible.
+3. **Global button in the Applications page header + per-row remove** on the
+   Applications list. One global "clear all" plus granular control.
+4. **Backend, in-memory, until restart.** Suppression lives in the lifecycle
+   manager (keyed by `InstanceKey`), shared by all dashboard tabs, resets on
+   dashboard process restart — the same ephemeral lifetime as the existing
+   registry. Auto-un-hides if the instance becomes active again.
+
+## Design
+
+### 1. Core mechanism — unified "dismiss" in the lifecycle layer
+
+All retained inactive state flows through the lifecycle overlay
+(`pkg/lifecycle/overlay.go`), which decorates the discovery service. That is the
+single chokepoint. The lifecycle manager gains an in-memory **suppression set**
+alongside the existing registry.
+
+- **`Manager.Dismiss(key string)`**:
+  - `registry.Drop(key)` — frees any synthesized ghost, and
+  - adds `key` to `suppressed map[string]struct{}` (guarded by the existing
+    mutex).
+
+  One code path handles both standalone/Aspire ghosts and
+  compose/testcontainers stopped containers. Dropping the registry entry is
+  redundant-but-harmless for compose (they are never registry-backed);
+  suppressing is redundant-but-harmless for a ghost (it will no longer be
+  synthesized). Keeping both keeps a single, uniform call site.
+
+- **`overlay.List` final filter pass** (after live scan + synthesized ghosts are
+  merged): for each instance, if `suppressed[key]`:
+  - if the instance is **fully stopped**, drop it from the returned list;
+  - if the instance is **active** (not fully stopped), keep it **and** remove
+    `key` from the suppression set (auto-un-hide). This makes a restarted app
+    reappear on its own.
+
+- **"Fully stopped" predicate (backend)**: `AppStatus == StatusStopped &&
+  DaprdStatus == StatusStopped`. This matches the frontend `isStopped` and the
+  current `removable` gate, minus the `!isCompose` exclusion — compose is now
+  included.
+
+Because components/subscriptions/actors/resources re-derive from `apps.List`,
+suppressing an app removes it from every page automatically. That is what makes
+the feature coherent and global with no per-page code.
+
+### 2. Backend API
+
+- **Generalize `DELETE /api/apps/{appId}`** (`pkg/server/apps.go`) from "Forget
+  registry entry" to "Dismiss". It resolves the `InstanceKey` (existing
+  resolution logic) and calls `Manager.Dismiss`. This now succeeds for compose
+  stopped containers (currently returns 404). Powers per-row remove and the
+  existing AppDetail button. Returns `204`. For an app that is not
+  fully stopped and has no registry entry, return `404`/`409` (see edge cases).
+
+- **New `POST /api/apps/clear-inactive`**: the handler does a fresh `svc.List`,
+  filters to fully-stopped instances, calls `Manager.Dismiss(key)` for each
+  distinct `InstanceKey`, and returns `{ "cleared": N }`. A distinct path
+  (`clear-inactive`) avoids collision with the `{appId}` route.
+
+### 3. Frontend
+
+- **Global button — Applications page header.** In `web/src/pages/Applications.tsx`,
+  the `.phead` header gains a right-aligned action `Clear inactive · N`,
+  rendered only when `N > 0`. `N` is the count of `isStopped(app)` over the
+  existing `['apps']` query — no new query, no cross-page polling (this is why
+  the header, not the topbar, is the home). Clicking opens a `ConfirmDialog`
+  ("Remove N stopped application(s) from the dashboard? They'll reappear if
+  restarted."), then calls `POST /api/apps/clear-inactive` and invalidates
+  `['apps']`.
+
+- **Per-row remove.** Each fully-stopped row on the Applications list gets a
+  remove control (in the existing trailing `<td>`), reusing the generalized
+  `DELETE /api/apps/{appId}` via the existing hook
+  (`web/src/hooks/useAppAction.ts`, `useAppForget` / `sendAppForget`). The row
+  action stops event propagation so it does not trigger row navigation, and
+  confirms before removing.
+
+- **AppDetail consistency.** In `web/src/pages/AppDetail.tsx`, drop the
+  `!isCompose` part of the `removable` gate (line 84) so the existing
+  "Remove from list" button also works for fully-stopped compose apps, matching
+  the new list behavior.
+
+- **Copy.** Because nothing is deleted from Docker, wording is "Remove from
+  dashboard" / "hidden until it runs again or the dashboard restarts" — never
+  "delete" or "remove container".
+
+- **Telemetry.** Reuse `trackAction` for `clear_inactive` (with count) and the
+  per-row/detail remove, consistent with existing action tracking.
+
+### 4. Edge cases
+
+- **Auto-un-hide**: a dismissed instance that reappears active is shown and
+  pruned from the suppression set (covered by the overlay filter).
+- **Dismiss a key not currently scanned**: no-op on the list, but the
+  suppression is still recorded (harmless; pruned when seen active, otherwise
+  lives until restart).
+- **`clear-inactive` with zero inactive**: returns `{ "cleared": 0 }`; the
+  button is hidden client-side anyway.
+- **Concurrency**: suppression set shares the manager mutex; `Dismiss` and the
+  overlay read are serialized.
+- **Not-fully-stopped single delete**: `DELETE /api/apps/{appId}` for an app
+  that is neither fully stopped nor a registry ghost returns an error
+  (`404`, preserving current `ErrNotFound` behavior) — you cannot dismiss a
+  live app.
+
+### 5. Testing (TDD)
+
+Backend (Go):
+- `overlay_test.go`: suppressed + fully-stopped instance is filtered out;
+  suppressed + active instance is returned and un-suppressed; unsuppressed
+  instances pass through unchanged.
+- `manager` test: `Dismiss` drops registry entry and records suppression;
+  idempotent.
+- `apps` handler tests: generalized `DELETE /api/apps/{appId}` dismisses a
+  compose stopped container (was 404); `POST /api/apps/clear-inactive` returns
+  the correct `cleared` count and dismisses every fully-stopped instance;
+  zero-inactive returns `0`.
+
+Frontend (Vitest + tsc):
+- Applications: `Clear inactive · N` shows only when N>0 with correct count;
+  clicking confirms then calls the endpoint and invalidates `['apps']`; per-row
+  remove appears only on fully-stopped rows, stops propagation, confirms, and
+  removes.
+- AppDetail: remove button now shows for a fully-stopped compose app.
+- Run `make build` (tsc) after any `.ts(x)` change — vitest alone does not
+  typecheck.
+
+## Non-goals
+
+- No `docker rm` / destruction of real Docker or container state.
+- No disk persistence of suppression (resets on dashboard restart, by design).
+- No change to the stateless discovery/scanning layer.
+- No removal semantics for half-running / orphaned instances.
+- No bulk-select UI (a single global clear + per-row remove is sufficient).
+
+## Files likely touched
+
+- `pkg/lifecycle/manager.go`, `pkg/lifecycle/overlay.go`,
+  `pkg/lifecycle/registry.go` (suppression set + `Dismiss` + filter)
+- `pkg/server/apps.go` (generalized DELETE, new clear-inactive route)
+- `web/src/pages/Applications.tsx` (global button + per-row remove)
+- `web/src/pages/AppDetail.tsx` (drop `!isCompose` gate)
+- `web/src/hooks/useAppAction.ts` (dismiss hook, if adjustments needed)
+- Tests alongside each.

--- a/docs/superpowers/specs/2026-07-27-clear-inactive-apps-design.md
+++ b/docs/superpowers/specs/2026-07-27-clear-inactive-apps-design.md
@@ -137,8 +137,10 @@ the feature coherent and global with no per-page code.
   dashboard" / "hidden until it runs again or the dashboard restarts" — never
   "delete" or "remove container".
 
-- **Telemetry.** Reuse `trackAction` for `clear_inactive` (with count) and the
-  per-row/detail remove, consistent with existing action tracking.
+- **Telemetry.** Reuse `trackAction` for `clear_inactive` (with count). As
+  shipped, only the global clear is tracked; adding parity `trackAction` on the
+  per-row and AppDetail Remove confirmations is an optional follow-up (the
+  AppDetail Remove was already untracked before this feature).
 
 ### 4. Edge cases
 
@@ -151,10 +153,15 @@ the feature coherent and global with no per-page code.
   button is hidden client-side anyway.
 - **Concurrency**: suppression set shares the manager mutex; `Dismiss` and the
   overlay read are serialized.
-- **Not-fully-stopped single delete**: `DELETE /api/apps/{appId}` for an app
-  that is neither fully stopped nor a registry ghost returns an error
-  (`404`, preserving current `ErrNotFound` behavior) — you cannot dismiss a
-  live app.
+- **Not-fully-stopped single delete**: `DELETE /api/apps/{appId}` always
+  succeeds (`204`) and suppresses the key unconditionally — `Dismiss` never
+  fails and never touches Docker. Suppressing a still-running or unknown key is
+  a safe no-op: the overlay only hides *fully-stopped* instances, so a running
+  app stays visible and the stray suppression is pruned on the very next
+  `List`. (The UI only ever exposes Remove on fully-stopped rows, so this path
+  is unreachable through the dashboard anyway.) This supersedes an earlier draft
+  that returned `404` for non-ghost live apps; the unconditional-204 contract is
+  simpler and observably equivalent.
 
 ### 5. Testing (TDD)
 

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -15,10 +15,15 @@ func logger() *slog.Logger { return slog.Default().With("component", "lifecycle"
 // Manager starts, stops and restarts discovered app instances.
 type Manager interface {
 	Do(ctx context.Context, key string, target Target, action Action) error
-	// Forget drops a remembered stopped instance so it no longer appears on
-	// the dashboard. Only registry-backed (fully stopped standalone)
-	// instances have an entry; anything else is discovery.ErrNotFound.
-	Forget(ctx context.Context, key string) error
+	// Dismiss hides an inactive instance from the dashboard: it drops any
+	// registry ghost and suppresses the InstanceKey so a natively-scanned
+	// stopped instance (e.g. a stopped compose container) stops appearing.
+	// The suppression auto-clears when the instance is seen running again.
+	// It always succeeds and never touches Docker.
+	Dismiss(ctx context.Context, key string) error
+	// ClearInactive dismisses every currently fully-stopped instance and
+	// returns how many distinct instances were dismissed.
+	ClearInactive(ctx context.Context) (int, error)
 }
 
 type manager struct {
@@ -119,16 +124,39 @@ func composeTargets(in discovery.Instance, target Target, action Action) ([]stri
 	return stopOrder, nil
 }
 
-// Forget implements Manager: it resolves key like the registry (InstanceKey
-// first, AppID fallback) and drops the entry under its own key.
-func (m *manager) Forget(ctx context.Context, key string) error {
-	e, ok := m.reg.Get(key)
-	if !ok {
-		return fmt.Errorf("%w: %s", discovery.ErrNotFound, key)
+// Dismiss resolves key to its canonical InstanceKey when a registry ghost
+// exists (so suppression matches the key the scanner reports), drops that
+// ghost, then suppresses the key. Suppressing a still-running instance is
+// harmless: the overlay un-suppresses it on the next scan.
+func (m *manager) Dismiss(ctx context.Context, key string) error {
+	ik := key
+	if e, ok := m.reg.Get(key); ok {
+		ik = e.Instance.InstanceKey
 	}
-	logger().Info("forgetting stopped instance", "key", e.Instance.InstanceKey)
-	m.reg.Drop(e.Instance.InstanceKey)
+	logger().Info("dismissing inactive instance", "key", ik)
+	m.reg.Drop(ik)
+	m.reg.Suppress(ik)
 	return nil
+}
+
+// ClearInactive lists the instances the dashboard currently serves (the
+// manager's apps service is the overlay, so this includes synthesized ghosts
+// and stopped compose containers) and dismisses each fully-stopped one.
+func (m *manager) ClearInactive(ctx context.Context) (int, error) {
+	items, err := m.apps.List(ctx)
+	if err != nil {
+		return 0, err
+	}
+	seen := map[string]bool{}
+	for _, in := range items {
+		if !fullyStopped(in) || seen[in.InstanceKey] {
+			continue
+		}
+		seen[in.InstanceKey] = true
+		m.reg.Drop(in.InstanceKey)
+		m.reg.Suppress(in.InstanceKey)
+	}
+	return len(seen), nil
 }
 
 // doStandalone dispatches start/stop/restart for a process-table instance.

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -363,26 +363,48 @@ func TestStandaloneAppStopSnapshotsEverything(t *testing.T) {
 	require.Contains(t, e.Procs, TargetAll, "cascade insurance: CLI command captured")
 }
 
-func TestForgetDropsRememberedInstance(t *testing.T) {
+func TestDismissSuppressesAndDropsGhost(t *testing.T) {
 	reg := NewRegistry()
-	reg.RecordStop(standaloneInst(), map[Target]ProcSnapshot{TargetAll: {PID: 300}})
+	ghost := standaloneInst() // InstanceKey "orders"
+	reg.RecordStop(ghost, map[Target]ProcSnapshot{TargetAll: {PID: 300}})
 	m := New(fakeApps{items: map[string]discovery.Instance{}}, reg, nil, newFakeProc(), nil)
 
-	require.NoError(t, m.Forget(context.Background(), "orders"))
-	_, ok := reg.Get("orders")
-	require.False(t, ok, "entry dropped")
+	require.NoError(t, m.Dismiss(context.Background(), "orders"))
 
-	require.ErrorIs(t, m.Forget(context.Background(), "orders"), discovery.ErrNotFound)
+	_, ok := reg.Get("orders")
+	require.False(t, ok) // ghost dropped
+	require.True(t, reg.IsSuppressed("orders"))
 }
 
-func TestForgetResolvesAppIDFallback(t *testing.T) {
+func TestDismissSuppressesComposeKeyWithoutGhost(t *testing.T) {
 	reg := NewRegistry()
-	in := standaloneInst()
-	in.InstanceKey = "orders-1"
-	reg.RecordStop(in, map[Target]ProcSnapshot{TargetAll: {PID: 300}})
 	m := New(fakeApps{items: map[string]discovery.Instance{}}, reg, nil, newFakeProc(), nil)
 
-	require.NoError(t, m.Forget(context.Background(), "orders"), "AppID fallback resolves")
-	_, ok := reg.Get("orders-1")
-	require.False(t, ok, "the entry's own key is dropped, not the fallback alias")
+	require.NoError(t, m.Dismiss(context.Background(), "shop-checkout-app-1"))
+
+	require.True(t, reg.IsSuppressed("shop-checkout-app-1"))
+}
+
+func TestClearInactiveDismissesEveryStoppedInstance(t *testing.T) {
+	reg := NewRegistry()
+	stopped1 := standaloneInst() // "orders"
+	stopped1.AppStatus, stopped1.DaprdStatus = discovery.StatusStopped, discovery.StatusStopped
+	stopped2 := composeInst() // "shop-checkout-app-1"
+	stopped2.AppStatus, stopped2.DaprdStatus = discovery.StatusStopped, discovery.StatusStopped
+	running := standaloneInst()
+	running.InstanceKey, running.AppID = "live", "live"
+	running.AppStatus, running.DaprdStatus = discovery.StatusRunning, discovery.StatusRunning
+
+	m := New(fakeApps{items: map[string]discovery.Instance{
+		"orders":              stopped1,
+		"shop-checkout-app-1": stopped2,
+		"live":                running,
+	}}, reg, nil, newFakeProc(), nil)
+
+	n, err := m.ClearInactive(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+	require.True(t, reg.IsSuppressed("orders"))
+	require.True(t, reg.IsSuppressed("shop-checkout-app-1"))
+	require.False(t, reg.IsSuppressed("live"))
 }

--- a/pkg/lifecycle/overlay.go
+++ b/pkg/lifecycle/overlay.go
@@ -38,6 +38,19 @@ func (o *overlay) List(ctx context.Context) ([]discovery.Instance, error) {
 			items = append(items, o.synthesize(e))
 		}
 	}
+	// Suppression: instances the user cleared stay hidden while still stopped;
+	// once one is seen running again it reappears and its suppression is pruned.
+	out := items[:0]
+	for _, in := range items {
+		if o.reg.IsSuppressed(in.InstanceKey) {
+			if fullyStopped(in) {
+				continue
+			}
+			o.reg.Unsuppress(in.InstanceKey)
+		}
+		out = append(out, in)
+	}
+	items = out
 	sort.SliceStable(items, func(a, b int) bool {
 		if items[a].AppID != items[b].AppID {
 			return items[a].AppID < items[b].AppID
@@ -91,6 +104,12 @@ func (o *overlay) applyEntry(in *discovery.Instance) {
 	in.AppStatus = discovery.StatusStopped
 	in.AppPID = 0
 	in.AppStartedAt = ""
+}
+
+// fullyStopped reports whether both halves of an instance are stopped — the
+// predicate the dashboard uses to treat an instance as inactive/removable.
+func fullyStopped(in discovery.Instance) bool {
+	return in.AppStatus == discovery.StatusStopped && in.DaprdStatus == discovery.StatusStopped
 }
 
 // synthesize renders a fully stopped instance from its stop-time snapshot.

--- a/pkg/lifecycle/overlay_test.go
+++ b/pkg/lifecycle/overlay_test.go
@@ -126,3 +126,30 @@ func TestOverlayKeepsCascadeInsuranceSnapshotsWhilePIDsMatch(t *testing.T) {
 	require.True(t, ok, "insurance snapshots survive while PIDs match")
 	require.Len(t, e.Procs, 3)
 }
+
+func TestOverlayHidesSuppressedStoppedInstance(t *testing.T) {
+	reg := NewRegistry()
+	stopped := standaloneInst()
+	stopped.AppStatus, stopped.DaprdStatus = discovery.StatusStopped, discovery.StatusStopped
+	reg.Suppress(stopped.InstanceKey)
+
+	svc := Overlay(fakeApps{items: map[string]discovery.Instance{"orders": stopped}}, reg, newFakeProc())
+
+	items, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, items) // suppressed + fully stopped -> hidden
+}
+
+func TestOverlayUnsuppressesReactivatedInstance(t *testing.T) {
+	reg := NewRegistry()
+	live := standaloneInst()
+	live.AppStatus, live.DaprdStatus = discovery.StatusRunning, discovery.StatusRunning
+	reg.Suppress(live.InstanceKey)
+
+	svc := Overlay(fakeApps{items: map[string]discovery.Instance{"orders": live}}, reg, newFakeProc())
+
+	items, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, items, 1)                             // running again -> shown
+	require.False(t, reg.IsSuppressed(live.InstanceKey)) // and pruned
+}

--- a/pkg/lifecycle/registry.go
+++ b/pkg/lifecycle/registry.go
@@ -17,11 +17,14 @@ type Entry struct {
 // intentionally not persisted: after a dashboard restart the processes are
 // genuinely gone and unknowable.
 type Registry struct {
-	mu      sync.Mutex
-	entries map[string]*Entry // keyed by InstanceKey
+	mu         sync.Mutex
+	entries    map[string]*Entry   // keyed by InstanceKey
+	suppressed map[string]struct{} // InstanceKeys the user cleared; hidden while stopped
 }
 
-func NewRegistry() *Registry { return &Registry{entries: map[string]*Entry{}} }
+func NewRegistry() *Registry {
+	return &Registry{entries: map[string]*Entry{}, suppressed: map[string]struct{}{}}
+}
 
 // RecordStop merges snaps into the entry for in's InstanceKey, storing in as
 // the display snapshot.
@@ -74,6 +77,30 @@ func (r *Registry) Drop(key string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	delete(r.entries, key)
+}
+
+// Suppress hides an InstanceKey from the overlay while it remains fully
+// stopped. It is cleared automatically when the instance is seen running
+// again (see overlay.List) or on dashboard restart (the set is not persisted).
+func (r *Registry) Suppress(key string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.suppressed[key] = struct{}{}
+}
+
+// Unsuppress removes a key from the suppression set.
+func (r *Registry) Unsuppress(key string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.suppressed, key)
+}
+
+// IsSuppressed reports whether key is currently suppressed.
+func (r *Registry) IsSuppressed(key string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.suppressed[key]
+	return ok
 }
 
 // List returns all entries sorted by InstanceKey.

--- a/pkg/lifecycle/registry_test.go
+++ b/pkg/lifecycle/registry_test.go
@@ -113,3 +113,22 @@ func TestDrop(t *testing.T) {
 	// Verify List is empty
 	require.Len(t, r.List(), 0)
 }
+
+func TestRegistrySuppression(t *testing.T) {
+	r := NewRegistry()
+	require.False(t, r.IsSuppressed("orders"))
+
+	r.Suppress("orders")
+	require.True(t, r.IsSuppressed("orders"))
+
+	// Idempotent.
+	r.Suppress("orders")
+	require.True(t, r.IsSuppressed("orders"))
+
+	r.Unsuppress("orders")
+	require.False(t, r.IsSuppressed("orders"))
+
+	// Unsuppressing an unknown key is a no-op.
+	r.Unsuppress("never")
+	require.False(t, r.IsSuppressed("never"))
+}

--- a/pkg/server/apps.go
+++ b/pkg/server/apps.go
@@ -80,15 +80,24 @@ func appsRouter(svc discovery.Service, containerLogs func(context.Context, strin
 			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "lifecycle actions unavailable"})
 			return
 		}
-		err := life.Forget(req.Context(), chi.URLParam(req, "appId"))
-		switch {
-		case err == nil:
-			w.WriteHeader(http.StatusNoContent)
-		case errors.Is(err, discovery.ErrNotFound):
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": "no remembered stopped instance for this app"})
-		default:
+		if err := life.Dismiss(req.Context(), chi.URLParam(req, "appId")); err != nil {
 			writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+			return
 		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	r.Post("/clear-inactive", func(w http.ResponseWriter, req *http.Request) {
+		if life == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "lifecycle actions unavailable"})
+			return
+		}
+		n, err := life.ClearInactive(req.Context())
+		if err != nil {
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]int{"cleared": n})
 	})
 
 	return r

--- a/pkg/server/apps_test.go
+++ b/pkg/server/apps_test.go
@@ -83,11 +83,13 @@ func TestAppsLogsReturns404WhenNoLogPath(t *testing.T) {
 
 // fakeLifecycle is a test double for lifecycle.Manager.
 type fakeLifecycle struct {
-	err       error
-	forgetErr error
-	gotKey    string
-	gotTgt    lifecycle.Target
-	gotAct    lifecycle.Action
+	err        error
+	dismissErr error
+	clearErr   error
+	cleared    int
+	gotKey     string
+	gotTgt     lifecycle.Target
+	gotAct     lifecycle.Action
 }
 
 func (f *fakeLifecycle) Do(ctx context.Context, key string, target lifecycle.Target, action lifecycle.Action) error {
@@ -95,9 +97,13 @@ func (f *fakeLifecycle) Do(ctx context.Context, key string, target lifecycle.Tar
 	return f.err
 }
 
-func (f *fakeLifecycle) Forget(ctx context.Context, key string) error {
+func (f *fakeLifecycle) Dismiss(ctx context.Context, key string) error {
 	f.gotKey = key
-	return f.forgetErr
+	return f.dismissErr
+}
+
+func (f *fakeLifecycle) ClearInactive(ctx context.Context) (int, error) {
+	return f.cleared, f.clearErr
 }
 
 func TestAppsLifecycleRoute(t *testing.T) {
@@ -139,18 +145,18 @@ func TestAppsLifecycleRouteNilManager(t *testing.T) {
 	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }
 
-func TestAppsForgetRoute(t *testing.T) {
+func TestAppsDismissRoute(t *testing.T) {
 	cases := []struct {
 		name   string
 		err    error
 		status int
 	}{
 		{"ok", nil, http.StatusNoContent},
-		{"not found", discovery.ErrNotFound, http.StatusNotFound},
+		{"exec failure", errors.New("boom"), http.StatusBadGateway},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			life := &fakeLifecycle{forgetErr: tc.err}
+			life := &fakeLifecycle{dismissErr: tc.err}
 			h := appsRouter(newFakeApps(), nil, life, FullCapabilities())
 			req := httptest.NewRequest(http.MethodDelete, "/orders", nil)
 			rec := httptest.NewRecorder()
@@ -163,7 +169,39 @@ func TestAppsForgetRoute(t *testing.T) {
 	}
 }
 
-func TestAppsForgetRouteNilManager(t *testing.T) {
+func TestAppsClearInactiveRoute(t *testing.T) {
+	life := &fakeLifecycle{cleared: 3}
+	h := appsRouter(newFakeApps(), nil, life, FullCapabilities())
+	req := httptest.NewRequest(http.MethodPost, "/clear-inactive", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Cleared int `json:"cleared"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, 3, body.Cleared)
+}
+
+func TestAppsClearInactiveRouteError(t *testing.T) {
+	life := &fakeLifecycle{clearErr: errors.New("boom")}
+	h := appsRouter(newFakeApps(), nil, life, FullCapabilities())
+	req := httptest.NewRequest(http.MethodPost, "/clear-inactive", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+func TestAppsClearInactiveRouteNilManager(t *testing.T) {
+	h := appsRouter(newFakeApps(), nil, nil, FullCapabilities())
+	req := httptest.NewRequest(http.MethodPost, "/clear-inactive", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestAppsDismissRouteNilManager(t *testing.T) {
 	h := appsRouter(newFakeApps(), nil, nil, FullCapabilities())
 	req := httptest.NewRequest(http.MethodDelete, "/orders", nil)
 	rec := httptest.NewRecorder()

--- a/web/src/hooks/useAppAction.test.tsx
+++ b/web/src/hooks/useAppAction.test.tsx
@@ -3,7 +3,7 @@ import { http, HttpResponse } from 'msw'
 import { describe, it, expect } from 'vitest'
 import { server } from '../test/setup'
 import { makeQueryClient, QueryProvider } from '../lib/query'
-import { useAppAction, useAppForget } from './useAppAction'
+import { useAppAction, useAppForget, useClearInactive } from './useAppAction'
 
 function wrapper({ children }: { children: React.ReactNode }) {
   return <QueryProvider client={makeQueryClient()}>{children}</QueryProvider>
@@ -62,5 +62,22 @@ describe('useAppForget', () => {
     result.current.mutate()
     await waitFor(() => expect(result.current.isError).toBe(true))
     expect(result.current.error?.message).toBe('no remembered stopped instance for this app')
+  })
+})
+
+describe('useClearInactive', () => {
+  it('POSTs to /apps/clear-inactive and returns the cleared count', async () => {
+    let hit = false
+    server.use(
+      http.post('/api/apps/clear-inactive', () => {
+        hit = true
+        return HttpResponse.json({ cleared: 2 })
+      }),
+    )
+    const { result } = renderHook(() => useClearInactive(), { wrapper })
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(hit).toBe(true)
+    expect(result.current.data?.cleared).toBe(2)
   })
 })

--- a/web/src/hooks/useAppAction.ts
+++ b/web/src/hooks/useAppAction.ts
@@ -54,3 +54,25 @@ export function useAppForget(key: string) {
     onSuccess: () => qc.invalidateQueries({ queryKey: ['apps'] }),
   })
 }
+
+export interface ClearInactiveResult {
+  cleared: number
+}
+
+async function sendClearInactive(): Promise<ClearInactiveResult> {
+  const res = await fetch(apiUrl('/apps/clear-inactive'), { method: 'POST' })
+  await throwIfNotOK(res)
+  return (await res.json()) as ClearInactiveResult
+}
+
+/**
+ * Removes every fully-stopped instance from the dashboard via
+ * POST /api/apps/clear-inactive. Invalidates all app queries on success.
+ */
+export function useClearInactive() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => sendClearInactive(),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['apps'] }),
+  })
+}

--- a/web/src/pages/AppDetail.test.tsx
+++ b/web/src/pages/AppDetail.test.tsx
@@ -606,7 +606,7 @@ describe('AppDetail', () => {
     expect(deleted).toBe(true)
   })
 
-  it('offers Remove from list for a fully stopped Aspire ghost, not for running or compose apps', async () => {
+  it('offers Remove from list for a fully stopped Aspire ghost', async () => {
     server.use(
       http.get('/api/apps/order', () =>
         HttpResponse.json({
@@ -623,6 +623,24 @@ describe('AppDetail', () => {
     renderDetail()
     await waitFor(() => expect(screen.getByRole('heading', { name: 'order' })).toBeInTheDocument())
     expect(screen.getByRole('button', { name: 'Remove from list' })).toBeInTheDocument()
+  })
+
+  it('offers Remove from list for a fully-stopped compose app', async () => {
+    server.use(
+      http.get('/api/apps/order', () =>
+        HttpResponse.json({
+          appId: 'checkout',
+          instanceKey: 'shop-checkout-app-1',
+          source: 'compose',
+          appStatus: 'stopped',
+          daprdStatus: 'stopped',
+          health: 'unknown',
+          runtime: 'go',
+        }),
+      ),
+    )
+    renderDetail()
+    expect(await screen.findByRole('button', { name: /remove from list/i })).toBeInTheDocument()
   })
 
   it('hides Remove from list for running instances', async () => {

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -79,14 +79,15 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
   const busy = action.isPending
   // An orphaned sidecar has nothing re-runnable: Stop is the only action.
   const orphaned = !!app.sidecarOrphaned
-  // Fully stopped standalone instances (incl. Aspire ghosts) exist only as
-  // registry memories; offer dropping them from the list.
-  const removable = !isCompose && appStopped && daprdStopped
+  // Fully stopped instances (standalone, Aspire ghosts, and compose) exist
+  // only as suppressible dashboard state; offer removing them from the list
+  // — nothing is deleted from Docker.
+  const removable = appStopped && daprdStopped
   const forget = useAppForget(key)
   const removeFromList = () => {
     setConfirm({
       title: `Remove "${app.appId}" from the list?`,
-      body: 'The stopped instance will no longer be shown.',
+      body: 'It will be hidden until it runs again or the dashboard restarts. Nothing is deleted from Docker.',
       label: 'Remove',
       danger: true,
       run: () =>

--- a/web/src/pages/AppDetail.tsx
+++ b/web/src/pages/AppDetail.tsx
@@ -13,6 +13,7 @@ import { appKey } from '../lib/appKey'
 import { formatUptime, useNow } from '../lib/uptime'
 import { getCapabilities } from '../lib/capabilities'
 import { modeLabel } from '../lib/modeLabel'
+import { trackAction } from '../lib/telemetry'
 import { useAppTelemetry } from '../hooks/useAppTelemetry'
 
 // ---------- content ----------
@@ -90,11 +91,13 @@ function AppDetailContent({ app }: { app: AppDetailType }) {
       body: 'It will be hidden until it runs again or the dashboard restarts. Nothing is deleted from Docker.',
       label: 'Remove',
       danger: true,
-      run: () =>
+      run: () => {
+        trackAction('app_remove', { source: app.source, scope: 'detail' })
         forget.mutate(undefined, {
           onError: (e) => toast.show(e instanceof Error ? e.message : 'Remove failed'),
           onSuccess: () => navigate('/'),
-        }),
+        })
+      },
     })
   }
 

--- a/web/src/pages/Applications.test.tsx
+++ b/web/src/pages/Applications.test.tsx
@@ -360,7 +360,7 @@ describe('Applications', () => {
     renderAt()
     const rows = await screen.findAllByRole('row')
     // Exactly one row (the stopped one) exposes a Remove button.
-    const removeButtons = screen.getAllByRole('button', { name: /^remove$/i })
+    const removeButtons = screen.getAllByRole('button', { name: /^remove\b/i })
     expect(removeButtons).toHaveLength(1)
     await userEvent.click(removeButtons[0])
     // Scope to the confirm dialog: it has its own "Remove" button, distinct

--- a/web/src/pages/Applications.test.tsx
+++ b/web/src/pages/Applications.test.tsx
@@ -2,11 +2,21 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { http, HttpResponse } from 'msw'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { server } from '../test/setup'
 import { makeQueryClient, QueryProvider } from '../lib/query'
 import { RefreshProvider } from '../lib/refresh'
+import { trackAction } from '../lib/telemetry'
 import { Applications } from './Applications'
+
+vi.mock('../lib/telemetry', () => ({
+  trackAction: vi.fn(),
+  trackView: vi.fn(),
+  trackError: vi.fn(),
+  setTelemetryContext: vi.fn(),
+  removeTelemetryContext: vi.fn(),
+  initTelemetry: vi.fn(),
+}))
 
 function renderAt() {
   const client = makeQueryClient()
@@ -369,5 +379,6 @@ describe('Applications', () => {
     await userEvent.click(within(dialog).getByRole('button', { name: /^remove$/i }))
     await waitFor(() => expect(deleted).toBe('orders'))
     expect(rows.length).toBeGreaterThan(0)
+    expect(trackAction).toHaveBeenCalledWith('app_remove', expect.objectContaining({ scope: 'list' }))
   })
 })

--- a/web/src/pages/Applications.test.tsx
+++ b/web/src/pages/Applications.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { http, HttpResponse } from 'msw'
 import { describe, it, expect } from 'vitest'
@@ -63,6 +64,15 @@ const sampleApps = [
     runTemplate: 'dapr.yaml',
   },
 ]
+
+const stoppedApp = {
+  ...baseApp,
+  appId: 'orders',
+  appStatus: 'stopped',
+  daprdStatus: 'stopped',
+  daprdPid: 0,
+  appPid: 0,
+}
 
 describe('Applications', () => {
   it('renders an app row with a link to detail', async () => {
@@ -307,5 +317,57 @@ describe('Applications', () => {
     renderAt()
     await waitFor(() => expect(screen.getByText('primes-go')).toBeInTheDocument())
     expect(screen.getByTitle(/publish the daprd HTTP port/i)).toBeInTheDocument()
+  })
+
+  it('shows the global Clear inactive button with the stopped count', async () => {
+    mockApps([{ ...baseApp }, stoppedApp])
+    renderAt()
+    expect(await screen.findByRole('button', { name: /clear inactive · 1/i })).toBeInTheDocument()
+  })
+
+  it('hides the Clear inactive button when nothing is stopped', async () => {
+    mockApps([{ ...baseApp }])
+    renderAt()
+    await screen.findByText('order') // list rendered
+    expect(screen.queryByRole('button', { name: /clear inactive/i })).not.toBeInTheDocument()
+  })
+
+  it('confirms then POSTs clear-inactive', async () => {
+    mockApps([{ ...baseApp }, stoppedApp])
+    let hit = false
+    server.use(
+      http.post('/api/apps/clear-inactive', () => {
+        hit = true
+        return HttpResponse.json({ cleared: 1 })
+      }),
+    )
+    renderAt()
+    await userEvent.click(await screen.findByRole('button', { name: /clear inactive · 1/i }))
+    // ConfirmDialog confirm button
+    await userEvent.click(await screen.findByRole('button', { name: /^clear inactive$/i }))
+    await waitFor(() => expect(hit).toBe(true))
+  })
+
+  it('shows a per-row Remove only for stopped rows and DELETEs it', async () => {
+    mockApps([{ ...baseApp }, stoppedApp])
+    let deleted = ''
+    server.use(
+      http.delete('/api/apps/:key', ({ params }) => {
+        deleted = String(params.key)
+        return new HttpResponse(null, { status: 204 })
+      }),
+    )
+    renderAt()
+    const rows = await screen.findAllByRole('row')
+    // Exactly one row (the stopped one) exposes a Remove button.
+    const removeButtons = screen.getAllByRole('button', { name: /^remove$/i })
+    expect(removeButtons).toHaveLength(1)
+    await userEvent.click(removeButtons[0])
+    // Scope to the confirm dialog: it has its own "Remove" button, distinct
+    // from the row's trigger button that is still rendered behind it.
+    const dialog = await screen.findByRole('dialog')
+    await userEvent.click(within(dialog).getByRole('button', { name: /^remove$/i }))
+    await waitFor(() => expect(deleted).toBe('orders'))
+    expect(rows.length).toBeGreaterThan(0)
   })
 })

--- a/web/src/pages/Applications.tsx
+++ b/web/src/pages/Applications.tsx
@@ -235,6 +235,7 @@ function AppRow({ app, onOpen }: { app: AppSummary; onOpen: () => void }) {
           confirmLabel="Remove"
           onCancel={() => setConfirmRemove(false)}
           onConfirm={() => {
+            trackAction('app_remove', { source: app.source, scope: 'list' })
             forget.mutate()
             setConfirmRemove(false)
           }}

--- a/web/src/pages/Applications.tsx
+++ b/web/src/pages/Applications.tsx
@@ -221,7 +221,7 @@ function AppRow({ app, onOpen }: { app: AppSummary; onOpen: () => void }) {
           <button
             className="tbtn"
             disabled={forget.isPending}
-            title={`Remove ${app.appId} from the dashboard`}
+            aria-label={`Remove ${app.appId} from the dashboard`}
             onClick={() => setConfirmRemove(true)}
           >
             Remove

--- a/web/src/pages/Applications.tsx
+++ b/web/src/pages/Applications.tsx
@@ -1,10 +1,16 @@
+import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useApps } from '../hooks/useApps'
+import { useClearInactive, useAppForget } from '../hooks/useAppAction'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { runtimeSwatch } from '../lib/runtimeSwatch'
 import { appKey } from '../lib/appKey'
 import { appDisplayState } from '../lib/appDisplayState'
 import { modeLabel } from '../lib/modeLabel'
+import { getCapabilities } from '../lib/capabilities'
+import { trackAction } from '../lib/telemetry'
+import { useToast } from '../lib/toast'
+import { ConfirmDialog } from '../components/ConfirmDialog'
 import type { AppSummary } from '../types/api'
 
 // Fully stopped: both the app process/container and its daprd sidecar report 'stopped'.
@@ -22,6 +28,10 @@ const PAGE_HEADER = (
 export function Applications() {
   const navigate = useNavigate()
   const { data: apps, isLoading } = useApps()
+  const caps = getCapabilities()
+  const { toast, toastNode } = useToast()
+  const clearInactive = useClearInactive()
+  const [confirmClear, setConfirmClear] = useState(false)
 
   useDocumentTitle('Applications')
 
@@ -54,10 +64,42 @@ export function Applications() {
   // Total components loaded across every running app; '—' when none report any.
   const componentsTotal = apps.reduce((n, a) => n + (a.components?.length ?? 0), 0)
   const componentsLoaded = componentsTotal > 0 ? componentsTotal : '—'
+  const inactive = apps.filter(isStopped)
 
   return (
     <div className="page">
-      {PAGE_HEADER}
+      <div className="phead">
+        <div>
+          <h1>Applications</h1>
+          <div className="sub">Dapr apps &amp; sidecars discovered on this machine</div>
+        </div>
+        {caps.lifecycle && inactive.length > 0 && (
+          <button
+            className="btn ghost"
+            disabled={clearInactive.isPending}
+            onClick={() => setConfirmClear(true)}
+          >
+            Clear inactive · {inactive.length}
+          </button>
+        )}
+      </div>
+      <ConfirmDialog
+        open={confirmClear}
+        title={`Remove ${inactive.length} stopped application${inactive.length === 1 ? '' : 's'} from the dashboard?`}
+        confirmLabel="Clear inactive"
+        onCancel={() => setConfirmClear(false)}
+        onConfirm={() => {
+          trackAction('clear_inactive', { count: inactive.length })
+          clearInactive.mutate(undefined, {
+            onError: (e) => toast.show(e instanceof Error ? e.message : 'Clear failed'),
+          })
+          setConfirmClear(false)
+        }}
+      >
+        <p className="muted">
+          They&rsquo;ll reappear if they run again or when the dashboard restarts. Nothing is deleted from Docker.
+        </p>
+      </ConfirmDialog>
       <div className="stats">
         <div className="stat">
           <div className="n">{running}</div>
@@ -107,11 +149,16 @@ export function Applications() {
         </div>
       </div>
       <p className="hint">Tip — click a row to open the application + daprd detail.</p>
+      {toastNode}
     </div>
   )
 }
 
 function AppRow({ app, onOpen }: { app: AppSummary; onOpen: () => void }) {
+  const caps = getCapabilities()
+  const forget = useAppForget(appKey(app))
+  const [confirmRemove, setConfirmRemove] = useState(false)
+  const removable = caps.lifecycle && isStopped(app)
   const num = (v: number) =>
     v ? <td className="mono tabnum">{v}</td> : <td className="mono tabnum faint">—</td>
   const state = appDisplayState(app)
@@ -169,7 +216,32 @@ function AppRow({ app, onOpen }: { app: AppSummary; onOpen: () => void }) {
       >
         {modeLabel(app)}
       </td>
-      <td className="kebab">⋯</td>
+      <td className="kebab" onClick={(e) => e.stopPropagation()}>
+        {removable ? (
+          <button
+            className="tbtn"
+            disabled={forget.isPending}
+            title={`Remove ${app.appId} from the dashboard`}
+            onClick={() => setConfirmRemove(true)}
+          >
+            Remove
+          </button>
+        ) : (
+          '⋯'
+        )}
+        <ConfirmDialog
+          open={confirmRemove}
+          title={`Remove "${app.appId}" from the dashboard?`}
+          confirmLabel="Remove"
+          onCancel={() => setConfirmRemove(false)}
+          onConfirm={() => {
+            forget.mutate()
+            setConfirmRemove(false)
+          }}
+        >
+          <p className="muted">It&rsquo;ll reappear if it runs again or when the dashboard restarts.</p>
+        </ConfirmDialog>
+      </td>
     </tr>
   )
 }


### PR DESCRIPTION
## What & why

The dashboard discovers Dapr apps by **scanning** the local machine. When an app goes fully **inactive** (both the app process/container and its daprd sidecar stopped), it lingers in the UI — and there was no coherent, global way to clear it. Removal was a single button buried on the App detail page, gated to non-compose apps only.

This adds an easy, **global, coherent** way to remove data related to inactive applications. Because components/subscriptions/actors/resources all re-derive from the app list, removing an app clears it from every page automatically.

## Design decisions

- **Dashboard-state only, non-destructive** — never runs `docker rm`. "Remove" suppresses an entry from the dashboard's view; it never deletes real Docker/container state.
- **Fully-stopped only** — eligible = `appStatus === 'stopped' && daprdStatus === 'stopped'` (matches the existing predicate).
- **Backend, in-memory, until restart** — suppression lives on `lifecycle.Registry`, shared across tabs, resets on dashboard restart (same lifetime as the existing registry). No disk persistence added to the stateless discovery layer.
- **Auto-un-hide** — a suppressed instance seen running again reappears and is pruned from the suppression set.

## How it works

A single **`Dismiss(instanceKey)`** in the lifecycle layer drops any registry "ghost" and adds the key to an in-memory suppression set. The overlay (`overlay.List`, the one chokepoint all retained state flows through) filters out suppressed instances while they're fully stopped, and un-suppresses any that come back running. `ClearInactive` dismisses every fully-stopped instance at once.

- **Backend:** suppression set on `Registry`; `Manager.Dismiss` (replaces `Forget`) + `Manager.ClearInactive`; `DELETE /api/apps/{id}` now dismisses (compose included); new `POST /api/apps/clear-inactive` → `{cleared: N}`.
- **Frontend:** `useClearInactive` hook; a global **"Clear inactive · N"** button in the Applications page header (shown only when N>0) with a confirm dialog; a per-row **Remove** on fully-stopped rows; AppDetail's Remove un-gated for compose. `trackAction` fires for the global clear and (new) per-row/detail removes.

## Testing

- Go: `go test -tags unit -race ./...` — all packages pass. Covers overlay suppression filter + auto-un-hide, manager Dismiss/ClearInactive (dedup + skip-running), and both HTTP routes.
- Web: 807 tests pass; `tsc` typecheck clean; eslint 0 errors. Covers hook, global-button visibility/count + confirm-and-clear, per-row remove (stopped-only, stopPropagation, DELETE), compose-removable AppDetail, and the `app_remove` telemetry event.
- `make build` produces the binary with the web bundle embedded.

⚠️ **Not run:** the live manual smoke (stop a compose container → Remove → restart → auto-reappears; multi-instance Clear inactive) needs a running compose/Dapr environment. Worth a quick manual pass before merge.

## Notes

- Spec: `docs/superpowers/specs/2026-07-27-clear-inactive-apps-design.md`; plan: `docs/superpowers/plans/2026-07-27-clear-inactive-apps.md`.
- Externally-stopped standalone apps already vanish from the scan — nothing to remove there. Stopped compose containers are handled by suppressing them from view (not `docker rm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
